### PR TITLE
add exponential backoff to redis client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/denisenkom/go-mssqldb v0.0.0-20190313032549-041949b8d268 // indirect
 	github.com/elastic/go-elasticsearch/v6 v6.8.3-0.20190714143207-256a620be07d
 	github.com/elastic/go-elasticsearch/v7 v7.2.1-0.20190714143206-f1e755531ff4
+	github.com/elliotchance/redismock v1.4.0
 
 	github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5 // indirect
 	github.com/fatih/color v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -98,6 +98,8 @@ github.com/elastic/go-elasticsearch/v6 v6.8.3-0.20190714143207-256a620be07d h1:6
 github.com/elastic/go-elasticsearch/v6 v6.8.3-0.20190714143207-256a620be07d/go.mod h1:UwaDJsD3rWLM5rKNFzv9hgox93HoX8utj1kxD9aFUcI=
 github.com/elastic/go-elasticsearch/v7 v7.2.1-0.20190714143206-f1e755531ff4 h1:TfN8NpHqvtY2/V2Yqpy0mTj8afjV7oEWq3JKGv12Iuk=
 github.com/elastic/go-elasticsearch/v7 v7.2.1-0.20190714143206-f1e755531ff4/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
+github.com/elliotchance/redismock v1.4.0 h1:x9aQqrARt7tEtPmAEi+4Kkt7eGovSf0o4fL0lnqZRhY=
+github.com/elliotchance/redismock v1.4.0/go.mod h1:8FFsGWghPUyP7nqj/UYXr2xqd6U2iNMxS4S5+Xadl5A=
 github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5 h1:Yzb9+7DPaBjB8zlTR87/ElzFsnQfuHnVUVqpZZIcV5Y=
 github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5/go.mod h1:a2zkGnVExMxdzMo3M0Hi/3sEU+cWnZpSni0O6/Yb/P0=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=

--- a/pkg/redis/mocks/Client.go
+++ b/pkg/redis/mocks/Client.go
@@ -4,6 +4,7 @@ package mocks
 
 import go_redisredis "github.com/go-redis/redis"
 import mock "github.com/stretchr/testify/mock"
+import mon "github.com/applike/gosoline/pkg/mon"
 
 import time "time"
 
@@ -219,4 +220,9 @@ func (_m *Client) Set(key string, value interface{}, expiration time.Duration) e
 	}
 
 	return r0
+}
+
+// SetLogger provides a mock function with given fields: logger
+func (_m *Client) SetLogger(logger mon.Logger) {
+	_m.Called(logger)
 }

--- a/pkg/redis/redis_client.go
+++ b/pkg/redis/redis_client.go
@@ -3,11 +3,17 @@ package redis
 import (
 	"fmt"
 	"github.com/applike/gosoline/pkg/cfg"
+	"github.com/applike/gosoline/pkg/mon"
+	"github.com/cenkalti/backoff"
 	baseRedis "github.com/go-redis/redis"
+	"strings"
 	"time"
 )
 
-const Nil = baseRedis.Nil
+const (
+	Nil                      = baseRedis.Nil
+	metricClientBackoffCount = "RedisClientBackoffCount"
+)
 
 func GetFullyQualifiedKey(appId cfg.AppId, key string) string {
 	return fmt.Sprintf("%v-%v-%v-%v-%v", appId.Project, appId.Environment, appId.Family, appId.Application, key)
@@ -31,26 +37,52 @@ type Client interface {
 }
 
 type redisClient struct {
-	base *baseRedis.Client
+	base   baseRedis.Cmdable
+	metric mon.MetricWriter
+
+	name string
 }
 
-func NewRedisClient(client *baseRedis.Client) Client {
+func NewRedisClient(client baseRedis.Cmdable, name string) Client {
+	defaults := mon.MetricData{
+		{
+			Priority:   mon.PriorityHigh,
+			MetricName: metricClientBackoffCount,
+			Dimensions: map[string]string{
+				"Redis": name,
+			},
+			Unit:  mon.UnitCount,
+			Value: 0.0,
+		},
+	}
+
+	metric := mon.NewMetricDaemonWriter(defaults...)
+
 	return &redisClient{
-		base: client,
+		base:   client,
+		metric: metric,
+		name:   name,
 	}
 }
 
-func (c *redisClient) GetBaseClient() *baseRedis.Client {
+func (c *redisClient) GetBaseClient() baseRedis.Cmdable {
 	c.base.Exists()
 
 	return c.base
 }
+
 func (c *redisClient) Exists(keys ...string) (int64, error) {
 	return c.base.Exists(keys...).Result()
 }
 
 func (c *redisClient) Set(key string, value interface{}, expiration time.Duration) error {
-	return c.base.Set(key, value, expiration).Err()
+	res := c.preventOOMByBackoff(func() (interface{}, error) {
+		cmd := c.base.Set(key, value, expiration)
+
+		return cmd, cmd.Err()
+	})
+
+	return res.(*baseRedis.StatusCmd).Err()
 }
 
 func (c *redisClient) Get(key string) (string, error) {
@@ -70,7 +102,13 @@ func (c *redisClient) LLen(key string) (int64, error) {
 }
 
 func (c *redisClient) RPush(key string, values ...interface{}) (int64, error) {
-	return c.base.RPush(key, values...).Result()
+	res := c.preventOOMByBackoff(func() (interface{}, error) {
+		cmd := c.base.RPush(key, values...)
+
+		return cmd, cmd.Err()
+	})
+
+	return res.(*baseRedis.IntCmd).Result()
 }
 
 func (c *redisClient) HGet(key, field string) (string, error) {
@@ -78,9 +116,51 @@ func (c *redisClient) HGet(key, field string) (string, error) {
 }
 
 func (c *redisClient) HSet(key, field string, value interface{}) error {
-	return c.base.HSet(key, field, value).Err()
+	res := c.preventOOMByBackoff(func() (interface{}, error) {
+		cmd := c.base.HSet(key, field, value)
+
+		return cmd, cmd.Err()
+	})
+
+	return res.(*baseRedis.BoolCmd).Err()
 }
 
 func (c *redisClient) Pipeline() baseRedis.Pipeliner {
 	return c.base.Pipeline()
+}
+
+func (c *redisClient) preventOOMByBackoff(wrappedCmd func() (interface{}, error)) interface{} {
+	backoffConfig := backoff.NewExponentialBackOff()
+	backoffConfig.InitialInterval = 200 * time.Millisecond
+	backoffConfig.MaxInterval = 30 * time.Second
+	backoffConfig.Multiplier = 3
+	backoffConfig.RandomizationFactor = 0.2
+
+	var res interface{}
+	var err error
+
+	notify := func(error, time.Duration) {
+		c.metric.WriteOne(&mon.MetricDatum{
+			MetricName: metricClientBackoffCount,
+			Value:      1.0,
+			Dimensions: map[string]string{
+				"Redis": c.name,
+			},
+		})
+	}
+
+	operation := func() error {
+		res, err = wrappedCmd()
+
+		if err != nil && !strings.HasPrefix(err.Error(), "OOM") {
+			err = backoff.Permanent(err)
+		}
+
+		return err
+	}
+
+	// No further error handling as the wrapped redis error is handled elsewhere
+	err = backoff.RetryNotify(operation, backoffConfig, notify)
+
+	return res
 }

--- a/pkg/redis/redis_factory.go
+++ b/pkg/redis/redis_factory.go
@@ -46,7 +46,7 @@ func GetClient(config cfg.Config, logger mon.Logger, name string) Client {
 	switch sel.mode {
 	case redisModeLocal:
 		logger.Infof("using local redis %s with address %s", name, sel.addr)
-		return GetClientWithAddress(sel.addr)
+		return GetClientWithAddress(sel.addr, sel.name)
 	case redisModeDiscover:
 		return GetClientFromDiscovery(logger, sel)
 	}
@@ -75,10 +75,10 @@ func GetClientFromDiscovery(logger mon.Logger, sel *selection) Client {
 	addr = fmt.Sprintf("%v:%v", srvs[0].Target, srvs[0].Port)
 	logger.Infof("found redis server %s with address %s", sel.name, addr)
 
-	return GetClientWithAddress(addr)
+	return GetClientWithAddress(sel.addr, sel.name)
 }
 
-func GetClientWithAddress(address string) Client {
+func GetClientWithAddress(address, name string) Client {
 	mutex.Lock()
 	defer mutex.Unlock()
 
@@ -90,7 +90,8 @@ func GetClientWithAddress(address string) Client {
 		Network: "tcp",
 		Addr:    address,
 	})
-	clients[address] = NewRedisClient(baseClient)
+
+	clients[address] = NewRedisClient(baseClient, name)
 
 	return clients[address]
 }


### PR DESCRIPTION
I noticed that upon certain redis errors (e.g. when the redis server crashes due to OOM), the producers do not notice it and messages get dropped.
In this pull request, I added an exponential backoff to mitigate the impact.