### PR TITLE
Fixed Key/Value store integration for dynamodb

### DIFF
--- a/pkg/kvstore/ddb.go
+++ b/pkg/kvstore/ddb.go
@@ -10,8 +10,8 @@ import (
 )
 
 type ddbItem struct {
-	Key   string `dynamo:"key,hash"`
-	Value string `dynamo:"value"`
+	Key   string `ddb:"key=hash"`
+	Value string
 }
 
 type DdbKvStore struct {


### PR DESCRIPTION
The current implementation of the key value store can't be used with dynamodb since the annotation changed from dynamodb to ddb and "key,hash" to "key=hash".