### PR TITLE
Use the correct client in a request and handle context cancellation 

### DIFF
--- a/pkg/currency/updater.go
+++ b/pkg/currency/updater.go
@@ -64,7 +64,8 @@ func (service *UpdaterService) EnsureRecentExchangeRates(ctx context.Context) er
 	}
 
 	service.logger.Info("CurrencyUpdaterService: Requesting exchange rates")
-	request := http.NewRequest().WithUrl(ExchangeRateUrl)
+	request := service.http.NewRequest().
+		WithUrl(ExchangeRateUrl)
 
 	response, err := service.http.Get(ctx, request)
 

--- a/pkg/http/mocks/Client.go
+++ b/pkg/http/mocks/Client.go
@@ -35,6 +35,22 @@ func (_m *Client) Get(ctx context.Context, request *http.Request) (*http.Respons
 	return r0, r1
 }
 
+// NewRequest provides a mock function with given fields:
+func (_m *Client) NewRequest() *http.Request {
+	ret := _m.Called()
+
+	var r0 *http.Request
+	if rf, ok := ret.Get(0).(func() *http.Request); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*http.Request)
+		}
+	}
+
+	return r0
+}
+
 // Post provides a mock function with given fields: ctx, request
 func (_m *Client) Post(ctx context.Context, request *http.Request) (*http.Response, error) {
 	ret := _m.Called(ctx, request)

--- a/pkg/http/request.go
+++ b/pkg/http/request.go
@@ -23,24 +23,28 @@ type Request struct {
 	queryParams url.Values
 }
 
-// use NewRequest to create a request, don't create the object inline!
-func NewRequest() *Request {
-	return &Request{
-		resty:       resty.NewRequest(),
-		url:         &url.URL{},
-		queryParams: url.Values{},
+// use NewRequest(client) or client.NewRequest() to create a request, don't create the object inline!
+func NewRequest(client Client) *Request {
+	if client == nil {
+		return &Request{
+			resty:       resty.NewRequest(),
+			url:         &url.URL{},
+			queryParams: url.Values{},
+		}
 	}
+
+	return client.NewRequest()
 }
 
 // use NewJsonRequest to create a request that already contains the application/json content-type, don't create the object inline!
-func NewJsonRequest() *Request {
-	return NewRequest().
+func NewJsonRequest(client Client) *Request {
+	return NewRequest(client).
 		WithHeader(HdrAccept, ContentTypeApplicationJson)
 }
 
 // use NewXmlRequest to create a request that already contains the application/xml content-type, don't create the object inline!
-func NewXmlRequest() *Request {
-	return NewRequest().
+func NewXmlRequest(client Client) *Request {
+	return NewRequest(client).
 		WithHeader(HdrAccept, ContentTypeApplicationXml)
 }
 

--- a/pkg/http/request_test.go
+++ b/pkg/http/request_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestRequest_WithAll(t *testing.T) {
-	request := http.NewRequest().
+	request := http.NewRequest(nil).
 		WithUrl("example.com/foo?some=key").
 		WithQueryParam("key", "value").
 		WithQueryMap(map[string]string{
@@ -73,7 +73,7 @@ func TestRequest_WithQueryObject(t *testing.T) {
 		},
 	}
 
-	request := http.NewRequest().
+	request := http.NewRequest(nil).
 		WithQueryObject(data)
 
 	err := request.GetError()
@@ -106,7 +106,7 @@ func TestRequest_WithQueryObject(t *testing.T) {
 }
 
 func TestRequest_GetUrl(t *testing.T) {
-	request := http.NewRequest().
+	request := http.NewRequest(nil).
 		WithUrl("https://applike.info?test999=1").
 		WithQueryParam("test", "test1", "test2").
 		WithQueryParam("test2", 1, 2.2, "test")

--- a/pkg/oauth2/google.go
+++ b/pkg/oauth2/google.go
@@ -45,7 +45,7 @@ func NewGoogleServiceWithInterfaces(httpClient http.Client) *GoogleService {
 }
 
 func (service *GoogleService) GetAuthRefresh(ctx context.Context, authRequest *GoogleAuthRequest) (*GoogleAuthResponse, error) {
-	request := http.NewRequest().
+	request := service.httpClient.NewRequest().
 		WithUrl(AuthTokenUrl).
 		WithBody(map[string]string{
 			"client_id":     authRequest.ClientId,

--- a/pkg/oauth2/google_test.go
+++ b/pkg/oauth2/google_test.go
@@ -23,7 +23,7 @@ func TestGoogleService_GetAuthRefresh(t *testing.T) {
 		ExpiresIn:   1,
 		TokenType:   "grizzly",
 	}
-	httpRequest := http.NewRequest().
+	httpRequest := http.NewRequest(nil).
 		WithUrl("https://accounts.google.com/o/oauth2/token").
 		WithBody(map[string]string{
 			"client_id":     googleAuthRequest.ClientId,
@@ -39,6 +39,7 @@ func TestGoogleService_GetAuthRefresh(t *testing.T) {
 	assert.NoError(t, err)
 
 	httpClient := new(httpMocks.Client)
+	httpClient.On("NewRequest").Return(http.NewRequest(nil))
 	httpClient.On("Post", context.TODO(), httpRequest).Return(response, nil)
 
 	service := NewGoogleServiceWithInterfaces(httpClient)
@@ -61,6 +62,7 @@ func TestGoogleService_GetAuthRefresh_Error(t *testing.T) {
 	}
 
 	httpClient := new(httpMocks.Client)
+	httpClient.On("NewRequest").Return(http.NewRequest(nil))
 	httpClient.On("Post", context.TODO(), mock.Anything).Return(nil, errors.New("test"))
 
 	service := NewGoogleServiceWithInterfaces(httpClient)


### PR DESCRIPTION
This MR addresses two problems:

- If you start an HTTP request and your context is canceled in the meantime, gosoline logs an error (i.e., a sentry message) and returns a wrapped error to the caller. Instead, we will now not log the error (which is the responsibility of the caller in the case of a canceled context) and return the original cancellation error (thus the caller can easily compare this to context.Canceled and handle it accordingly).
- If you create a request with http.NewRequest() it would use the default resty client instead of the client later used to perform the request. Thus, the settings for timeout and retries had no effect. This is a breaking change as it requires the caller to use pass the client in http.NewRequest(client). Passing nil is supported to get the old behavior (i.e., so you can easily upgrade your code), mainly however to create an request in tests. We could also move this behavior to the mock of the Http Client if desired.