### PR TITLE
stream: parallize sqs input readers;

### DIFF
--- a/pkg/ddb/repository.go
+++ b/pkg/ddb/repository.go
@@ -237,7 +237,6 @@ func (r *repository) chunkWriteItem(ctx context.Context, input *dynamodb.BatchWr
 		}
 
 		processedItems := totalItemCount(input.RequestItems) - totalItemCount(out.UnprocessedItems)
-
 		input.RequestItems = out.UnprocessedItems
 
 		// If we made any process, we try again and reset our backoff. As long as we are making process we can try again

--- a/pkg/stream/input_configurable.go
+++ b/pkg/stream/input_configurable.go
@@ -105,6 +105,7 @@ type snsInputConfiguration struct {
 	WaitTime          int64             `cfg:"wait_time"`
 	VisibilityTimeout int               `cfg:"visibility_timeout"`
 	RedrivePolicy     sqs.RedrivePolicy `cfg:"redrive_policy"`
+	RunnerCount       int               `cfg:"runner_count"`
 	Targets           []snsInputTarget  `cfg:"targets"`
 }
 
@@ -119,6 +120,7 @@ func newSnsInputFromConfig(config cfg.Config, logger mon.Logger, name string) In
 		WaitTime:          configuration.WaitTime,
 		RedrivePolicy:     configuration.RedrivePolicy,
 		VisibilityTimeout: configuration.VisibilityTimeout,
+		RunnerCount:       configuration.RunnerCount,
 	}
 
 	targets := make([]SnsInputTarget, len(configuration.Targets))
@@ -143,6 +145,7 @@ type sqsInputConfiguration struct {
 	WaitTime          int64             `cfg:"wait_time"`
 	VisibilityTimeout int               `cfg:"visibility_timeout"`
 	RedrivePolicy     sqs.RedrivePolicy `cfg:"redrive_policy"`
+	RunnerCount       int               `cfg:"runner_count"`
 }
 
 func newSqsInputFromConfig(config cfg.Config, logger mon.Logger, name string) Input {
@@ -161,6 +164,7 @@ func newSqsInputFromConfig(config cfg.Config, logger mon.Logger, name string) In
 		WaitTime:          configuration.WaitTime,
 		VisibilityTimeout: configuration.VisibilityTimeout,
 		RedrivePolicy:     configuration.RedrivePolicy,
+		RunnerCount:       configuration.RunnerCount,
 	}
 
 	return NewSqsInput(config, logger, settings)

--- a/pkg/stream/input_sns.go
+++ b/pkg/stream/input_sns.go
@@ -10,10 +10,11 @@ import (
 type SnsInputSettings struct {
 	cfg.AppId
 	AutoSubscribe     bool
-	QueueId           string
-	WaitTime          int64
+	QueueId           string            `cfg:"queue_id"`
+	WaitTime          int64             `cfg:"wait_time"`
 	RedrivePolicy     sqs.RedrivePolicy `cfg:"redrive_policy"`
 	VisibilityTimeout int               `cfg:"visibility_timeout"`
+	RunnerCount       int               `cfg:"runner_count"`
 }
 
 type SnsInputTarget struct {
@@ -35,6 +36,7 @@ func NewSnsInput(config cfg.Config, logger mon.Logger, s SnsInputSettings, targe
 		WaitTime:          s.WaitTime,
 		RedrivePolicy:     s.RedrivePolicy,
 		VisibilityTimeout: s.VisibilityTimeout,
+		RunnerCount:       s.RunnerCount,
 	})
 	sqsInput.SetUnmarshaler(SnsUnmarshaler)
 


### PR DESCRIPTION
add config option `runner_count` to stream sqs input to run multiple sqs receive actions simultaneously