### PR TITLE
Add option to suppress binding validation errors

### DIFF
--- a/pkg/apiserver/crud/create.go
+++ b/pkg/apiserver/crud/create.go
@@ -3,7 +3,9 @@ package crud
 import (
 	"context"
 	"github.com/applike/gosoline/pkg/apiserver"
+	"github.com/applike/gosoline/pkg/cfg"
 	"github.com/applike/gosoline/pkg/db"
+	"github.com/applike/gosoline/pkg/mon"
 	"github.com/gin-gonic/gin"
 	"net/http"
 )
@@ -12,12 +14,12 @@ type createHandler struct {
 	transformer Handler
 }
 
-func NewCreateHandler(transformer Handler) gin.HandlerFunc {
+func NewCreateHandler(transformer Handler, config cfg.Config, logger mon.Logger) gin.HandlerFunc {
 	ch := createHandler{
 		transformer: transformer,
 	}
 
-	return apiserver.CreateJsonHandler(ch)
+	return apiserver.CreateJsonHandler(ch, config, logger)
 }
 
 func (ch createHandler) GetInput() interface{} {

--- a/pkg/apiserver/crud/handler.go
+++ b/pkg/apiserver/crud/handler.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"github.com/applike/gosoline/pkg/apiserver"
+	"github.com/applike/gosoline/pkg/cfg"
 	"github.com/applike/gosoline/pkg/db-repo"
+	"github.com/applike/gosoline/pkg/mon"
 	"github.com/jinzhu/inflection"
 	"net/http"
 )
@@ -34,18 +36,18 @@ type Handler interface {
 	List(ctx context.Context, qb *db_repo.QueryBuilder, apiView string) (out interface{}, err error)
 }
 
-func AddCrudHandlers(d *apiserver.Definitions, version int, basePath string, handler Handler) {
+func AddCrudHandlers(d *apiserver.Definitions, version int, basePath string, handler Handler, config cfg.Config, logger mon.Logger) {
 	path := fmt.Sprintf("/v%d/%s", version, basePath)
 	idPath := fmt.Sprintf("%s/:id", path)
 
-	d.POST(path, NewCreateHandler(handler))
+	d.POST(path, NewCreateHandler(handler, config, logger))
 	d.GET(idPath, NewReadHandler(handler))
-	d.PUT(idPath, NewUpdateHandler(handler))
+	d.PUT(idPath, NewUpdateHandler(handler, config, logger))
 	d.DELETE(idPath, NewDeleteHandler(handler))
 
 	plural := inflection.Plural(basePath)
 	path = fmt.Sprintf("/v%d/%s", version, plural)
-	d.POST(path, NewListHandler(handler))
+	d.POST(path, NewListHandler(handler, config, logger))
 }
 
 func getApiViewFromHeader(reqHeaders http.Header) string {

--- a/pkg/apiserver/crud/list.go
+++ b/pkg/apiserver/crud/list.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"github.com/applike/gosoline/pkg/apiserver"
 	"github.com/applike/gosoline/pkg/apiserver/sql"
+	"github.com/applike/gosoline/pkg/cfg"
+	"github.com/applike/gosoline/pkg/mon"
 	"github.com/gin-gonic/gin"
 )
 
@@ -16,12 +18,12 @@ type listHandler struct {
 	transformer Handler
 }
 
-func NewListHandler(transformer Handler) gin.HandlerFunc {
+func NewListHandler(transformer Handler, config cfg.Config, logger mon.Logger) gin.HandlerFunc {
 	lh := listHandler{
 		transformer: transformer,
 	}
 
-	return apiserver.CreateJsonHandler(lh)
+	return apiserver.CreateJsonHandler(lh, config, logger)
 }
 
 func (lh listHandler) GetInput() interface{} {

--- a/pkg/apiserver/crud/update.go
+++ b/pkg/apiserver/crud/update.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"github.com/applike/gosoline/pkg/apiserver"
+	"github.com/applike/gosoline/pkg/cfg"
 	"github.com/applike/gosoline/pkg/db"
+	"github.com/applike/gosoline/pkg/mon"
 	"github.com/gin-gonic/gin"
 	"net/http"
 )
@@ -13,12 +15,12 @@ type updateHandler struct {
 	transformer Handler
 }
 
-func NewUpdateHandler(transformer Handler) gin.HandlerFunc {
+func NewUpdateHandler(transformer Handler, config cfg.Config, logger mon.Logger) gin.HandlerFunc {
 	uh := updateHandler{
 		transformer: transformer,
 	}
 
-	return apiserver.CreateJsonHandler(uh)
+	return apiserver.CreateJsonHandler(uh, config, logger)
 }
 
 func (uh updateHandler) GetInput() interface{} {

--- a/pkg/apiserver/handler_test.go
+++ b/pkg/apiserver/handler_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"fmt"
 	"github.com/applike/gosoline/pkg/apiserver"
+	cfgMocks "github.com/applike/gosoline/pkg/cfg/mocks"
+	"github.com/applike/gosoline/pkg/mon/mocks"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"net/http"
 	"testing"
 )
@@ -66,7 +69,11 @@ func TestHtmlHandler(t *testing.T) {
 }
 
 func TestCreateIoHandler_InputFailure(t *testing.T) {
-	handler := apiserver.CreateJsonHandler(JsonHandler{})
+	config := new(cfgMocks.Config)
+	logger := mocks.NewLoggerMockedAll()
+	handler := apiserver.CreateJsonHandler(JsonHandler{}, config, logger)
+
+	config.On("GetBool", mock.Anything).Return(false)
 	response := apiserver.HttpTest("PUT", "/action", "/action", `{}`, handler)
 
 	assert.Equal(t, http.StatusBadRequest, response.Code)
@@ -74,7 +81,11 @@ func TestCreateIoHandler_InputFailure(t *testing.T) {
 }
 
 func TestCreateIoHandler(t *testing.T) {
-	handler := apiserver.CreateJsonHandler(JsonHandler{})
+	config := new(cfgMocks.Config)
+	logger := mocks.NewLoggerMockedAll()
+	handler := apiserver.CreateJsonHandler(JsonHandler{}, config, logger)
+
+	config.On("GetBool", mock.Anything).Return(false)
 	response := apiserver.HttpTest("PUT", "/action", "/action", `{"text":"foobar"}`, handler)
 
 	assert.Equal(t, http.StatusOK, response.Code)


### PR DESCRIPTION
- Option is configurable via a 'suppress_binding_validation_errors' key (boolean)
- Logic is updated in the CreateQueryHandler and CreateJsonHandler functions
- If 'suppress_binding_validation_errors' is set to true and there is an error when validating, we log the error but continue to proceed through the handler logic
- Unit tests updated