### PR TITLE
apiserver: log api errors;

### DIFF
--- a/pkg/apiserver/handler.go
+++ b/pkg/apiserver/handler.go
@@ -139,7 +139,7 @@ func handleWithStream(handler HandlerWithStream, binding binding.Binding, errHan
 		err := binding.Bind(ginCtx.Request, input)
 
 		if err != nil {
-			writeErrorResponse(ginCtx, errHandler, http.StatusBadRequest, err)
+			handleError(ginCtx, errHandler, http.StatusBadRequest, err)
 			return
 		}
 
@@ -154,7 +154,7 @@ func handleWithStream(handler HandlerWithStream, binding binding.Binding, errHan
 		err = handler.Handle(ginCtx, reqCtx, request)
 
 		if err != nil {
-			writeErrorResponse(ginCtx, errHandler, http.StatusInternalServerError, err)
+			handleError(ginCtx, errHandler, http.StatusInternalServerError, err)
 			return
 		}
 	}
@@ -166,7 +166,7 @@ func handleWithInput(handler HandlerWithInput, binding binding.Binding, errHandl
 		err := binding.Bind(ginCtx.Request, input)
 
 		if err != nil {
-			writeErrorResponse(ginCtx, errHandler, http.StatusBadRequest, err)
+			handleError(ginCtx, errHandler, http.StatusBadRequest, err)
 			return
 		}
 
@@ -183,7 +183,7 @@ func handleWithMultipleBindings(handler HandlerWithMultipleBindings, errHandler 
 			err := bindings[i].Bind(ginCtx.Request, input)
 
 			if err != nil {
-				writeErrorResponse(ginCtx, errHandler, http.StatusBadRequest, err)
+				handleError(ginCtx, errHandler, http.StatusBadRequest, err)
 				return
 			}
 
@@ -198,7 +198,7 @@ func handleRaw(handler HandlerWithoutInput, errHandler ErrorHandler) gin.Handler
 		body, err := ioutil.ReadAll(ginCtx.Request.Body)
 
 		if err != nil {
-			writeErrorResponse(ginCtx, errHandler, http.StatusBadRequest, err)
+			handleError(ginCtx, errHandler, http.StatusBadRequest, err)
 			return
 		}
 
@@ -219,14 +219,14 @@ func handle(ginCtx *gin.Context, handler HandlerWithoutInput, input interface{},
 	resp, err := handler.Handle(reqCtx, request)
 
 	if err != nil {
-		writeErrorResponse(ginCtx, errHandler, http.StatusInternalServerError, err)
+		handleError(ginCtx, errHandler, http.StatusInternalServerError, err)
 		return
 	}
 
 	writer, err := mkResponseBodyWriter(resp)
 
 	if err != nil {
-		writeErrorResponse(ginCtx, errHandler, http.StatusInternalServerError, err)
+		handleError(ginCtx, errHandler, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -234,7 +234,8 @@ func handle(ginCtx *gin.Context, handler HandlerWithoutInput, input interface{},
 	writer(ginCtx)
 }
 
-func writeErrorResponse(ginCtx *gin.Context, errHandler ErrorHandler, statusCode int, err error) {
+func handleError(ginCtx *gin.Context, errHandler ErrorHandler, statusCode int, err error) {
+	_ = ginCtx.Error(err)
 	resp := errHandler(statusCode, err)
 
 	writer, err := mkResponseBodyWriter(resp)


### PR DESCRIPTION
the apiserver logger middleware should log a request as error level if there is an error during handling the request instead of in the info level