### PR TITLE
redis: use integer config values for backoff;

### DIFF
--- a/pkg/redis/redis_client.go
+++ b/pkg/redis/redis_client.go
@@ -182,11 +182,11 @@ func (c *redisClient) attemptPreventingFailuresByBackoff(wrappedCmd func() (inte
 	backOffSettings := c.settings.BackoffSettings
 
 	backoffConfig := backoff.NewExponentialBackOff()
-	backoffConfig.InitialInterval = backOffSettings.InitialInterval * time.Second
-	backoffConfig.MaxInterval = backOffSettings.MaxInterval * time.Second
+	backoffConfig.InitialInterval = backOffSettings.InitialInterval
+	backoffConfig.MaxInterval = backOffSettings.MaxInterval
+	backoffConfig.MaxElapsedTime = backOffSettings.MaxElapsedTime
 	backoffConfig.Multiplier = backOffSettings.Multiplier
 	backoffConfig.RandomizationFactor = backOffSettings.RandomizationFactor
-	backoffConfig.MaxElapsedTime = backOffSettings.MaxElapsedTime
 
 	var res interface{}
 	var err error


### PR DESCRIPTION
The current setting creates an initial backoff interval of 10^12 seconds. I suggest switching to an integer based configuration, and just assume the given values to be in seconds.