### PR TITLE
application: provide defaults for an api service which already provides a health check;

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -79,3 +79,5 @@ require (
 	gopkg.in/yaml.v2 v2.2.2
 	gopkg.in/yaml.v3 v3.0.0-20190924164351-c8b7dadae555
 )
+
+go 1.11

--- a/pkg/application/app.go
+++ b/pkg/application/app.go
@@ -26,7 +26,7 @@ func (a *App) addLoggerOption(opt LoggerOption) {
 	a.loggerOptions = append(a.loggerOptions, opt)
 }
 
-func Default(options ...Option) kernel.Kernel {
+func ApiDefaultOptions(options ...Option) []Option {
 	defaults := []Option{
 		WithConfigErrorHandlers(defaultErrorHandler),
 		WithConfigFile("./config.dist.yml", "yml"),
@@ -39,13 +39,25 @@ func Default(options ...Option) kernel.Kernel {
 		WithLoggerContextFieldsResolver(mon.ContextLoggerFieldsResolver, tracing.ContextTraceFieldsResolver),
 		WithLoggerMetricHook,
 		WithLoggerSentryHook(mon.SentryExtraConfigProvider, mon.SentryExtraEcsMetadataProvider),
-		WithApiHealthCheck,
 		WithMetricDaemon,
 	}
 
-	options = append(defaults, options...)
+	return append(defaults, options...)
+}
 
-	return New(options...)
+func DefaultOptions(options ...Option) []Option {
+	return append(ApiDefaultOptions(options...), WithApiHealthCheck)
+}
+
+// Default options for the kernel if you define your own apiserver.
+// It does the same as Default, but does not include an health check.
+// Your apiserver will provide the health check instead.
+func ApiDefault(options ...Option) kernel.Kernel {
+	return New(ApiDefaultOptions(options...)...)
+}
+
+func Default(options ...Option) kernel.Kernel {
+	return New(DefaultOptions(options...)...)
 }
 
 func New(options ...Option) kernel.Kernel {

--- a/pkg/sub/subscriber.go
+++ b/pkg/sub/subscriber.go
@@ -191,7 +191,7 @@ func (s *subscriber) recover(ctx context.Context, msg *stream.Message) {
 
 	s.logger.WithContext(ctx).WithFields(mon.Fields{
 		"body": msg.Body,
-	}).Errorf(err, "can not persist model")
+	}).Error(err, "can not persist model")
 }
 
 func (s *subscriber) writeMetric(err error) {


### PR DESCRIPTION
Currently if you use `application.Default()` to create your app, you will get a health check for free. However, if you then define an apiserver, you will get another health check for free. We only need one, so I added `application.ApiDefault()` for api nodes. They will only get a health check if they do define one themselves through an apiserver.