### PR TITLE
db-repo, sql: added ability to treat nulls like in go instead of like in sql;

### DIFF
--- a/pkg/apiserver/crud/crud_test.go
+++ b/pkg/apiserver/crud/crud_test.go
@@ -251,8 +251,8 @@ func TestListHandler_Handle(t *testing.T) {
 		TableName:  "footable",
 		PrimaryKey: "id",
 		Mappings: db_repo.FieldMappings{
-			"id":   db_repo.NewSimpleFieldMapping("id"),
-			"name": db_repo.NewSimpleFieldMapping("name"),
+			"id":   db_repo.NewFieldMapping("id"),
+			"name": db_repo.NewFieldMapping("name"),
 		},
 	})
 	transformer.Repo.On("Count", mock.AnythingOfType("*context.emptyCtx"), qb, &Model{}).Return(1, nil)

--- a/pkg/db-repo/metadata.go
+++ b/pkg/db-repo/metadata.go
@@ -5,7 +5,14 @@ import "github.com/applike/gosoline/pkg/mdl"
 const (
 	BoolAnd = "AND"
 	BoolOr  = "OR"
+
+	// Nulls will be treated like SQL defines them. null != 1 yields null
+	NullModeDefault = 0
+	// Nulls will be treated like Go defines them. null != 1 yields true
+	NullModeDistinct = 1
 )
+
+type NullMode int
 
 type Metadata struct {
 	ModelId    mdl.ModelId
@@ -16,23 +23,84 @@ type Metadata struct {
 
 type FieldMappings map[string]FieldMapping
 
+type FieldMappingColumn struct {
+	name     string
+	nullMode NullMode
+}
+
+func (c FieldMappingColumn) Name() string {
+	return c.name
+}
+
+func (c FieldMappingColumn) NullMode() NullMode {
+	return c.nullMode
+}
+
 type FieldMapping struct {
-	Columns []string
-	Joins   []string
-	Bool    string
+	columns []FieldMappingColumn
+	joins   []string
+	bool    string
 }
 
-func NewSimpleFieldMapping(column string) FieldMapping {
+func (f FieldMapping) Columns() []FieldMappingColumn {
+	return f.columns
+}
+
+func (f FieldMapping) Joins() []string {
+	return f.joins
+}
+
+func (f FieldMapping) Bool() string {
+	return f.bool
+}
+
+func (f FieldMapping) ColumnNames() []string {
+	names := make([]string, 0, len(f.columns))
+
+	for _, c := range f.columns {
+		names = append(names, c.name)
+	}
+
+	return names
+}
+
+func NewFieldMapping(column string) FieldMapping {
+	return NewFieldMappingWithMode(column, NullModeDefault)
+}
+
+func NewFieldMappingWithMode(column string, nullMode NullMode) FieldMapping {
 	return FieldMapping{
-		Columns: []string{column},
-		Bool:    BoolOr,
+		columns: []FieldMappingColumn{
+			{
+				name:     column,
+				nullMode: nullMode,
+			},
+		},
+		bool: BoolOr,
 	}
 }
 
-func NewJoinedFieldMapping(column string, join string) FieldMapping {
-	return FieldMapping{
-		Columns: []string{column},
-		Joins:   []string{join},
-		Bool:    BoolOr,
-	}
+func (f FieldMapping) WithColumn(column string) FieldMapping {
+	return f.WithColumnWithMode(column, NullModeDefault)
+}
+
+func (f FieldMapping) WithColumnWithMode(column string, nullMode NullMode) FieldMapping {
+	f.columns = append(f.columns, FieldMappingColumn{
+		name:     column,
+		nullMode: nullMode,
+	})
+
+	return f
+}
+
+func (f FieldMapping) WithJoin(join string) FieldMapping {
+	f.joins = append(f.joins, join)
+
+	return f
+}
+
+func (f FieldMapping) WithBool(bool string) FieldMapping {
+	f.bool = bool
+
+	return f
 }


### PR DESCRIPTION
If you now query for `foo != null`, you will get some results instead of nothing at all.