### PR TITLE
mon: lock metric daemon while adding default metrics;

### DIFF
--- a/pkg/mon/metric_daemon.go
+++ b/pkg/mon/metric_daemon.go
@@ -115,9 +115,14 @@ func (d *cwDaemon) Run(ctx context.Context) error {
 	}
 }
 
-func (d *cwDaemon) AddDefault(datum *MetricDatum) {
-	id := datum.Id()
-	d.defaults[id] = datum
+func (d *cwDaemon) AddDefaults(data ...*MetricDatum) {
+	d.Lock()
+	defer d.Unlock()
+
+	for _, datum := range data {
+		id := datum.Id()
+		d.defaults[id] = datum
+	}
 }
 
 func (d *cwDaemon) append(datum *MetricDatum) {

--- a/pkg/mon/metric_writer_daemon.go
+++ b/pkg/mon/metric_writer_daemon.go
@@ -13,9 +13,7 @@ func NewMetricDaemonWriter(defaults ...*MetricDatum) *daemonWriter {
 	clock := clockwork.NewRealClock()
 	daemon := ProvideCwDaemon()
 
-	for _, def := range defaults {
-		daemon.AddDefault(def)
-	}
+	daemon.AddDefaults(defaults...)
 
 	return NewMetricDaemonWriterWithInterfaces(clock, daemon)
 }


### PR DESCRIPTION
there is a race condition during application boot if multiple modules add default metrics  
this should be prevented by locking the `AddDefault` function