### PR TITLE
parquet: write time.Time like firehose;

### DIFF
--- a/pkg/parquet/schema.go
+++ b/pkg/parquet/schema.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/applike/gosoline/pkg/encoding/json"
 	"github.com/applike/gosoline/pkg/refl"
+	"math/big"
 	"reflect"
 	"time"
 )
@@ -39,7 +40,7 @@ var schemaTypeMap = map[reflect.Type]string{
 	reflect.TypeOf(float64(0)):  "DOUBLE",
 	reflect.TypeOf(""):          "UTF8",
 	reflect.TypeOf([]byte{}):    "BYTE_ARRAY",
-	reflect.TypeOf(time.Time{}): "TIMESTAMP_MILLIS",
+	reflect.TypeOf(time.Time{}): "INT96",
 }
 
 func mapFieldsToTags(value interface{}) (map[string]interface{}, error) {
@@ -80,7 +81,7 @@ func mapFieldsToTags(value interface{}) (map[string]interface{}, error) {
 				return nil, fmt.Errorf("could not access time field %s for conversion: type %T", tField.Name, vField.Interface())
 			}
 
-			result[fieldName] = createTimestamp(t)
+			result[fieldName] = createParquetInt96Timestamp(t)
 		default:
 			result[fieldName] = v
 		}
@@ -169,22 +170,64 @@ func createTag(props map[string]string) string {
 	return tag
 }
 
-func createTimestamp(t time.Time) string {
+// Note: firehose stores timestamp_millis as nano + julian date little endian int96 values (old parquet format)
+// the corresponding go type would be a 12 byte byte array, with
+// - the first 8 bytes are the nanoseconds within the day
+// - the following four bytes represent the julian date
+
+func createParquetInt96Timestamp(t time.Time) string {
+	// convert timestamp to julian date and nanoseconds within the day
 	// based on https://github.com/carlosjhr64/jd/blob/master/jd.go
 
-	year := t.Year()
-	month := int(t.Month())
-	day := t.Day()
+	i := t.Year()
+	j := int(t.Month())
+	k := t.Day()
 
-	v := day - 32075 + 1461*(year+4800+(month-14)/12)/4 + 367*(month-2-(month-14)/12*12)/12 - 3*((year+4900+(month-14)/12)/100)/4
+	v := k - 32075 + 1461*(i+4800+(j-14)/12)/4 + 367*(j-2-(j-14)/12*12)/12 - 3*((i+4900+(j-14)/12)/100)/4
 
 	hour, minute, second := t.Clock()
-	nano := (hour*3600 + minute*60 + second) * 1000
+	nanos := t.Nanosecond()
+	nano := time.Duration(hour)*time.Hour +
+		time.Duration(minute)*time.Minute +
+		time.Duration(second)*time.Second +
+		time.Duration(nanos)
+
+	// xitongsys / parquet requires a big endian int96 string representation to write it the same way as firehose
 
 	parquetDate := make([]byte, 12)
 
-	binary.LittleEndian.PutUint64(parquetDate[:8], uint64(nano))
-	binary.LittleEndian.PutUint32(parquetDate[8:], uint32(v))
+	binary.BigEndian.PutUint32(parquetDate[:4], uint32(v))
+	binary.BigEndian.PutUint64(parquetDate[4:], uint64(nano))
 
-	return string(parquetDate)
+	bi := big.NewInt(0)
+	bi.SetBytes(parquetDate)
+
+	return bi.String()
+}
+
+func parseInt96Timestamp(t string) time.Time {
+	parquetDate := []byte(t)
+
+	// split into julian date and nano seconds within the day
+
+	nano := binary.LittleEndian.Uint64(parquetDate[:8])
+	dt := binary.LittleEndian.Uint32(parquetDate[8:])
+
+	// julian date to Y-m-d conversion based on https://github.com/carlosjhr64/jd/blob/master/jd.go#L24
+
+	l := dt + 68569
+	n := 4 * l / 146097
+	l = l - (146097*n+3)/4
+	i := 4000 * (l + 1) / 1461001
+	l = l - 1461*i/4 + 31
+	j := 80 * l / 2447
+	k := l - 2447*j/80
+	l = j / 11
+	j = j + 2 - 12*l
+	i = 100*(n-49) + i + l
+
+	tm := time.Date(int(i), time.Month(j), int(k), 0, 0, 0, 0, time.UTC)
+	tm = tm.Add(time.Duration(nano))
+
+	return tm
 }


### PR DESCRIPTION
Fix writing timestamps, use the same format as AWS firehose