### PR TITLE
logger: copy fields and structs passed into the logger deeply;

### DIFF
--- a/pkg/mon/logger.go
+++ b/pkg/mon/logger.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"io"
 	"os"
+	"reflect"
 	"runtime"
 	"strconv"
 	"strings"
@@ -354,25 +355,84 @@ func getStackTrace(depthSkip int) string {
 }
 
 func mergeMapStringInterface(receiver map[string]interface{}, input map[string]interface{}) map[string]interface{} {
-	for k, v := range input {
-		switch v := v.(type) {
-		case error:
-			// Otherwise errors are ignored by `encoding/json`
-			input[k] = v.Error()
-		default:
-			input[k] = v
-		}
-	}
-
 	newMap := make(map[string]interface{}, len(receiver)+len(input))
 
 	for k, v := range receiver {
-		newMap[k] = v
+		newMap[k] = prepareForLog(v)
 	}
 
 	for k, v := range input {
-		newMap[k] = v
+		newMap[k] = prepareForLog(v)
 	}
 
 	return newMap
+}
+
+func prepareForLog(v interface{}) interface{} {
+	switch t := v.(type) {
+	case error:
+		// Otherwise errors are ignored by `encoding/json`
+		return t.Error()
+
+	case map[string]interface{}:
+		// perform a deep copy of any maps contained in this map element
+		// to ensure we own the object completely
+		return mergeMapStringInterface(t, nil)
+
+	default:
+		// same as before, but handle the case of the map mapping to something
+		// different than interface{}
+		// should quite rarely get hit, otherwise you are using too complex objects for your logs
+		rv := reflect.ValueOf(v)
+		switch rv.Kind() {
+		case reflect.Map:
+			iter := rv.MapRange()
+			newMap := make(map[string]interface{}, rv.Len())
+
+			for iter.Next() {
+				keyValue := iter.Key()
+				elemValue := iter.Value()
+				newMap[fmt.Sprint(keyValue.Interface())] = prepareForLog(elemValue.Interface())
+			}
+
+			return newMap
+
+		case reflect.Ptr, reflect.Interface:
+			if rv.IsNil() {
+				return nil
+			}
+
+			return prepareForLog(rv.Elem().Interface())
+
+		case reflect.Struct:
+			rvt := rv.Type()
+			newMap := make(map[string]interface{}, rv.NumField())
+
+			for i := 0; i < rv.NumField(); i++ {
+				field := rv.Field(i)
+				if !field.CanInterface() {
+					continue
+				}
+				newMap[rvt.Field(i).Name] = prepareForLog(field.Interface())
+			}
+
+			return newMap
+
+		case reflect.Slice, reflect.Array:
+			if rv.Kind() == reflect.Slice && rv.IsNil() {
+				return nil
+			}
+
+			newArray := make([]interface{}, rv.Len())
+
+			for i := range newArray {
+				newArray[i] = prepareForLog(rv.Index(i).Interface())
+			}
+
+			return newArray
+
+		default:
+			return v
+		}
+	}
 }

--- a/pkg/mon/logger_options.go
+++ b/pkg/mon/logger_options.go
@@ -1,5 +1,9 @@
 package mon
 
+import (
+	"fmt"
+)
+
 type LoggerOption func(logger *logger) error
 
 func WithContextFieldsResolver(resolver ...ContextFieldsResolver) LoggerOption {
@@ -11,6 +15,10 @@ func WithContextFieldsResolver(resolver ...ContextFieldsResolver) LoggerOption {
 
 func WithFormat(format string) LoggerOption {
 	return func(logger *logger) error {
+		if _, ok := formatters[format]; !ok {
+			return fmt.Errorf("unknown logger format: %s", format)
+		}
+
 		logger.format = format
 		return nil
 	}


### PR DESCRIPTION
In the past, we would only store a reference to maps passed into
our logger with WithFields, WithContext, a context resolver or any
other means. As we needed to transform the errors to strings for
them to appear in the json encoded message, we replaced the value
in the map directly. However, this caused concurrent reads and writes
to the map to happen if more than one thread was using the same map.

We later started to take a copy of the map, so we were a lot less likely
to run into a concurrent read and write. Still, we did not account for
nested maps and objects, so a concurrent read and write panic could
still happen.

The new solution is to perform a deep clone of any maps, structs or
arrays (basically anything meaningful represented by a pointer) and
avoid writing anything into the maps we get passed as input. Performance
wise this could be a lot slower, but in most cases one should not pass
nested maps or pass them as map[string]interface{}. In the latter case
we have a special case to do the copy directly without resorting to
reflection. All other cases are handled by reflection.