### PR TITLE
mon: logger support time.Time fields

### DIFF
--- a/pkg/mon/logger.go
+++ b/pkg/mon/logger.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 )
 
 const (
@@ -373,7 +374,8 @@ func prepareForLog(v interface{}) interface{} {
 	case error:
 		// Otherwise errors are ignored by `encoding/json`
 		return t.Error()
-
+	case time.Time:
+		return v
 	case map[string]interface{}:
 		// perform a deep copy of any maps contained in this map element
 		// to ensure we own the object completely

--- a/pkg/mon/logger_test.go
+++ b/pkg/mon/logger_test.go
@@ -178,10 +178,11 @@ func TestClient_WithFields(t *testing.T) {
 	logger1 := logger0.WithFields(mon.Fields{
 		"field1": "a",
 		"field2": 1,
+		"time":   time.Unix(1580480991, 0),
 	})
 	logger1.Info("foobar")
 
-	expected := `{"fields":{"field1":"a","field2":1},"context":{},"channel": "default", "level":2,"level_name":"info","message":"foobar","timestamp":"1984-04-04T00:00:00Z"}`
+	expected := `{"fields":{"field1":"a","field2":1,"time":"2020-01-31T15:29:51+01:00"},"context":{},"channel": "default", "level":2,"level_name":"info","message":"foobar","timestamp":"1984-04-04T00:00:00Z"}`
 	assert.JSONEq(t, expected, out.String(), "output should match")
 
 	out.Reset()
@@ -190,7 +191,7 @@ func TestClient_WithFields(t *testing.T) {
 	})
 	logger2.Info("msg2")
 
-	expected = `{"fields":{"field1":"a","field2":1, "field3":0.3},"context":{},"channel": "default", "level":2,"level_name":"info","message":"msg2","timestamp":"1984-04-04T00:00:00Z"}`
+	expected = `{"fields":{"field1":"a","field2":1,"time":"2020-01-31T15:29:51+01:00","field3":0.3},"context":{},"channel": "default", "level":2,"level_name":"info","message":"msg2","timestamp":"1984-04-04T00:00:00Z"}`
 	assert.JSONEq(t, expected, out.String(), "output should match")
 
 	out.Reset()


### PR DESCRIPTION
currently if we try to log a field of type `time.Time` an empty object is logged instead.

Expected behavior: allow `time.Time` fields to be logged.
