### PR TITLE
stream: add sns and sqs support compression for the message body

### DIFF
--- a/pkg/compression/gzip.go
+++ b/pkg/compression/gzip.go
@@ -1,0 +1,52 @@
+package compression
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+)
+
+func Gzip(data []byte) ([]byte, error) {
+	var b bytes.Buffer
+	gz := gzip.NewWriter(&b)
+
+	_, err := gz.Write(data)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = gz.Flush(); err != nil {
+		return nil, err
+	}
+
+	if err = gz.Close(); err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
+}
+
+func GzipString(data string) ([]byte, error) {
+	return Gzip([]byte(data))
+}
+
+func Gunzip(data []byte) ([]byte, error) {
+	b := bytes.NewBuffer(data)
+
+	var r io.Reader
+	r, err := gzip.NewReader(b)
+	if err != nil {
+		return nil, err
+	}
+	var resB bytes.Buffer
+	_, err = resB.ReadFrom(r)
+	if err != nil {
+		return nil, err
+	}
+	return resB.Bytes(), nil
+}
+
+func GunzipToString(data []byte) (string, error) {
+	uncompressedData, err := Gunzip(data)
+
+	return string(uncompressedData), err
+}

--- a/pkg/compression/gzip_test.go
+++ b/pkg/compression/gzip_test.go
@@ -1,0 +1,17 @@
+package compression_test
+
+import (
+	"github.com/applike/gosoline/pkg/compression"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+const testData = "string to be compressed"
+
+func TestGzip(t *testing.T) {
+	compressedData, err := compression.GzipString(testData)
+	assert.NoError(t, err)
+	originalData, err := compression.GunzipToString(compressedData)
+	assert.NoError(t, err)
+	assert.Equal(t, testData, originalData)
+}

--- a/pkg/encoding/base64/base64.go
+++ b/pkg/encoding/base64/base64.go
@@ -1,0 +1,11 @@
+package base64
+
+import b64 "encoding/base64"
+
+func Encode(v []byte) string {
+	return b64.StdEncoding.EncodeToString(v)
+}
+
+func DecodeString(v string) ([]byte, error) {
+	return b64.StdEncoding.DecodeString(v)
+}

--- a/pkg/sqs/queue.go
+++ b/pkg/sqs/queue.go
@@ -34,6 +34,7 @@ type Queue interface {
 type Message struct {
 	DelaySeconds   *int64
 	MessageGroupId *string
+	Compressed     *bool
 	Body           *string
 }
 

--- a/pkg/stream/input_sqs.go
+++ b/pkg/stream/input_sqs.go
@@ -116,6 +116,13 @@ func (i *sqsInput) runLoop(ctx context.Context) error {
 
 			msg.Attributes[AttributeSqsReceiptHandle] = *sqsMessage.ReceiptHandle
 
+			if msg.IsCompressed() {
+				err := msg.Decompress()
+				if err != nil {
+					return err
+				}
+			}
+
 			i.channel <- msg
 		}
 	}

--- a/pkg/stream/message_test.go
+++ b/pkg/stream/message_test.go
@@ -29,3 +29,20 @@ func BuildSqsTestMessage() (*stream.Message, error) {
 
 	return builder.GetMessage()
 }
+
+func BuildSqsTestMessageWithCompression() (*stream.Message, error) {
+	type BodyStruct struct {
+		Foo string
+	}
+
+	body := BodyStruct{
+		Foo: "bar",
+	}
+
+	builder := stream.NewMessageBuilder()
+	builder.WithBody(body)
+	builder.WithSqsDelaySeconds(45)
+	builder.WithCompression()
+
+	return builder.GetMessage()
+}

--- a/pkg/stream/output_sns.go
+++ b/pkg/stream/output_sns.go
@@ -71,6 +71,13 @@ func (o *snsOutput) publishToTopic(ctx context.Context, batch []*Message) error 
 	errors := make([]error, 0)
 
 	for _, msg := range batch {
+		if msg.IsCompressed() {
+			err := msg.Compress()
+			if err != nil {
+				return err
+			}
+		}
+
 		body, err := msg.MarshalToString()
 
 		if err != nil {

--- a/pkg/stream/output_sqs_test.go
+++ b/pkg/stream/output_sqs_test.go
@@ -2,6 +2,8 @@ package stream_test
 
 import (
 	"context"
+	"github.com/applike/gosoline/pkg/compression"
+	"github.com/applike/gosoline/pkg/encoding/base64"
 	"github.com/applike/gosoline/pkg/mdl"
 	monMocks "github.com/applike/gosoline/pkg/mon/mocks"
 	"github.com/applike/gosoline/pkg/sqs"
@@ -22,6 +24,7 @@ func TestSqsOutput_WriteOne(t *testing.T) {
 		{
 			DelaySeconds: mdl.Int64(45),
 			Body:         mdl.String(expectedBody),
+			Compressed:   mdl.Bool(false),
 		},
 	}
 
@@ -29,6 +32,33 @@ func TestSqsOutput_WriteOne(t *testing.T) {
 	queue.On("SendBatch", mock.AnythingOfType("*context.emptyCtx"), expectedSqsMessages).Return(nil)
 
 	msg, err := BuildSqsTestMessage()
+	assert.NoError(t, err)
+
+	output := stream.NewSqsOutputWithInterfaces(logger, tracer, queue, stream.SqsOutputSettings{})
+	err = output.WriteOne(context.Background(), msg)
+
+	assert.NoError(t, err)
+}
+
+func TestSqsOutput_WriteOne_Compressed(t *testing.T) {
+	logger := monMocks.NewLoggerMockedAll()
+	tracer := tracing.NewNoopTracer()
+
+	compressedBody, err := compression.GzipString("{\"Foo\":\"bar\"}")
+	assert.NoError(t, err)
+	expectedBody := `{"trace":{"traceId":"","id":"","parentId":"","sampled":false},"attributes":{"compressedMessage":true,"sqsDelaySeconds":45},"body":"` + base64.Encode(compressedBody) + `"}`
+	expectedSqsMessages := []*sqs.Message{
+		{
+			DelaySeconds: mdl.Int64(45),
+			Body:         mdl.String(expectedBody),
+			Compressed:   mdl.Bool(true),
+		},
+	}
+
+	queue := new(sqsMocks.Queue)
+	queue.On("SendBatch", mock.AnythingOfType("*context.emptyCtx"), expectedSqsMessages).Return(nil)
+
+	msg, err := BuildSqsTestMessageWithCompression()
 	assert.NoError(t, err)
 
 	output := stream.NewSqsOutputWithInterfaces(logger, tracer, queue, stream.SqsOutputSettings{})


### PR DESCRIPTION
Some times the messages are too large to be transferred  due to 256 KB message size limit.
For this reason it would be nice to be able to compress the message body