### PR TITLE
fixtures: separate loader from module;

### DIFF
--- a/pkg/fixtures/loader.go
+++ b/pkg/fixtures/loader.go
@@ -1,10 +1,8 @@
 package fixtures
 
 import (
-	"context"
 	"fmt"
 	"github.com/applike/gosoline/pkg/cfg"
-	"github.com/applike/gosoline/pkg/kernel"
 	"github.com/applike/gosoline/pkg/mon"
 )
 
@@ -15,8 +13,6 @@ type FixtureSet struct {
 }
 
 type FixtureLoader struct {
-	kernel.BackgroundModule
-	Writers     []FixtureWriter
 	fixtureSets []*FixtureSet
 }
 
@@ -26,7 +22,7 @@ func NewFixtureLoader(fixtureSets []*FixtureSet) *FixtureLoader {
 	}
 }
 
-func (f *FixtureLoader) Boot(config cfg.Config, logger mon.Logger) error {
+func (f *FixtureLoader) Load(config cfg.Config, logger mon.Logger) error {
 	logger = logger.WithChannel("fixture_loader")
 
 	if !config.IsSet("fixture_loader_enabled") {
@@ -35,7 +31,7 @@ func (f *FixtureLoader) Boot(config cfg.Config, logger mon.Logger) error {
 	}
 
 	if !config.GetBool("fixture_loader_enabled") {
-		logger.Info("fixture loader is ot enabled")
+		logger.Info("fixture loader is not enabled")
 		return nil
 	}
 
@@ -58,10 +54,5 @@ func (f *FixtureLoader) Boot(config cfg.Config, logger mon.Logger) error {
 		}
 	}
 
-	return nil
-}
-
-func (f *FixtureLoader) Run(ctx context.Context) error {
-	// do nothing: fixtures are loaded during boot
 	return nil
 }

--- a/pkg/fixtures/module.go
+++ b/pkg/fixtures/module.go
@@ -1,0 +1,32 @@
+package fixtures
+
+import (
+	"context"
+	"github.com/applike/gosoline/pkg/cfg"
+	"github.com/applike/gosoline/pkg/kernel"
+	"github.com/applike/gosoline/pkg/mon"
+)
+
+type FixtureLoaderModule struct {
+	kernel.BackgroundModule
+	loader *FixtureLoader
+}
+
+func NewFixtureLoaderModule(fixtureSets []*FixtureSet) *FixtureLoaderModule {
+	loader := &FixtureLoader{
+		fixtureSets: fixtureSets,
+	}
+
+	return &FixtureLoaderModule{
+		loader: loader,
+	}
+}
+
+func (m *FixtureLoaderModule) Boot(config cfg.Config, logger mon.Logger) error {
+	return m.loader.Load(config, logger)
+}
+
+func (m *FixtureLoaderModule) Run(ctx context.Context) error {
+	// do nothing: fixtures are loaded during boot
+	return nil
+}

--- a/pkg/fixtures/writer_ddb.go
+++ b/pkg/fixtures/writer_ddb.go
@@ -16,22 +16,14 @@ type dynamoDbFixtureWriter struct {
 
 func DynamoDbFixtureWriterFactory(modelId *mdl.ModelId) FixtureWriterFactory {
 	return func(cfg cfg.Config, logger mon.Logger) FixtureWriter {
-		writer := NewDynamoDbFixtureWriter(cfg, logger)
-		writer.WithModelId(modelId)
+		writer := &dynamoDbFixtureWriter{
+			config:  cfg,
+			logger:  logger,
+			modelId: modelId,
+		}
 
 		return writer
 	}
-}
-
-func NewDynamoDbFixtureWriter(cfg cfg.Config, logger mon.Logger) *dynamoDbFixtureWriter {
-	return &dynamoDbFixtureWriter{
-		config: cfg,
-		logger: logger,
-	}
-}
-
-func (d *dynamoDbFixtureWriter) WithModelId(modelId *mdl.ModelId) {
-	d.modelId = modelId
 }
 
 func (d *dynamoDbFixtureWriter) WriteFixtures(fs *FixtureSet) error {

--- a/pkg/fixtures/writer_ddb_kv.go
+++ b/pkg/fixtures/writer_ddb_kv.go
@@ -23,22 +23,14 @@ type dynamoDbKeyValueFixtureWriter struct {
 
 func DynamoDbKvStoreFixtureWriterFactory(modelId *mdl.ModelId) FixtureWriterFactory {
 	return func(cfg cfg.Config, logger mon.Logger) FixtureWriter {
-		writer := newDynamoDbKvStoreFixtureWriter(cfg, logger)
-		writer.WithModelId(modelId)
+		writer := &dynamoDbKeyValueFixtureWriter{
+			config:  cfg,
+			logger:  logger,
+			modelId: modelId,
+		}
 
 		return writer
 	}
-}
-
-func newDynamoDbKvStoreFixtureWriter(cfg cfg.Config, logger mon.Logger) *dynamoDbKeyValueFixtureWriter {
-	return &dynamoDbKeyValueFixtureWriter{
-		config: cfg,
-		logger: logger,
-	}
-}
-
-func (d *dynamoDbKeyValueFixtureWriter) WithModelId(modelId *mdl.ModelId) {
-	d.modelId = modelId
 }
 
 func (d *dynamoDbKeyValueFixtureWriter) WriteFixtures(fs *FixtureSet) error {

--- a/pkg/fixtures/writer_mysql.go
+++ b/pkg/fixtures/writer_mysql.go
@@ -16,23 +16,15 @@ type mySqlFixtureWriter struct {
 }
 
 func MySqlFixtureWriterFactory(metadata *db_repo.Metadata) FixtureWriterFactory {
-	return func(cfg cfg.Config, logger mon.Logger) FixtureWriter {
-		writer := newMySqlFixtureWriter(cfg, logger)
-		writer.WithMetadata(metadata)
+	return func(config cfg.Config, logger mon.Logger) FixtureWriter {
+		writer := &mySqlFixtureWriter{
+			config:   config,
+			logger:   logger,
+			metadata: metadata,
+		}
 
 		return writer
 	}
-}
-
-func newMySqlFixtureWriter(config cfg.Config, logger mon.Logger) *mySqlFixtureWriter {
-	return &mySqlFixtureWriter{
-		config: config,
-		logger: logger,
-	}
-}
-
-func (m *mySqlFixtureWriter) WithMetadata(metadata *db_repo.Metadata) {
-	m.metadata = metadata
 }
 
 func (m *mySqlFixtureWriter) WriteFixtures(fs *FixtureSet) error {

--- a/test/fixtures_dynamodb_test.go
+++ b/test/fixtures_dynamodb_test.go
@@ -40,7 +40,7 @@ func (s FixturesDynamoDbSuite) TestDynamoDb() {
 
 	config := configFromFiles("test_configs/config.dynamodb.test.yml", "test_configs/config.fixtures_dynamodb.test.yml")
 
-	err := loader.Boot(config, s.logger)
+	err := loader.Load(config, s.logger)
 	assert.NoError(s.T(), err)
 
 	gio, err := s.db.GetItem(&dynamodb.GetItemInput{
@@ -64,7 +64,7 @@ func (s FixturesDynamoDbSuite) TestDynamoDbKvStore() {
 
 	config := configFromFiles("test_configs/config.dynamodb.test.yml", "test_configs/config.fixtures_dynamodb.test.yml")
 
-	err := loader.Boot(config, s.logger)
+	err := loader.Load(config, s.logger)
 	assert.NoError(s.T(), err)
 
 	gio, err := s.db.GetItem(&dynamodb.GetItemInput{

--- a/test/fixtures_mysql_test.go
+++ b/test/fixtures_mysql_test.go
@@ -57,7 +57,7 @@ func Test_enabled_fixtures_mysql(t *testing.T) {
 	logger := mon.NewLogger()
 	config := configFromFiles("test_configs/config.mysql.test.yml", "test_configs/config.fixtures_mysql.test.yml")
 
-	err := loader.Boot(config, logger)
+	err := loader.Load(config, logger)
 	assert.NoError(t, err)
 
 	settings := db_repo.Settings{


### PR DESCRIPTION
**Motivation:**
For some use cases, for example in tests, I just want to load some fixtures in a synchronous way and I do not need to use the module/application/kernel abstraction for that.

In those cases you can just create the `FixtureLoader` directly and call the `Load` method.