### PR TITLE
fixtures: allow to include global settings for ddb writer;

### DIFF
--- a/test/fixtures_dynamodb_test.go
+++ b/test/fixtures_dynamodb_test.go
@@ -4,10 +4,12 @@ package test_test
 
 import (
 	"github.com/applike/gosoline/pkg/cfg"
+	"github.com/applike/gosoline/pkg/ddb"
 	"github.com/applike/gosoline/pkg/fixtures"
 	"github.com/applike/gosoline/pkg/mdl"
 	"github.com/applike/gosoline/pkg/mon"
 	"github.com/applike/gosoline/pkg/test"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -46,10 +48,10 @@ func (s FixturesDynamoDbSuite) TestDynamoDb() {
 	gio, err := s.db.GetItem(&dynamodb.GetItemInput{
 		Key: map[string]*dynamodb.AttributeValue{
 			"Name": {
-				S: mdl.String("Ash"),
+				S: aws.String("Ash"),
 			},
 		},
-		TableName: mdl.String("gosoline-test-integration-test-test-application-testModel"),
+		TableName: aws.String("gosoline-test-integration-test-test-application-testModel"),
 	})
 
 	// should have created the item
@@ -57,6 +59,21 @@ func (s FixturesDynamoDbSuite) TestDynamoDb() {
 	assert.Len(s.T(), gio.Item, 2, "2 attributes expected")
 	assert.Equal(s.T(), "Ash", *(gio.Item["Name"].S))
 	assert.Equal(s.T(), "10", *(gio.Item["Age"].N))
+
+	qo, err := s.db.Query(&dynamodb.QueryInput{
+		TableName:              aws.String("gosoline-test-integration-test-test-application-testModel"),
+		IndexName:              aws.String("IDX_Age"),
+		KeyConditionExpression: aws.String("Age = :v_age"),
+		ExpressionAttributeValues: map[string]*dynamodb.AttributeValue{
+			":v_age": {
+				N: aws.String("10"),
+			},
+		},
+	})
+
+	// should have created global index
+	assert.NoError(s.T(), err)
+	assert.Len(s.T(), qo.Items, 1, "1 item expected")
 }
 
 func (s FixturesDynamoDbSuite) TestDynamoDbKvStore() {
@@ -70,10 +87,10 @@ func (s FixturesDynamoDbSuite) TestDynamoDbKvStore() {
 	gio, err := s.db.GetItem(&dynamodb.GetItemInput{
 		Key: map[string]*dynamodb.AttributeValue{
 			"key": {
-				S: mdl.String("Ash"),
+				S: aws.String("Ash"),
 			},
 		},
-		TableName: mdl.String("gosoline-test-integration-test-test-application-kvstore-testModel"),
+		TableName: aws.String("gosoline-test-integration-test-test-application-kvstore-testModel"),
 	})
 
 	// should have created the item
@@ -84,7 +101,7 @@ func (s FixturesDynamoDbSuite) TestDynamoDbKvStore() {
 
 type DynamoDbTestModel struct {
 	Name string `ddb:"key=hash"`
-	Age  uint
+	Age  uint   `ddb:"global=hash"`
 }
 
 func dynamoDbKvStoreFixtures() []*fixtures.FixtureSet {
@@ -112,12 +129,25 @@ func dynamoDbFixtures() []*fixtures.FixtureSet {
 	return []*fixtures.FixtureSet{
 		{
 			Enabled: true,
-			Writer: fixtures.DynamoDbFixtureWriterFactory(&mdl.ModelId{
-				Project:     "gosoline",
-				Environment: "test",
-				Family:      "integration-test",
-				Application: "test-application",
-				Name:        "testModel",
+			Writer: fixtures.DynamoDbFixtureWriterFactory(&ddb.Settings{
+				ModelId: mdl.ModelId{
+					Project:     "gosoline",
+					Environment: "test",
+					Family:      "integration-test",
+					Application: "test-application",
+					Name:        "testModel",
+				},
+				Main: ddb.MainSettings{
+					Model: DynamoDbTestModel{},
+				},
+				Global: []ddb.GlobalSettings{
+					{
+						Name:               "IDX_Age",
+						Model:              DynamoDbTestModel{},
+						ReadCapacityUnits:  1,
+						WriteCapacityUnits: 1,
+					},
+				},
 			}),
 			Fixtures: []interface{}{
 				&DynamoDbTestModel{Name: "Ash", Age: 10},


### PR DESCRIPTION
This is needed to be able to create global secondary indexes.