### PR TITLE
blob, ddb: avoid error log on existing bucket and strip out additional json arguments;

### DIFF
--- a/pkg/blob/store.go
+++ b/pkg/blob/store.go
@@ -274,7 +274,8 @@ func isBucketAlreadyExistsError(err error) bool {
 	}
 
 	if aerr, ok := err.(awserr.Error); ok {
-		return aerr.Code() == s3.ErrCodeBucketAlreadyExists
+		return aerr.Code() == s3.ErrCodeBucketAlreadyExists ||
+			aerr.Code() == s3.ErrCodeBucketAlreadyOwnedByYou
 	}
 
 	return false

--- a/pkg/ddb/expr_projection.go
+++ b/pkg/ddb/expr_projection.go
@@ -10,7 +10,7 @@ func buildProjectionExpression(metadata FieldAware, model interface{}) (*express
 		return nil, nil
 	}
 
-	projectedFields, err := metadataReadFields(model)
+	projectedFields, err := MetadataReadFields(model)
 
 	if err != nil {
 		return nil, err

--- a/pkg/ddb/metadata_factory.go
+++ b/pkg/ddb/metadata_factory.go
@@ -130,7 +130,7 @@ func (f *metadataFactory) getFields(model interface{}, hashTag string, rangeTag 
 		rangeKey = mdl.String(rangeAttribute.AttributeName)
 	}
 
-	if fields, err = metadataReadFields(model); err != nil {
+	if fields, err = MetadataReadFields(model); err != nil {
 		return metadataFields{}, err
 	}
 
@@ -313,7 +313,7 @@ func (f *metadataFactory) getAttributeType(field reflect.StructField) string {
 	return attributeType
 }
 
-func metadataReadFields(model interface{}) ([]string, error) {
+func MetadataReadFields(model interface{}) ([]string, error) {
 	t := findBaseType(model)
 	fields := make([]string, 0)
 
@@ -338,6 +338,12 @@ func metadataReadFields(model interface{}) ([]string, error) {
 
 		if tag == "-" {
 			continue
+		}
+
+		tag = strings.SplitN(tag, ",", 2)[0]
+
+		if len(tag) == 0 {
+			tag = field.Name
 		}
 
 		fields = append(fields, tag)

--- a/pkg/ddb/metadata_factory_test.go
+++ b/pkg/ddb/metadata_factory_test.go
@@ -1,0 +1,27 @@
+package ddb_test
+
+import (
+	"github.com/applike/gosoline/pkg/ddb"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+type TestModel struct {
+	MyName         int `json:"myName"`
+	MyNameWithAttr int `json:"myNameWithAttr,omitempty"`
+	MyNamePlain    int `json:",omitempty"`
+	MyIgnoredField int `json:"-"`
+	DashField      int `json:"-,"`
+}
+
+func TestMetadataReadFields(t *testing.T) {
+	fields, err := ddb.MetadataReadFields(TestModel{})
+	assert.NoError(t, err)
+	assert.Equal(t, []string{
+		"myName",
+		"myNameWithAttr",
+		"MyNamePlain",
+		// MyIgnoredField is... ignored, so there is no entry for it
+		"-",
+	}, fields)
+}


### PR DESCRIPTION
If you are using a real (no localstack) endpoint for S3 and use
autoCreate, S3 might return an error telling you the bucket does already
exist. We handled this in the past (failing to create a bucket because
it already exsits is not really an error, especially in the context of
autoCreate), but S3 can return a second error telling you you already
own the bucket instead. As this is basically the same situation, also
ignore that error.

For ddb, if we automatically generate the table, we have to strip any
json tags, otherwise a line like 'Foo string `json:"foo,omitempty"`'
would try to create a field called "foo,omitempty" instead of foo. This
then breakes if the the field is used for any keys because it can later
not be found (because you only reference foo instead of foo,omitempty).