### PR TITLE
fixtures: cleanup pointer to slice;

### DIFF
--- a/examples/gosoline-fixture-loading/main.go
+++ b/examples/gosoline-fixture-loading/main.go
@@ -50,8 +50,8 @@ func createFixtures() []*fixtures.FixtureSet {
 				Columns:   []string{"id", "name"},
 			}),
 			Fixtures: []interface{}{
-				&fixtures.MysqlPlainFixtureValues{1, "testName1"},
-				&fixtures.MysqlPlainFixtureValues{2, "testName2"},
+				fixtures.MysqlPlainFixtureValues{1, "testName1"},
+				fixtures.MysqlPlainFixtureValues{2, "testName2"},
 			},
 		},
 		{

--- a/pkg/fixtures/loader_noop.go
+++ b/pkg/fixtures/loader_noop.go
@@ -7,13 +7,17 @@ import (
 	"github.com/applike/gosoline/pkg/mon"
 )
 
-func NewFixtureLoader(config cfg.Config, logger mon.Logger) FixtureLoader {
-	return &noopFixtureLoader{}
+type noopFixtureLoader struct {
+	logger mon.Logger
 }
 
-type noopFixtureLoader struct {
+func NewFixtureLoader(config cfg.Config, logger mon.Logger) FixtureLoader {
+	return &noopFixtureLoader{
+		logger: logger.WithChannel("fixture_loader"),
+	}
 }
 
 func (n noopFixtureLoader) Load(fixtureSets []*FixtureSet) error {
-	return nil // do nothing
+	n.logger.Info("fixtures loading disabled, to enable it use the 'fixtures' build tag")
+	return nil
 }

--- a/pkg/fixtures/writer_ddb_kvstore.go
+++ b/pkg/fixtures/writer_ddb_kvstore.go
@@ -2,12 +2,10 @@ package fixtures
 
 import (
 	"context"
-	"fmt"
 	"github.com/applike/gosoline/pkg/cfg"
 	"github.com/applike/gosoline/pkg/kvstore"
 	"github.com/applike/gosoline/pkg/mdl"
 	"github.com/applike/gosoline/pkg/mon"
-	"reflect"
 )
 
 type KvStoreFixture struct {
@@ -45,11 +43,7 @@ func NewDynamoDbKvStoreFixtureWriterWithInterfaces(logger mon.Logger, store kvst
 
 func (d *dynamoDbKvStoreFixtureWriter) Write(fs *FixtureSet) error {
 	for _, item := range fs.Fixtures {
-		kvItem, ok := item.(*KvStoreFixture)
-
-		if !ok {
-			return fmt.Errorf("invalid fixture type: %s", reflect.TypeOf(item))
-		}
+		kvItem := item.(*KvStoreFixture)
 
 		err := d.store.Put(context.Background(), kvItem.Key, kvItem.Value)
 

--- a/pkg/fixtures/writer_mysql_orm.go
+++ b/pkg/fixtures/writer_mysql_orm.go
@@ -2,11 +2,9 @@ package fixtures
 
 import (
 	"context"
-	"fmt"
 	"github.com/applike/gosoline/pkg/cfg"
 	"github.com/applike/gosoline/pkg/db-repo"
 	"github.com/applike/gosoline/pkg/mon"
-	"reflect"
 )
 
 type mysqlOrmFixtureWriter struct {
@@ -40,11 +38,7 @@ func (m *mysqlOrmFixtureWriter) Write(fs *FixtureSet) error {
 	ctx := context.Background()
 
 	for _, item := range fs.Fixtures {
-		model, ok := item.(db_repo.ModelBased)
-
-		if !ok {
-			return fmt.Errorf("invalid fixture type: %s", reflect.TypeOf(item))
-		}
+		model := item.(db_repo.ModelBased)
 
 		err := m.repo.Update(ctx, model)
 

--- a/pkg/fixtures/writer_mysql_plain.go
+++ b/pkg/fixtures/writer_mysql_plain.go
@@ -6,7 +6,6 @@ import (
 	"github.com/applike/gosoline/pkg/cfg"
 	"github.com/applike/gosoline/pkg/db"
 	"github.com/applike/gosoline/pkg/mon"
-	"reflect"
 )
 
 type MysqlPlainFixtureValues []interface{}
@@ -39,11 +38,7 @@ func NewMysqlPlainFixtureWriterWithInterfaces(logger mon.Logger, dbClient db.Cli
 
 func (m *mysqlPlainFixtureWriter) Write(fs *FixtureSet) error {
 	for _, item := range fs.Fixtures {
-		fixture, ok := item.(*MysqlPlainFixtureValues)
-
-		if !ok {
-			return fmt.Errorf("invalid fixture type: %s", reflect.TypeOf(item))
-		}
+		fixture := item.(MysqlPlainFixtureValues)
 
 		sql, args, err := m.buildSql(fixture)
 
@@ -71,11 +66,11 @@ func (m *mysqlPlainFixtureWriter) Write(fs *FixtureSet) error {
 	return nil
 }
 
-func (m *mysqlPlainFixtureWriter) buildSql(values *MysqlPlainFixtureValues) (string, []interface{}, error) {
+func (m *mysqlPlainFixtureWriter) buildSql(values MysqlPlainFixtureValues) (string, []interface{}, error) {
 	insertBuilder := squirrel.Replace(m.metaData.TableName).
 		PlaceholderFormat(squirrel.Question).
 		Columns(m.metaData.Columns...).
-		Values(*values...)
+		Values(values...)
 
 	return insertBuilder.ToSql()
 }

--- a/pkg/fixtures/writer_redis.go
+++ b/pkg/fixtures/writer_redis.go
@@ -5,7 +5,6 @@ import (
 	"github.com/applike/gosoline/pkg/cfg"
 	"github.com/applike/gosoline/pkg/mon"
 	"github.com/applike/gosoline/pkg/redis"
-	"reflect"
 	"time"
 )
 
@@ -57,11 +56,7 @@ func NewRedisFixtureWriterWithInterfaces(logger mon.Logger, client redis.Client,
 
 func (d *redisFixtureWriter) Write(fs *FixtureSet) error {
 	for _, item := range fs.Fixtures {
-		redisFixture, ok := item.(*RedisFixture)
-
-		if !ok {
-			return fmt.Errorf("invalid fixture type: %s", reflect.TypeOf(item))
-		}
+		redisFixture := item.(*RedisFixture)
 
 		handler, ok := redisHandlers[d.operation]
 

--- a/pkg/fixtures/writer_redis_kvstore.go
+++ b/pkg/fixtures/writer_redis_kvstore.go
@@ -2,12 +2,10 @@ package fixtures
 
 import (
 	"context"
-	"fmt"
 	"github.com/applike/gosoline/pkg/cfg"
 	"github.com/applike/gosoline/pkg/kvstore"
 	"github.com/applike/gosoline/pkg/mdl"
 	"github.com/applike/gosoline/pkg/mon"
-	"reflect"
 )
 
 type redisKvStoreFixtureWriter struct {
@@ -40,11 +38,7 @@ func NewRedisKvStoreFixtureWriterWithInterfaces(logger mon.Logger, store kvstore
 
 func (d *redisKvStoreFixtureWriter) Write(fs *FixtureSet) error {
 	for _, item := range fs.Fixtures {
-		kvItem, ok := item.(*KvStoreFixture)
-
-		if !ok {
-			return fmt.Errorf("invalid fixture type: %s", reflect.TypeOf(item))
-		}
+		kvItem := item.(*KvStoreFixture)
 
 		err := d.store.Put(context.Background(), kvItem.Key, kvItem.Value)
 

--- a/test/fixtures_mysql_test.go
+++ b/test/fixtures_mysql_test.go
@@ -85,8 +85,8 @@ func plainMysqlTestFixtures() []*fixtures.FixtureSet {
 				Columns:   []string{"id", "name"},
 			}),
 			Fixtures: []interface{}{
-				&fixtures.MysqlPlainFixtureValues{2, "testName2"},
-				&fixtures.MysqlPlainFixtureValues{2, "testName3"},
+				fixtures.MysqlPlainFixtureValues{2, "testName2"},
+				fixtures.MysqlPlainFixtureValues{2, "testName3"},
 			},
 		},
 	}


### PR DESCRIPTION
**Summary:**

- Cleanup unnecessary pointer to slice. See [use case for pointer to slices](https://medium.com/swlh/golang-tips-why-pointers-to-slices-are-useful-and-how-ignoring-them-can-lead-to-tricky-bugs-cac90f72e77b).
- Cleanup redundant type assertion check. The default behavior is panicking and producing a better error message.
- Add a log message to the noop fixture loader (useful when running tests).