### PR TITLE
stream: fix file output writing too much;

### DIFF
--- a/pkg/stream/output_file.go
+++ b/pkg/stream/output_file.go
@@ -33,6 +33,8 @@ func (o *fileOutput) Write(ctx context.Context, batch []*Message) error {
 	flags := os.O_CREATE | os.O_WRONLY
 	if o.settings.Append {
 		flags = flags | os.O_APPEND
+	} else {
+		flags = flags | os.O_TRUNC
 	}
 
 	file, err := os.OpenFile(o.settings.Filename, flags, 0644)


### PR DESCRIPTION
**Steps to reproduce:**

Write a unit test and write different values to the file output in a loop (500 times should be enough). 
At some point in the iteration, it will not completely truncate the contents of the file (it looks like it wrote too much).

This issue was causing some integration tests to flap (failing 1 every 20 runs).

**Solution:**

Add an explicit flag when opening the file to make sure it is truncated.