### PR TITLE
test: make docker expiration period configurable;

### DIFF
--- a/pkg/test/component_cloudwatch.go
+++ b/pkg/test/component_cloudwatch.go
@@ -49,6 +49,7 @@ func (c *cloudwatchComponent) Start() {
 		},
 		HealthCheck: localstackHealthCheck(c.settings.healthcheckMockSettings, componentCloudwatch),
 		PrintLogs:   c.settings.Debug,
+		ExpireAfter: c.settings.ExpireAfter,
 	})
 }
 

--- a/pkg/test/component_dynamodb.go
+++ b/pkg/test/component_dynamodb.go
@@ -45,7 +45,8 @@ func (d *dynamoDbComponent) Start() {
 
 			return err
 		},
-		PrintLogs: d.settings.Debug,
+		PrintLogs:   d.settings.Debug,
+		ExpireAfter: d.settings.ExpireAfter,
 	})
 }
 

--- a/pkg/test/component_elasticsearch.go
+++ b/pkg/test/component_elasticsearch.go
@@ -55,6 +55,7 @@ func (e *elasticsearchComponent) Start() {
 
 			return nil
 		},
-		PrintLogs: e.settings.Debug,
+		PrintLogs:   e.settings.Debug,
+		ExpireAfter: e.settings.ExpireAfter,
 	})
 }

--- a/pkg/test/component_kinesis.go
+++ b/pkg/test/component_kinesis.go
@@ -49,6 +49,7 @@ func (k *kinesisComponent) Start() {
 		},
 		HealthCheck: localstackHealthCheck(k.settings.healthcheckMockSettings, componentKinesis),
 		PrintLogs:   k.settings.Debug,
+		ExpireAfter: k.settings.ExpireAfter,
 	})
 }
 

--- a/pkg/test/component_mysql.go
+++ b/pkg/test/component_mysql.go
@@ -65,7 +65,8 @@ func (m *mysqlComponent) Start() {
 
 			return nil
 		},
-		PrintLogs: m.settings.Debug,
+		PrintLogs:   m.settings.Debug,
+		ExpireAfter: m.settings.ExpireAfter,
 	})
 }
 

--- a/pkg/test/component_redis.go
+++ b/pkg/test/component_redis.go
@@ -45,7 +45,8 @@ func (r *redisComponent) Start() {
 
 			return err
 		},
-		PrintLogs: r.settings.Debug,
+		PrintLogs:   r.settings.Debug,
+		ExpireAfter: r.settings.ExpireAfter,
 	})
 }
 

--- a/pkg/test/component_sns_sqs.go
+++ b/pkg/test/component_sns_sqs.go
@@ -64,6 +64,7 @@ func (s *snsSqsComponent) Start() {
 		},
 		HealthCheck: localstackHealthCheck(s.settings.healthcheckMockSettings, componentSns, componentSqs),
 		PrintLogs:   s.settings.Debug,
+		ExpireAfter: s.settings.ExpireAfter,
 	})
 }
 

--- a/pkg/test/component_wiremock.go
+++ b/pkg/test/component_wiremock.go
@@ -48,6 +48,8 @@ func (w *wiremockComponent) Start() {
 
 			return err
 		},
+		PrintLogs:   w.settings.Debug,
+		ExpireAfter: w.settings.ExpireAfter,
 	})
 
 	jsonStr, err := ioutil.ReadFile(w.settings.Mocks)

--- a/pkg/test/docker.go
+++ b/pkg/test/docker.go
@@ -94,7 +94,9 @@ func (d *dockerRunner) Run(name string, config containerConfig) {
 		panic(fmt.Errorf("could not expire %s container: %w", containerName, err))
 	}
 
-	logger.Infof("container will expire after %s", config.ExpireAfter)
+	logger.WithFields(map[string]interface{}{
+		"expire_after": config.ExpireAfter,
+	}).Info("set container expiry")
 
 	err = d.pool.Retry(config.HealthCheck)
 

--- a/pkg/test/test.go
+++ b/pkg/test/test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/applike/gosoline/pkg/cfg"
 	"github.com/applike/gosoline/pkg/mon"
 	"sync"
+	"time"
 )
 
 type mockComponent interface {
@@ -13,9 +14,10 @@ type mockComponent interface {
 }
 
 type mockSettings struct {
-	Debug     bool   `cfg:"debug"`
-	Component string `cfg:"component"`
-	Host      string `cfg:"host"`
+	Debug       bool          `cfg:"debug"`
+	Component   string        `cfg:"component"`
+	Host        string        `cfg:"host"`
+	ExpireAfter time.Duration `cfg:"expire_after" default:"60s"`
 }
 
 type Mocks struct {

--- a/test/test_configs/config.mysql.test.yml
+++ b/test/test_configs/config.mysql.test.yml
@@ -6,4 +6,4 @@ mocks:
     debug: false
     dbName: myDbName
     version: "8"
-    expire_after: 1m30s
+    expire_after: 1m1s

--- a/test/test_configs/config.mysql.test.yml
+++ b/test/test_configs/config.mysql.test.yml
@@ -6,3 +6,4 @@ mocks:
     debug: false
     dbName: myDbName
     version: "8"
+    expire_after: 1m30s


### PR DESCRIPTION
**Summary:**

* In some cases, the tests are not cleaning up the docker containers they started. 
* This causes problems when trying to run the tests again (locally or on a CI environment).
* Set the default expiration period to 1 minute (was previously 1 hour)
* Make it configurable so that it can be adapted if needed e.g. for long-running tests for example.
* Add more logging to investigate failing tests due to docker problems in the CI.

<img width="906" alt="image" src="https://user-images.githubusercontent.com/772593/76967656-feeff080-6927-11ea-956a-82ef16e08d9f.png">
