### PR TITLE
cloud: improved support to detected canceled context errors;

### DIFF
--- a/pkg/cloud/error.go
+++ b/pkg/cloud/error.go
@@ -1,9 +1,11 @@
 package cloud
 
 import (
+	"context"
 	"errors"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/hashicorp/go-multierror"
 	"io"
 	"net"
 	"net/url"
@@ -12,17 +14,36 @@ import (
 )
 
 func IsAwsError(err error, awsCode string) bool {
-	if err == nil {
-		return false
+	var aerr awserr.Error
+	if errors.As(err, &aerr) {
+		return aerr.Code() == awsCode
 	}
 
-	aerr, ok := err.(awserr.Error)
-
-	return ok && aerr.Code() == awsCode
+	return false
 }
 
+// Check if the given error was (only) caused by a canceled context - if there is any other error contained in it, we
+// return false. Thus, if IsRequestCanceled returns true, you can (and should) ignore the error and stop processing instead.
 func IsRequestCanceled(err error) bool {
-	return IsAwsError(err, request.CanceledErrorCode)
+	if errors.Is(err, context.Canceled) || errors.Is(err, RequestCanceledError) || IsAwsError(err, request.CanceledErrorCode) {
+		return true
+	}
+
+	// some functions (like a batched Write) return a multierror which does not properly unwrap
+	// so we check if all these requests failed. If there is any other error, we return false to
+	// trigger normal error handling
+	var multiErr *multierror.Error
+	if errors.As(err, &multiErr) && multiErr != nil {
+		for _, err := range multiErr.Errors {
+			if !IsRequestCanceled(err) {
+				return false
+			}
+		}
+
+		return len(multiErr.Errors) > 0
+	}
+
+	return false
 }
 
 func IsUsedClosedConnectionError(err error) bool {

--- a/pkg/cloud/request.go
+++ b/pkg/cloud/request.go
@@ -2,7 +2,6 @@ package cloud
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"github.com/applike/gosoline/pkg/mon"
 	"github.com/aws/aws-sdk-go/aws/request"
@@ -224,7 +223,7 @@ func (e *BackoffExecutor) Execute(ctx context.Context, f RequestFunction) (inter
 			return nil
 		}
 
-		if IsRequestCanceled(err) || errors.Is(err, RequestCanceledError) {
+		if IsRequestCanceled(err) {
 			return backoff.Permanent(err)
 		}
 

--- a/pkg/currency/service.go
+++ b/pkg/currency/service.go
@@ -11,10 +11,10 @@ import (
 
 //go:generate mockery -name Service
 type Service interface {
-	HasCurrency(context.Context, string) (bool, error)
-	ToEur(context.Context, float64, string) (float64, error)
-	ToUsd(context.Context, float64, string) (float64, error)
-	ToCurrency(context.Context, string, float64, string) (float64, error)
+	HasCurrency(ctx context.Context, currency string) (bool, error)
+	ToEur(ctx context.Context, value float64, from string) (float64, error)
+	ToUsd(ctx context.Context, value float64, from string) (float64, error)
+	ToCurrency(ctx context.Context, to string, value float64, from string) (float64, error)
 }
 
 type CurrencyService struct {

--- a/pkg/sqs/queue.go
+++ b/pkg/sqs/queue.go
@@ -152,7 +152,7 @@ func (q *queue) SendBatch(ctx context.Context, messages []*Message) error {
 		return q.client.SendMessageBatchRequest(input)
 	})
 
-	if err != nil {
+	if err != nil && !cloud.IsRequestCanceled(err) {
 		q.logger.WithContext(ctx).Errorf(err, "could not send batch to sqs queue %s", q.properties.Name)
 	}
 


### PR DESCRIPTION
Sadly in the current state it is quite hard to see whether an error was
the result of a context getting canceled. For now we moved all the logic
to detect this into a single function handling AWS errors, our own
canceled context error as well as multierrors containing canceled
contexts. A user of the library can thus easily use our function to
check whether the error could be handled in any way besides stopping
processing as fast as possible.