### PR TITLE
test: docker containers not being purged due to race condition;

### DIFF
--- a/pkg/test/test.go
+++ b/pkg/test/test.go
@@ -95,7 +95,7 @@ func (m *Mocks) runComponent(component mockComponent) {
 }
 
 func (m *Mocks) Shutdown() {
-	m.dockerRunner.PurgeAllResources()
+	m.dockerRunner.RemoveAllContainers()
 }
 
 func Boot(configFilenames ...string) *Mocks {


### PR DESCRIPTION
When starting 2 test components concurrently, there's an issue with the cleanup.

* Starting 1 succeeds.
* Starting 2 fails. We panic.
* Container 1 was not yet added to the cleanup list.
* Shutdown/cleanup is called because it was deferred in the test.
* Container 1 was not stopped and maybe not even marked for expiration, so it will hang there forever.

