### PR TITLE
test: provide hostname mapping;

### DIFF
--- a/pkg/test/component_cloudwatch.go
+++ b/pkg/test/component_cloudwatch.go
@@ -51,6 +51,10 @@ func (c *cloudwatchComponent) Start() error {
 			"4582/tcp": &c.settings.Port,
 			"8080/tcp": &c.settings.Healthcheck.Port,
 		},
+		HostMapping: hostMapping{
+			dialPort: &c.settings.Port,
+			setHost:  &c.settings.Host,
+		},
 		HealthCheck: localstackHealthCheck(c.settings.healthcheckMockSettings, componentCloudwatch),
 		PrintLogs:   c.settings.Debug,
 		ExpireAfter: c.settings.ExpireAfter,

--- a/pkg/test/component_dynamodb.go
+++ b/pkg/test/component_dynamodb.go
@@ -41,6 +41,10 @@ func (d *dynamoDbComponent) Start() error {
 		PortMappings: portMapping{
 			"8000/tcp": &d.settings.Port,
 		},
+		HostMapping: hostMapping{
+			dialPort: &d.settings.Port,
+			setHost:  &d.settings.Host,
+		},
 		HealthCheck: func() error {
 			client := d.provideDynamoDbClient()
 

--- a/pkg/test/component_elasticsearch.go
+++ b/pkg/test/component_elasticsearch.go
@@ -48,6 +48,10 @@ func (e *elasticsearchComponent) Start() error {
 		PortMappings: portMapping{
 			"9200/tcp": &e.settings.Port,
 		},
+		HostMapping: hostMapping{
+			dialPort: &e.settings.Port,
+			setHost:  &e.settings.Host,
+		},
 		HealthCheck: func() error {
 			resp, err := http.Get(fmt.Sprintf("http://%s:%d/_cluster/health", e.settings.Host, e.settings.Port))
 

--- a/pkg/test/component_kinesis.go
+++ b/pkg/test/component_kinesis.go
@@ -51,6 +51,10 @@ func (k *kinesisComponent) Start() error {
 			"4568/tcp": &k.settings.Port,
 			"8080/tcp": &k.settings.Healthcheck.Port,
 		},
+		HostMapping: hostMapping{
+			dialPort: &k.settings.Port,
+			setHost:  &k.settings.Host,
+		},
 		HealthCheck: localstackHealthCheck(k.settings.healthcheckMockSettings, componentKinesis),
 		PrintLogs:   k.settings.Debug,
 		ExpireAfter: k.settings.ExpireAfter,

--- a/pkg/test/component_mysql.go
+++ b/pkg/test/component_mysql.go
@@ -53,6 +53,10 @@ func (m *mysqlComponent) Start() error {
 		PortMappings: portMapping{
 			"3306/tcp": &m.settings.Port,
 		},
+		HostMapping: hostMapping{
+			dialPort: &m.settings.Port,
+			setHost:  &m.settings.Host,
+		},
 		HealthCheck: func() error {
 			client, err := m.provideMysqlClient()
 

--- a/pkg/test/component_redis.go
+++ b/pkg/test/component_redis.go
@@ -41,6 +41,10 @@ func (r *redisComponent) Start() error {
 		PortMappings: portMapping{
 			"6379/tcp": &r.settings.Port,
 		},
+		HostMapping: hostMapping{
+			dialPort: &r.settings.Port,
+			setHost:  &r.settings.Host,
+		},
 		HealthCheck: func() error {
 			client := r.provideRedisClient()
 			_, err := client.Ping().Result()

--- a/pkg/test/component_sns_sqs.go
+++ b/pkg/test/component_sns_sqs.go
@@ -67,6 +67,10 @@ func (s *snsSqsComponent) Start() error {
 			"4576/tcp": &s.settings.SqsPort,
 			"8080/tcp": &s.settings.Healthcheck.Port,
 		},
+		HostMapping: hostMapping{
+			dialPort: &s.settings.SnsPort,
+			setHost:  &s.settings.Host,
+		},
 		HealthCheck: localstackHealthCheck(s.settings.healthcheckMockSettings, componentSns, componentSqs),
 		PrintLogs:   s.settings.Debug,
 		ExpireAfter: s.settings.ExpireAfter,

--- a/pkg/test/component_wiremock.go
+++ b/pkg/test/component_wiremock.go
@@ -44,6 +44,10 @@ func (w *wiremockComponent) Start() error {
 		PortMappings: portMapping{
 			"8080/tcp": &w.settings.Port,
 		},
+		HostMapping: hostMapping{
+			dialPort: &w.settings.Port,
+			setHost:  &w.settings.Host,
+		},
 		HealthCheck: func() error {
 			url := w.getUrl()
 

--- a/pkg/test/mocks_hosts.go
+++ b/pkg/test/mocks_hosts.go
@@ -1,0 +1,46 @@
+package test
+
+func (m *Mocks) ProvideSqsHost(name string) string {
+	component := m.components[name].(*snsSqsComponent)
+	return component.settings.Host
+}
+
+func (m *Mocks) ProvideSnsHost(name string) string {
+	component := m.components[name].(*snsSqsComponent)
+	return component.settings.Host
+}
+
+func (m *Mocks) ProvideCloudwatchHost(name string) string {
+	component := m.components[name].(*cloudwatchComponent)
+	return component.settings.Host
+}
+
+func (m *Mocks) ProvideDynamoDbHost(name string) string {
+	component := m.components[name].(*dynamoDbComponent)
+	return component.settings.Host
+}
+
+func (m *Mocks) ProvideElasticsearchHost(name string) string {
+	component := m.components[name].(*elasticsearchComponent)
+	return component.settings.Host
+}
+
+func (m *Mocks) ProvideKinesisHost(name string) string {
+	component := m.components[name].(*kinesisComponent)
+	return component.settings.Host
+}
+
+func (m *Mocks) ProvideMysqlHost(name string) string {
+	component := m.components[name].(*mysqlComponent)
+	return component.settings.Host
+}
+
+func (m *Mocks) ProvideRedisHost(name string) string {
+	component := m.components[name].(*redisComponent)
+	return component.settings.Host
+}
+
+func (m *Mocks) ProvideWiremockHost(name string) string {
+	component := m.components[name].(*wiremockComponent)
+	return component.settings.Host
+}

--- a/pkg/test/test.go
+++ b/pkg/test/test.go
@@ -15,9 +15,9 @@ type mockComponent interface {
 }
 
 type mockSettings struct {
+	Host        string
 	Debug       bool          `cfg:"debug"`
 	Component   string        `cfg:"component"`
-	Host        string        `cfg:"host"`
 	ExpireAfter time.Duration `cfg:"expire_after" default:"60s"`
 }
 

--- a/test/component_wiremock_test.go
+++ b/test/component_wiremock_test.go
@@ -26,8 +26,9 @@ func Test_wiremock(t *testing.T) {
 		return
 	}
 
+	host := mocks.ProvideWiremockHost("wiremock")
 	port := mocks.ProvideWiremockPort("wiremock")
-	url := fmt.Sprintf("http://%s:%d%s", "172.17.0.1", port, "/__admin")
+	url := fmt.Sprintf("http://%s:%d%s", host, port, "/__admin")
 	resp, err := http.Get(url)
 
 	assert.NoError(t, err)

--- a/test/es/config-v6.test.yml
+++ b/test/es/config-v6.test.yml
@@ -2,4 +2,3 @@ mocks:
   metrics_v6:
     component: elasticsearch
     version: 6.8.1
-    host: 172.17.0.1

--- a/test/es/config-v7.test.yml
+++ b/test/es/config-v7.test.yml
@@ -2,4 +2,3 @@ mocks:
   metrics_v7:
     component: elasticsearch
     version: 7.1.1
-    host: 172.17.0.1

--- a/test/fixtures_dynamodb_test.go
+++ b/test/fixtures_dynamodb_test.go
@@ -1,4 +1,4 @@
-//+build integration
+//+build integration,fixtures
 
 package test_test
 
@@ -52,9 +52,7 @@ func (s FixturesDynamoDbSuite) TestDynamoDb() {
 	err := config.Option(
 		cfg.WithConfigFile("test_configs/config.dynamodb.test.yml", "yml"),
 		cfg.WithConfigFile("test_configs/config.fixtures_dynamodb.test.yml", "yml"),
-		cfg.WithConfigMap(map[string]interface{}{
-			"aws_dynamoDb_endpoint": fmt.Sprintf("%s:%d", "http://172.17.0.1", s.mocks.ProvideDynamoDbPort("dynamodb")),
-		}),
+		cfg.WithConfigMap(s.dynamoDbConfig()),
 	)
 
 	assert.NoError(s.T(), err)
@@ -100,9 +98,7 @@ func (s FixturesDynamoDbSuite) TestDynamoDbWithPurge() {
 	err := config.Option(
 		cfg.WithConfigFile("test_configs/config.dynamodb.test.yml", "yml"),
 		cfg.WithConfigFile("test_configs/config.fixtures_dynamodb.test.yml", "yml"),
-		cfg.WithConfigMap(map[string]interface{}{
-			"aws_dynamoDb_endpoint": fmt.Sprintf("%s:%d", "http://172.17.0.1", s.mocks.ProvideDynamoDbPort("dynamodb")),
-		}),
+		cfg.WithConfigMap(s.dynamoDbConfig()),
 	)
 
 	assert.NoError(s.T(), err)
@@ -179,9 +175,7 @@ func (s FixturesDynamoDbSuite) TestDynamoDbKvStore() {
 	err := config.Option(
 		cfg.WithConfigFile("test_configs/config.dynamodb.test.yml", "yml"),
 		cfg.WithConfigFile("test_configs/config.fixtures_dynamodb.test.yml", "yml"),
-		cfg.WithConfigMap(map[string]interface{}{
-			"aws_dynamoDb_endpoint": fmt.Sprintf("%s:%d", "http://172.17.0.1", s.mocks.ProvideDynamoDbPort("dynamodb")),
-		}),
+		cfg.WithConfigMap(s.dynamoDbConfig()),
 	)
 
 	assert.NoError(s.T(), err)
@@ -208,12 +202,11 @@ func (s FixturesDynamoDbSuite) TestDynamoDbKvStore() {
 
 func (s FixturesDynamoDbSuite) TestDynamoDbKvStoreWithPurge() {
 	config := cfg.New()
+
 	err := config.Option(
 		cfg.WithConfigFile("test_configs/config.dynamodb.test.yml", "yml"),
 		cfg.WithConfigFile("test_configs/config.fixtures_dynamodb.test.yml", "yml"),
-		cfg.WithConfigMap(map[string]interface{}{
-			"aws_dynamoDb_endpoint": fmt.Sprintf("%s:%d", "http://172.17.0.1", s.mocks.ProvideDynamoDbPort("dynamodb")),
-		}),
+		cfg.WithConfigMap(s.dynamoDbConfig()),
 	)
 
 	assert.NoError(s.T(), err)
@@ -375,5 +368,12 @@ func dynamoDbEnabledPurgeFixtures() []*fixtures.FixtureSet {
 				&DynamoDbTestModel{Name: "Bash", Age: 10},
 			},
 		},
+	}
+}
+
+func (s FixturesDynamoDbSuite) dynamoDbConfig() map[string]interface{} {
+	dynamoDbEndpoint := fmt.Sprintf("http://%s:%d", s.mocks.ProvideDynamoDbHost("dynamodb"), s.mocks.ProvideDynamoDbPort("dynamodb"))
+	return map[string]interface{}{
+		"aws_dynamoDb_endpoint": dynamoDbEndpoint,
 	}
 }

--- a/test/fixtures_mysql_test.go
+++ b/test/fixtures_mysql_test.go
@@ -1,4 +1,4 @@
-//+build integration
+//+build integration,fixtures
 
 package test_test
 
@@ -56,7 +56,8 @@ func (s *FixturesMysqlSuite) SetupSuite() {
 		cfg.WithConfigFile("test_configs/config.mysql.test.yml", "yml"),
 		cfg.WithConfigFile("test_configs/config.fixtures_mysql.test.yml", "yml"),
 		cfg.WithConfigMap(map[string]interface{}{
-			"db_port": s.mocks.ProvideMysqlPort("mysql"),
+			"db_port":     s.mocks.ProvideMysqlPort("mysql"),
+			"db_hostname": s.mocks.ProvideMysqlHost("mysql"),
 		}),
 	)
 

--- a/test/fixtures_redis_test.go
+++ b/test/fixtures_redis_test.go
@@ -1,4 +1,4 @@
-//+build integration
+//+build integration,fixtures
 
 package test_test
 
@@ -54,12 +54,10 @@ func TestFixturesRedisSuite(t *testing.T) {
 
 func (s FixturesRedisSuite) TestRedis() {
 	config := cfg.New()
-	config.Option(
+	_ = config.Option(
 		cfg.WithConfigFile("test_configs/config.redis.test.yml", "yml"),
 		cfg.WithConfigFile("test_configs/config.fixtures_redis.test.yml", "yml"),
-		cfg.WithConfigMap(map[string]interface{}{
-			"redis_default_addr": fmt.Sprintf("%s:%d", "172.17.0.1", s.mocks.ProvideRedisPort("redis")),
-		}),
+		cfg.WithConfigMap(s.redisConfig()),
 	)
 
 	// ensure clean start
@@ -92,12 +90,10 @@ func (s FixturesRedisSuite) TestRedis() {
 
 func (s FixturesRedisSuite) TestRedisWithPurge() {
 	config := cfg.New()
-	config.Option(
+	_ = config.Option(
 		cfg.WithConfigFile("test_configs/config.redis.test.yml", "yml"),
 		cfg.WithConfigFile("test_configs/config.fixtures_redis.test.yml", "yml"),
-		cfg.WithConfigMap(map[string]interface{}{
-			"redis_default_addr": fmt.Sprintf("%s:%d", "172.17.0.1", s.mocks.ProvideRedisPort("redis")),
-		}),
+		cfg.WithConfigMap(s.redisConfig()),
 	)
 
 	// ensure clean start
@@ -140,12 +136,10 @@ func (s FixturesRedisSuite) TestRedisWithPurge() {
 
 func (s FixturesRedisSuite) TestRedisKvStore() {
 	config := cfg.New()
-	config.Option(
+	_ = config.Option(
 		cfg.WithConfigFile("test_configs/config.redis.test.yml", "yml"),
 		cfg.WithConfigFile("test_configs/config.fixtures_redis.test.yml", "yml"),
-		cfg.WithConfigMap(map[string]interface{}{
-			"redis_kvstore_testModel_addr": fmt.Sprintf("%s:%d", "172.17.0.1", s.mocks.ProvideRedisPort("redis")),
-		}),
+		cfg.WithConfigMap(s.redisKvStoreConfig()),
 	)
 
 	// ensure clean start
@@ -166,12 +160,10 @@ func (s FixturesRedisSuite) TestRedisKvStore() {
 
 func (s FixturesRedisSuite) TestRedisKvStoreWithPurge() {
 	config := cfg.New()
-	config.Option(
+	_ = config.Option(
 		cfg.WithConfigFile("test_configs/config.redis.test.yml", "yml"),
 		cfg.WithConfigFile("test_configs/config.fixtures_redis.test.yml", "yml"),
-		cfg.WithConfigMap(map[string]interface{}{
-			"redis_kvstore_testModel_addr": fmt.Sprintf("%s:%d", "172.17.0.1", s.mocks.ProvideRedisPort("redis")),
-		}),
+		cfg.WithConfigMap(s.redisKvStoreConfig()),
 	)
 
 	// ensure clean start
@@ -295,5 +287,19 @@ func redisKvstoreEnabledPurgeFixtures() []*fixtures.FixtureSet {
 				},
 			},
 		},
+	}
+}
+
+func (s FixturesRedisSuite) redisConfig() map[string]interface{} {
+	redisAddress := fmt.Sprintf("%s:%d", s.mocks.ProvideRedisHost("redis"), s.mocks.ProvideRedisPort("redis"))
+	return map[string]interface{}{
+		"redis_default_addr": redisAddress,
+	}
+}
+
+func (s FixturesRedisSuite) redisKvStoreConfig() map[string]interface{} {
+	redisAddress := fmt.Sprintf("%s:%d", s.mocks.ProvideRedisHost("redis"), s.mocks.ProvideRedisPort("redis"))
+	return map[string]interface{}{
+		"redis_kvstore_testModel_addr": redisAddress,
 	}
 }

--- a/test/test_configs/config.cloudwatch.test.yml
+++ b/test/test_configs/config.cloudwatch.test.yml
@@ -1,5 +1,4 @@
 mocks:
   cloudwatch:
     component: cloudwatch
-    host: 172.17.0.1
     debug: true

--- a/test/test_configs/config.dynamodb.test.yml
+++ b/test/test_configs/config.dynamodb.test.yml
@@ -1,5 +1,4 @@
 mocks:
   dynamodb:
     component: dynamodb
-    host: 172.17.0.1
     debug: true

--- a/test/test_configs/config.elasticsearch.test.yml
+++ b/test/test_configs/config.elasticsearch.test.yml
@@ -1,6 +1,5 @@
 mocks:
   elasticsearch:
     component: elasticsearch
-    host: 172.17.0.1
     version: 6.0.0
     debug: false

--- a/test/test_configs/config.fixtures_mysql.test.yml
+++ b/test/test_configs/config.fixtures_mysql.test.yml
@@ -4,7 +4,6 @@ app_family: integration-test
 app_name: fixture-loader
 
 db_drivername: "mysql"
-db_hostname: "172.17.0.1"
 db_database: "myDbName"
 db_username: "root"
 db_password: "gosoline"

--- a/test/test_configs/config.kinesis.test.yml
+++ b/test/test_configs/config.kinesis.test.yml
@@ -1,5 +1,4 @@
 mocks:
   kinesis:
     component: kinesis
-    host: 172.17.0.1
     debug: false

--- a/test/test_configs/config.mysql.test.yml
+++ b/test/test_configs/config.mysql.test.yml
@@ -1,7 +1,6 @@
 mocks:
   mysql:
     component: mysql
-    host: 172.17.0.1
     debug: false
     dbName: myDbName
     version: "8"

--- a/test/test_configs/config.redis.test.yml
+++ b/test/test_configs/config.redis.test.yml
@@ -1,5 +1,4 @@
 mocks:
   redis:
     component: redis
-    host: 172.17.0.1
     debug: false

--- a/test/test_configs/config.sns_sqs.test.yml
+++ b/test/test_configs/config.sns_sqs.test.yml
@@ -2,4 +2,3 @@ mocks:
   sns_sqs:
     debug: false
     component: sns_sqs
-    host: 172.17.0.1

--- a/test/test_configs/config.wiremock.test.yml
+++ b/test/test_configs/config.wiremock.test.yml
@@ -1,5 +1,4 @@
 mocks:
   wiremock:
     component: wiremock
-    host: 172.17.0.1
     mocks: test_fixtures/wiremock_fixtures.json


### PR DESCRIPTION
Closes #225 

In an ideal world, we would always use localhost for Docker-based tests. 

But this is not the case:

- In CI we use docker-in-docker (dind), so we cannot use localhost. We can use either the container ip or the gateway ip for the Bridge network.
- For Mac users this approach does not work. They should use localhost or create a network alias to support the gateway ip adress.

To simplify the usage of the tests package we take care of it, check which address is reacheable and provide the host via `mock.ProvideXxxPort()` methods.