### PR TITLE
db_repo: change history

### DIFF
--- a/pkg/db-repo/change_history.go
+++ b/pkg/db-repo/change_history.go
@@ -1,0 +1,41 @@
+package db_repo
+
+import (
+	"github.com/applike/gosoline/pkg/cfg"
+	"github.com/applike/gosoline/pkg/mon"
+	"time"
+)
+
+type ChangeHistoryModelBased interface {
+	GetHistoryAction() string
+	GetHistoryActionAt() time.Time
+	GetHistoryRevision() int
+}
+
+type ChangeHistoryModel struct {
+	ChangeHistoryAction   string    `sql:"type: VARCHAR(8) NOT NULL DEFAULT 'insert'"`
+	ChangeHistoryActionAt time.Time `gorm:"default:CURRENT_TIMESTAMP"`
+	ChangeHistoryRevision int       `gorm:"primary_key"`
+}
+
+func (c *ChangeHistoryModel) GetHistoryAction() string {
+	return c.ChangeHistoryAction
+}
+
+func (c *ChangeHistoryModel) GetHistoryActionAt() time.Time {
+	return c.ChangeHistoryActionAt
+}
+
+func (c *ChangeHistoryModel) GetHistoryRevision() int {
+	return c.ChangeHistoryRevision
+}
+
+func MigrateChangeHistory(config cfg.Config, logger mon.Logger, models ...ModelBased) {
+	for _, model := range models {
+		manager := newChangeHistoryManager(config, logger, model)
+		err := manager.runMigration()
+		if err != nil {
+			panic(err)
+		}
+	}
+}

--- a/pkg/db-repo/change_history_manager.go
+++ b/pkg/db-repo/change_history_manager.go
@@ -1,0 +1,232 @@
+package db_repo
+
+import (
+	"fmt"
+	"github.com/applike/gosoline/pkg/cfg"
+	"github.com/applike/gosoline/pkg/mon"
+	"github.com/jinzhu/gorm"
+	"reflect"
+	"strings"
+)
+
+type changeHistoryManagerSettings struct {
+	ChangeAuthorField string `cfg:"change_author_column"`
+	TableSuffix       string `cfg:"table_suffix" default:"history"`
+}
+
+type changeHistoryManager struct {
+	orm           *gorm.DB
+	logger        mon.Logger
+	settings      *changeHistoryManagerSettings
+	model         ModelBased
+	originalTable *tableMetadata
+	historyTable  *tableMetadata
+	statements    []string
+}
+
+func newChangeHistoryManager(config cfg.Config, logger mon.Logger, model ModelBased) *changeHistoryManager {
+	orm := NewOrm(config, logger)
+
+	settings := &changeHistoryManagerSettings{}
+	config.UnmarshalKey("change_history", settings)
+
+	return newChangeHistoryManagerWithInterfaces(logger, orm, model, settings)
+}
+
+func newChangeHistoryManagerWithInterfaces(logger mon.Logger, orm *gorm.DB, model ModelBased, settings *changeHistoryManagerSettings) *changeHistoryManager {
+	statements := make([]string, 0)
+
+	logger = logger.WithChannel("change_history_manager").WithFields(mon.Fields{
+		"model": reflect.TypeOf(model).Elem().Name(),
+	})
+
+	return &changeHistoryManager{
+		logger:     logger,
+		orm:        orm,
+		model:      model,
+		statements: statements,
+		settings:   settings,
+	}
+}
+
+func (c *changeHistoryManager) runMigration() error {
+	c.buildOriginalTableMetadata()
+	c.buildHistoryTableMetadata()
+
+	if !c.historyTable.exists {
+		c.createHistoryTable()
+		c.dropHistoryTriggers()
+		c.createHistoryTriggers()
+		c.logger.Info("creating change history setup")
+		return c.execute()
+	}
+
+	updated := c.updateHistoryTable()
+	if updated {
+		c.dropHistoryTriggers()
+		c.createHistoryTriggers()
+		c.logger.Info("updating change history setup")
+		return c.execute()
+	}
+
+	c.logger.Info("change history setup was already up to date")
+
+	return nil
+}
+
+func (c *changeHistoryManager) buildOriginalTableMetadata() {
+	scope := c.orm.NewScope(c.model)
+	fields := scope.GetModelStruct().StructFields
+	tableName := scope.TableName()
+
+	c.originalTable = newTableMetadata(scope, tableName, fields)
+}
+
+func (c *changeHistoryManager) buildHistoryTableMetadata() {
+	historyScope := c.orm.NewScope(ChangeHistoryModel{})
+	tableName := fmt.Sprintf("%s_%s", c.originalTable.tableName, c.settings.TableSuffix)
+	modelFields := c.orm.NewScope(c.model).GetModelStruct().StructFields
+	fields := append(historyScope.GetModelStruct().StructFields, modelFields...)
+
+	c.historyTable = newTableMetadata(historyScope, tableName, fields)
+}
+
+func (c *changeHistoryManager) createHistoryTable() {
+	c.appendStatement(fmt.Sprintf("CREATE TABLE %v (%v, PRIMARY KEY (%v))",
+		c.historyTable.tableNameQuoted,
+		strings.Join(c.historyTable.columnDefinitions(), ","),
+		strings.Join(c.historyTable.primaryKeyNamesQuoted(), ","),
+	))
+}
+
+func (c *changeHistoryManager) appendStatement(statement string) {
+	c.statements = append(c.statements, statement)
+}
+
+func (c *changeHistoryManager) dropHistoryTriggers() {
+	triggers := []string{
+		c.originalTable.tableName + "_ai",
+		c.originalTable.tableName + "_au",
+		c.originalTable.tableName + "_bd",
+		c.historyTable.tableName + "_revai",
+	}
+
+	for _, trigger := range triggers {
+		c.appendStatement(fmt.Sprintf(`DROP TRIGGER IF EXISTS %s`, trigger))
+	}
+}
+
+func (c *changeHistoryManager) createHistoryTriggers() {
+	const NewRecord = "NEW"
+	const OldRecord = "OLD"
+
+	c.appendStatement(fmt.Sprintf(`CREATE TRIGGER %s_ai AFTER INSERT ON %s FOR EACH ROW %s WHERE %s`,
+		c.originalTable.tableName,
+		c.originalTable.tableNameQuoted,
+		c.insertHistoryEntry("insert", true),
+		c.primaryKeysMatchCondition(NewRecord),
+	))
+
+	c.appendStatement(fmt.Sprintf(`CREATE TRIGGER %s_au AFTER UPDATE ON %s FOR EACH ROW %s WHERE %s AND (%s)`,
+		c.originalTable.tableName,
+		c.originalTable.tableNameQuoted,
+		c.insertHistoryEntry("update", true),
+		c.primaryKeysMatchCondition(NewRecord),
+		c.rowUpdatedCondition(),
+	))
+
+	c.appendStatement(fmt.Sprintf(`CREATE TRIGGER %s_bd BEFORE DELETE ON %s FOR EACH ROW %s WHERE %s`,
+		c.originalTable.tableName,
+		c.originalTable.tableNameQuoted,
+		c.insertHistoryEntry("delete", false),
+		c.primaryKeysMatchCondition(OldRecord),
+	))
+
+	c.appendStatement(fmt.Sprintf(`CREATE TRIGGER %s_revai BEFORE INSERT ON %s FOR EACH ROW %s`,
+		c.historyTable.tableName,
+		c.historyTable.tableNameQuoted,
+		c.incrementRevision(),
+	))
+}
+
+func (c *changeHistoryManager) insertHistoryEntry(action string, includeAuthorEmail bool) string {
+	columnNames := c.originalTable.columnNamesQuoted()
+	if !includeAuthorEmail {
+		columnNames = c.originalTable.columnNamesQuotedExcludingValue(c.settings.ChangeAuthorField)
+	}
+
+	columns := strings.Join(columnNames, ",")
+	values := "d." + strings.Join(columnNames, ", d.")
+
+	return fmt.Sprintf(`
+		INSERT INTO %s (change_history_action,change_history_revision,change_history_action_at,%s) 
+			SELECT '%s', NULL, NOW(), %s 
+			FROM %s AS d`,
+		c.historyTable.tableNameQuoted,
+		columns,
+		action,
+		values,
+		c.originalTable.tableNameQuoted)
+}
+
+func (c *changeHistoryManager) incrementRevision() string {
+	return fmt.Sprintf(`
+		BEGIN 
+			SET NEW.change_history_revision = (SELECT IFNULL(MAX(d.change_history_revision), 0) + 1 FROM %s as d WHERE %s); 
+		END`,
+		c.historyTable.tableNameQuoted,
+		c.primaryKeysMatchCondition("NEW"),
+	)
+}
+
+func (c *changeHistoryManager) primaryKeysMatchCondition(record string) string {
+	var conditions []string
+	for _, columnName := range c.originalTable.primaryKeyNamesQuoted() {
+		condition := fmt.Sprintf("d.%s = %s.%s", columnName, record, columnName)
+		conditions = append(conditions, condition)
+	}
+	return strings.Join(conditions, " AND ")
+}
+
+func (c *changeHistoryManager) rowUpdatedCondition() string {
+	columnNames := c.originalTable.columnNamesQuotedExcludingValue(c.settings.ChangeAuthorField, ColumnUpdatedAt)
+	var conditions []string
+	for _, columnName := range columnNames {
+		condition := fmt.Sprintf("OLD.%s != NEW.%s", columnName, columnName)
+		conditions = append(conditions, condition)
+	}
+	return strings.Join(conditions, " OR ")
+}
+
+func (c *changeHistoryManager) updateHistoryTable() bool {
+	for _, column := range c.historyTable.columns {
+		if column.exists {
+			continue
+		}
+
+		c.appendStatement(fmt.Sprintf("ALTER TABLE %s ADD %s",
+			c.historyTable.tableNameQuoted,
+			column.definition,
+		))
+		return true
+	}
+
+	return false
+}
+
+func (c *changeHistoryManager) execute() error {
+	for _, statement := range c.statements {
+		c.logger.Debug(statement)
+		_, err := c.orm.CommonDB().Exec(statement)
+		if err != nil {
+			c.logger.WithFields(mon.Fields{
+				"sql": statement,
+			}).Error(err, "")
+			return fmt.Errorf("could not migrate change history: %w", err)
+		}
+	}
+
+	c.logger.Info("change history setup is now up to date")
+
+	return nil
+}

--- a/pkg/db-repo/change_history_metadata.go
+++ b/pkg/db-repo/change_history_metadata.go
@@ -1,0 +1,115 @@
+package db_repo
+
+import (
+	"github.com/jinzhu/gorm"
+	"github.com/thoas/go-funk"
+	"strings"
+)
+
+type columnMetadata struct {
+	exists     bool
+	name       string
+	nameQuoted string
+	definition string
+}
+
+type tableMetadata struct {
+	exists          bool
+	tableName       string
+	tableNameQuoted string
+	columns         []columnMetadata
+	primaryKeys     []columnMetadata
+}
+
+type tableMetadataBuilder struct {
+	scope     *gorm.Scope
+	tableName string
+	fields    []*gorm.StructField
+}
+
+func (m *tableMetadataBuilder) build() *tableMetadata {
+	metadata := &tableMetadata{}
+	metadata.exists = m.scope.Dialect().HasTable(m.tableName)
+	metadata.tableName = m.tableName
+	metadata.tableNameQuoted = m.scope.Quote(m.tableName)
+	metadata.columns = m.buildColumns()
+	metadata.primaryKeys = m.buildPrimaryKeys()
+	return metadata
+}
+
+func (m *tableMetadataBuilder) buildColumns() []columnMetadata {
+	var columns []columnMetadata
+	for _, field := range m.fields {
+		if field.IsNormal {
+			columns = append(columns, m.buildColumn(field))
+		}
+	}
+	return columns
+}
+
+func (m *tableMetadataBuilder) buildPrimaryKeys() []columnMetadata {
+	var columns []columnMetadata
+	for _, field := range m.fields {
+		if field.IsPrimaryKey {
+			columns = append(columns, m.buildColumn(field))
+		}
+	}
+	return columns
+}
+
+func (m *tableMetadataBuilder) buildColumn(field *gorm.StructField) columnMetadata {
+	return columnMetadata{
+		name:       field.DBName,
+		nameQuoted: m.scope.Quote(field.DBName),
+		definition: m.scope.Quote(field.DBName) + " " + m.dataTypeOfField(field),
+		exists:     m.scope.Dialect().HasColumn(m.tableName, field.DBName),
+	}
+}
+
+func (m *tableMetadataBuilder) dataTypeOfField(field *gorm.StructField) string {
+	tag := m.scope.Dialect().DataTypeOf(field)
+
+	tag = strings.Replace(tag, "AUTO_INCREMENT", "", -1)
+	tag = strings.Replace(tag, "UNIQUE", "", -1)
+
+	return tag
+}
+
+func newTableMetadata(scope *gorm.Scope, tableName string, fields []*gorm.StructField) *tableMetadata {
+	builder := tableMetadataBuilder{
+		tableName: tableName,
+		scope:     scope,
+		fields:    fields,
+	}
+	return builder.build()
+}
+
+func (m *tableMetadata) columnNamesQuoted() []string {
+	return m.namesQuoted(m.columns)
+}
+
+func (m *tableMetadata) primaryKeyNamesQuoted() []string {
+	return m.namesQuoted(m.primaryKeys)
+}
+
+func (m *tableMetadata) columnDefinitions() []string {
+	return m.definitions(m.columns)
+}
+
+func (m *tableMetadata) namesQuoted(items []columnMetadata) []string {
+	return funk.Map(items, func(item columnMetadata) string {
+		return item.nameQuoted
+	}).([]string)
+}
+
+func (m *tableMetadata) definitions(items []columnMetadata) []string {
+	return funk.Map(items, func(item columnMetadata) string {
+		return item.definition
+	}).([]string)
+}
+
+func (m *tableMetadata) columnNamesQuotedExcludingValue(excluded ...string) []string {
+	return m.namesQuoted(funk.Filter(m.columns, func(item columnMetadata) bool {
+		return !funk.ContainsString(excluded, item.name)
+	}).([]columnMetadata))
+}

--- a/pkg/db-repo/model.go
+++ b/pkg/db-repo/model.go
@@ -5,6 +5,8 @@ import (
 	"time"
 )
 
+const ColumnUpdatedAt = "updated_at"
+
 type ModelBased interface {
 	mdl.Identifiable
 	TimeStampable

--- a/pkg/test/component_mysql.go
+++ b/pkg/test/component_mysql.go
@@ -46,7 +46,7 @@ func (m *mysqlComponent) Start() error {
 		Repository: "mysql",
 		Tag:        m.settings.Version,
 		Env:        env,
-		Cmd:        []string{"--sql_mode=NO_ENGINE_SUBSTITUTION"},
+		Cmd:        []string{"--sql_mode=NO_ENGINE_SUBSTITUTION", "--log-bin-trust-function-creators=TRUE"},
 		PortBindings: portBinding{
 			"3306/tcp": fmt.Sprint(m.settings.Port),
 		},

--- a/test/db_repo_change_history_test.go
+++ b/test/db_repo_change_history_test.go
@@ -1,0 +1,158 @@
+//+build integration
+
+package test_test
+
+import (
+	"context"
+	"github.com/applike/gosoline/pkg/cfg"
+	"github.com/applike/gosoline/pkg/db-repo"
+	"github.com/applike/gosoline/pkg/mdl"
+	"github.com/applike/gosoline/pkg/mon"
+	"github.com/applike/gosoline/pkg/test"
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type DbRepoChangeHistoryTestSuite struct {
+	suite.Suite
+	logger mon.Logger
+	config cfg.Config
+	mocks  *test.Mocks
+	repo   db_repo.Repository
+}
+
+func TestDbChangelogTestSuite(t *testing.T) {
+	suite.Run(t, new(DbRepoChangeHistoryTestSuite))
+}
+
+func (s *DbRepoChangeHistoryTestSuite) SetupSuite() {
+	setup(s.T())
+	mocks, err := test.Boot("test_configs/config.mysql.test.yml")
+
+	if !s.NoError(err) {
+		return
+	}
+
+	s.mocks = mocks
+
+	config := cfg.New()
+	_ = config.Option(
+		cfg.WithConfigFile("test_configs/config.mysql.test.yml", "yml"),
+		cfg.WithConfigFile("test_configs/config.db_repo_change_history.test.yml", "yml"),
+		cfg.WithConfigMap(map[string]interface{}{
+			"db_port":     s.mocks.ProvideMysqlPort("mysql"),
+			"db_hostname": s.mocks.ProvideMysqlHost("mysql"),
+		}),
+	)
+
+	s.config = config
+	s.logger = mon.NewLogger()
+	s.repo = db_repo.New(s.config, s.logger, db_repo.Settings{})
+}
+
+func (s *DbRepoChangeHistoryTestSuite) TearDownSuite() {
+	s.mocks.Shutdown()
+}
+
+func (s *DbRepoChangeHistoryTestSuite) TestChangeHistoryMigration_Migrate_CreateTable() {
+
+	type TestModel1 struct {
+		db_repo.Model
+		Name *string
+	}
+
+	type TestModel1HistoryEntry struct {
+		db_repo.ChangeHistoryModel
+		TestModel1
+	}
+
+	s.NotPanics(func() {
+		db_repo.MigrateChangeHistory(s.config, s.logger, &TestModel1{})
+	})
+
+	model := &TestModel1{
+		Name: mdl.String("name1"),
+	}
+
+	err := s.repo.Create(context.Background(), model)
+	s.NoError(err)
+
+	model.Name = mdl.String("name2")
+	err = s.repo.Update(context.Background(), model)
+	s.NoError(err)
+
+	err = s.repo.Delete(context.Background(), model)
+	s.NoError(err)
+
+	entries := make([]*TestModel1HistoryEntry, 0)
+	err = s.repo.Query(context.Background(), &db_repo.QueryBuilder{}, &entries)
+	s.NoError(err)
+	s.Equal(3, len(entries), "expected 3 change history entries")
+
+	s.Equal(1, entries[0].ChangeHistoryRevision)
+	s.Equal("insert", entries[0].ChangeHistoryAction)
+	s.Equal("name1", *entries[0].Name)
+
+	s.Equal(2, entries[1].ChangeHistoryRevision)
+	s.Equal("update", entries[1].ChangeHistoryAction)
+	s.Equal("name2", *entries[1].Name)
+
+	s.Equal(3, entries[2].ChangeHistoryRevision)
+	s.Equal("delete", entries[2].ChangeHistoryAction)
+	s.Equal("name2", *entries[2].Name)
+}
+
+func (s *DbRepoChangeHistoryTestSuite) TestChangeHistoryMigration_Migrate_UpdateTable() {
+
+	type TestModel2 struct {
+		db_repo.Model
+		Name         *string
+		Foo          *string
+		ChangeAuthor *string
+	}
+
+	type TestModel2HistoryEntry struct {
+		db_repo.ChangeHistoryModel
+		TestModel2
+	}
+
+	s.NotPanics(func() {
+		db_repo.MigrateChangeHistory(s.config, s.logger, &TestModel2{})
+	})
+
+	model := &TestModel2{
+		Name:         mdl.String("name1"),
+		Foo:          mdl.String("foo1"),
+		ChangeAuthor: mdl.String("john@example.com"),
+	}
+
+	err := s.repo.Create(context.Background(), model)
+	s.NoError(err)
+
+	model.Foo = mdl.String("foo2")
+	err = s.repo.Update(context.Background(), model)
+	s.NoError(err)
+
+	err = s.repo.Delete(context.Background(), model)
+	s.NoError(err)
+
+	entries := make([]*TestModel2HistoryEntry, 0)
+	err = s.repo.Query(context.Background(), &db_repo.QueryBuilder{}, &entries)
+	s.NoError(err)
+	s.Equal(3, len(entries), "expected 3 change history entries")
+
+	s.Equal(1, entries[0].ChangeHistoryRevision)
+	s.Equal("insert", entries[0].ChangeHistoryAction)
+	s.Equal("foo1", *entries[0].Foo)
+	s.Equal("john@example.com", *entries[0].ChangeAuthor)
+
+	s.Equal(2, entries[1].ChangeHistoryRevision)
+	s.Equal("update", entries[1].ChangeHistoryAction)
+	s.Equal("foo2", *entries[1].Foo)
+	s.Equal("john@example.com", *entries[1].ChangeAuthor)
+
+	s.Equal(3, entries[2].ChangeHistoryRevision)
+	s.Equal("delete", entries[2].ChangeHistoryAction)
+	s.Equal("foo2", *entries[2].Foo)
+	s.Nil(entries[2].ChangeAuthor) // change-author is excluded for delete actions as it may be misleading
+}

--- a/test/test_configs/config.db_repo_change_history.test.yml
+++ b/test/test_configs/config.db_repo_change_history.test.yml
@@ -1,0 +1,20 @@
+env: test
+app_project: gosoline
+app_family: integration-test
+app_name: db-repo-change-history-test
+
+db_drivername: "mysql"
+db_database: "myDbName"
+db_username: "root"
+db_password: "gosoline"
+db_retry_wait: 10
+db_health_check_delay: 30
+db_max_connection_lifetime: 120
+db_parse_time: true
+db_auto_migrate: true
+db_table_prefixed: false
+db_migrations_path: file://test_fixtures/migrations_db_repo_change_history/
+
+change_history:
+  table_suffix: history_entries
+  change_author_column: change_author

--- a/test/test_fixtures/migrations_db_repo_change_history/1_migrations_tables.up.sql
+++ b/test/test_fixtures/migrations_db_repo_change_history/1_migrations_tables.up.sql
@@ -1,0 +1,32 @@
+create table test_model1
+(
+  id int unsigned auto_increment
+    primary key,
+  name varchar(255) null,
+  updated_at timestamp null,
+  created_at timestamp null
+);
+
+create table test_model2
+(
+  id int unsigned auto_increment primary key,
+  name varchar(255) null,
+  foo  varchar(8) null,
+  change_author varchar(255),
+  updated_at timestamp null,
+  created_at timestamp null
+);
+
+/* used to test with an existing history table */
+ CREATE TABLE test_model2_history_entries
+ (
+ change_history_action  VARCHAR(8) NOT NULL DEFAULT 'insert',
+ change_history_revision int ,
+ change_history_action_at timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+ id int unsigned ,
+ updated_at timestamp NULL,
+ created_at timestamp NULL,
+ change_author varchar(255),
+ name varchar(255),
+ PRIMARY KEY (change_history_revision,id)
+ );


### PR DESCRIPTION
**Summary:**

- Add a `db_repo.MigrateChangeHistory` function.
- The migration creates and updates a history table and a set of triggers.
- This has only been tested on mysql.
- Changed connection cache on `pkg/db/connection.go` to allow connections with different settings (integration tests were failing when running after each other).

**Open points:**

- It is not possible to get the change_author for delete operations with this approach.
- Need a way to prevent 2 applications to run the migration concurrently. (won't implement it in this iteration)
- Needs mysql option `log_bin_trust_function_creators=1`