### PR TITLE
db: fix client error in QueryRow;

### DIFF
--- a/pkg/db/client.go
+++ b/pkg/db/client.go
@@ -155,7 +155,7 @@ func (c *ClientSqlx) Query(query string, args ...interface{}) (*sql.Rows, error)
 }
 
 func (c *ClientSqlx) QueryRow(query string, args ...interface{}) *sql.Row {
-	return c.db.QueryRow(query, args)
+	return c.db.QueryRow(query, args...)
 }
 
 func (c *ClientSqlx) Queryx(query string, args ...interface{}) (*sqlx.Rows, error) {


### PR DESCRIPTION
`QueryRow` implementation was broken and the errors were just being ignored.