### PR TITLE
coffin: refactored coffin type to contain a pointer to a tomb instead of a tomb;

### DIFF
--- a/pkg/coffin/coffin.go
+++ b/pkg/coffin/coffin.go
@@ -7,30 +7,107 @@ import (
 )
 
 type Coffin interface {
+	// Alive returns true if the coffin is not in a dying or dead state.
 	Alive() bool
+	// Context returns a context that is a copy of the provided parent context with
+	// a replaced Done channel that is closed when either the coffin is dying or the
+	// parent is cancelled.
+	//
+	// If parent is nil, it defaults to the parent provided via WithContext, or an
+	// empty background parent if the coffin wasn't created via WithContext.
 	Context(parent context.Context) context.Context
+	// Dead returns the channel that can be used to wait until
+	// all goroutines have finished running.
 	Dead() <-chan struct{}
+	// Dying returns the channel that can be used to wait until
+	// t.Kill is called.
 	Dying() <-chan struct{}
 	Err() (reason error)
+	// Go runs f in a new goroutine and tracks its termination.
+	//
+	// If f returns a non-nil error, t.Kill is called with that
+	// error as the death reason parameter.
+	//
+	// It is f's responsibility to monitor the coffin and return
+	// appropriately once it is in a dying state.
+	//
+	// It is safe for the f function to call the Go method again
+	// to create additional tracked goroutines. Once all tracked
+	// goroutines return, the Dead channel is closed and the
+	// Wait method unblocks and returns the death reason.
+	//
+	// Calling the Go method after all tracked goroutines return
+	// causes a runtime panic. For that reason, calling the Go
+	// method a second time out of a tracked goroutine is unsafe.
 	Go(f func() error)
+	// Gof is like Go, but wraps the returned error with the given
+	// name and args
 	Gof(f func() error, name string, args ...interface{})
+	// GoWithContext is like Go, but passes the given context to f
 	GoWithContext(ctx context.Context, f func(ctx context.Context) error)
+	// GoWithContextf is like Gof, but passes the given context to f
 	GoWithContextf(ctx context.Context, f func(ctx context.Context) error, msg string, args ...interface{})
+	// Kill puts the coffin in a dying state for the given reason,
+	// closes the Dying channel, and sets Alive to false.
+	//
+	// Although Kill may be called multiple times, only the first
+	// non-nil error is recorded as the death reason.
+	//
+	// If reason is ErrDying, the previous reason isn't replaced
+	// even if nil. It's a runtime error to call Kill with ErrDying
+	// if t is not in a dying state.
 	Kill(reason error)
+	// Killf calls the Kill method with an error built providing the received
+	// parameters to fmt.Errorf. The generated error is also returned.
 	Killf(f string, a ...interface{}) error
+	// Wait blocks until all goroutines have finished running, and
+	// then returns the reason for their death.
 	Wait() error
 }
 
 type coffin struct {
-	tomb.Tomb
+	// we MUST represent this as a ptr as tomb.Tomb contains a mutex which
+	// we are not allowed to copy!
+	tomb *tomb.Tomb
 }
 
 func New() Coffin {
-	return &coffin{}
+	return &coffin{
+		tomb: new(tomb.Tomb),
+	}
+}
+
+func WithContext(parent context.Context) (Coffin, context.Context) {
+	tmb, ctx := tomb.WithContext(parent)
+	cfn := &coffin{
+		tomb: tmb,
+	}
+
+	return cfn, ctx
+}
+
+func (c *coffin) Alive() bool {
+	return c.tomb.Alive()
+}
+
+func (c *coffin) Context(parent context.Context) context.Context {
+	return c.tomb.Context(parent)
+}
+
+func (c *coffin) Dead() <-chan struct{} {
+	return c.tomb.Dead()
+}
+
+func (c *coffin) Dying() <-chan struct{} {
+	return c.tomb.Dying()
+}
+
+func (c *coffin) Err() (reason error) {
+	return c.tomb.Err()
 }
 
 func (c *coffin) Go(f func() error) {
-	c.Tomb.Go(func() (err error) {
+	c.tomb.Go(func() (err error) {
 		defer func() {
 			panicErr := ResolveRecovery(recover())
 
@@ -44,7 +121,7 @@ func (c *coffin) Go(f func() error) {
 }
 
 func (c *coffin) Gof(f func() error, msg string, args ...interface{}) {
-	c.Tomb.Go(func() (err error) {
+	c.tomb.Go(func() (err error) {
 		defer func() {
 			panicErr := ResolveRecovery(recover())
 
@@ -70,9 +147,14 @@ func (c *coffin) GoWithContextf(ctx context.Context, f func(ctx context.Context)
 	}, msg, args...)
 }
 
-func WithContext(parent context.Context) (Coffin, context.Context) {
-	tmb, ctx := tomb.WithContext(parent)
-	cfn := &coffin{Tomb: *tmb}
+func (c *coffin) Kill(reason error) {
+	c.tomb.Kill(reason)
+}
 
-	return cfn, ctx
+func (c *coffin) Killf(f string, a ...interface{}) error {
+	return c.tomb.Killf(f, a...)
+}
+
+func (c *coffin) Wait() error {
+	return c.tomb.Wait()
 }

--- a/pkg/coffin/coffin_test.go
+++ b/pkg/coffin/coffin_test.go
@@ -1,0 +1,85 @@
+package coffin_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/applike/gosoline/pkg/coffin"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestCoffin_New(t *testing.T) {
+	cfn := coffin.New()
+	myErr := errors.New("my error")
+
+	cfn.Gof(func() error {
+		panic(myErr)
+	}, "got this error: %d", 42)
+
+	err := cfn.Wait()
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, myErr))
+	assert.Equal(t, "got this error: 42: my error", err.Error())
+}
+
+func TestCoffin_WithContext(t *testing.T) {
+	// if you are asking wtf is this, you might be correct. But let me explain:
+	// - we iterate a few times because this is a race condition and does not
+	//   trigger every time
+	// - the nested coffin pattern is actually used if your module is using the
+	//   coffin module. The outer coffin is actually used by the kernel to keep
+	//   track of your module
+	// - the error we are testing for is "panic: close of closed channel"
+	// - the error triggers because the old coffin implementation did COPY a coffin
+	//   and by doing so did copy a mutex. but a mutex is not safe to copy after
+	//   someone already got a reference to it - in this case tomb.WithContext
+	// - thus, tomb.WithContext locked a DIFFERENT mutex than we later locked when
+	//   killing the tomb/coffin, but closed the SAME channel
+	// - this test is thus intended to make sure no one actually reintroduces this
+	//   behavior
+	for i := 0; i < 10; i++ {
+		t.Run(fmt.Sprintf("iteration %d", i), func(t *testing.T) {
+			assert.NotPanics(t, func() {
+				cfn, ctx := coffin.WithContext(context.Background())
+				c := make(chan struct{})
+				errStop := errors.New("please stop")
+
+				cfn.GoWithContext(ctx, func(ctx context.Context) error {
+					nestedCfn, cfnCtx := coffin.WithContext(ctx)
+
+					nestedCfn.GoWithContext(cfnCtx, func(ctx context.Context) error {
+						ticker := time.NewTicker(time.Millisecond)
+						defer ticker.Stop()
+						count := 0
+
+						for {
+							select {
+							case <-ticker.C:
+								count++
+								if count == 3 {
+									close(c)
+								}
+							case <-ctx.Done():
+								return nil
+							}
+						}
+					})
+
+					err := nestedCfn.Wait()
+					if !errors.Is(err, context.Canceled) {
+						assert.NoError(t, err)
+					}
+					return err
+				})
+
+				<-c
+				cfn.Kill(errStop)
+				err := cfn.Wait()
+
+				assert.Equal(t, errStop, err)
+			})
+		})
+	}
+}


### PR DESCRIPTION
A tomb contains a mutex which again may not be copied after it is
first used. If we copy a tomb we copy the mutex. However, if we got the
tomb from tomb.WithContext, another go routine already has a reference
to this tomb and thus will lock a different copy of the mutex than we
have stored in our coffin. Thus, if the tomb later tries to close the
dying channel the critical section of doing this might be entered twice
at the same time, causing a panic because we are closing a closed
channel.