### PR TITLE
apiserver: exposed AddProfilingEndpoints to stop skipping tests and added `go vet` to ci config;

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Build
         run: go build -v ./...
 
+      - name: Static code analysis
+        run: go vet ./...
+
       - name: Test
         run: go test ./...
 

--- a/pkg/apiserver/profiler.go
+++ b/pkg/apiserver/profiler.go
@@ -19,25 +19,22 @@ const (
 	ThreadCreate  = "/threadcreate"
 )
 
-func addProfilingEndpoints(r *gin.Engine) {
+func AddProfilingEndpoints(r *gin.Engine) {
 	pr := r.Group(BaseProfiling)
-	{
-		pr.GET("/", profilingHandler(pprof.Index))
-		pr.GET(CmdLine, profilingHandler(pprof.Cmdline))
-		pr.GET(Profile, profilingHandler(pprof.Profile))
-		pr.POST(Symbol, profilingHandler(pprof.Symbol))
-		pr.GET(Symbol, profilingHandler(pprof.Symbol))
-		pr.GET(Trace, profilingHandler(pprof.Trace))
-		pr.GET(Block, profilingHandler(pprof.Handler("block").ServeHTTP))
-		pr.GET(GoRoutine, profilingHandler(pprof.Handler("goroutine").ServeHTTP))
-		pr.GET(Heap, profilingHandler(pprof.Handler("heap").ServeHTTP))
-		pr.GET(Mutex, profilingHandler(pprof.Handler("mutex").ServeHTTP))
-		pr.GET(ThreadCreate, profilingHandler(pprof.Handler("threadcreate").ServeHTTP))
-	}
+	pr.GET("/", profilingHandler(pprof.Index))
+	pr.GET(CmdLine, profilingHandler(pprof.Cmdline))
+	pr.GET(Profile, profilingHandler(pprof.Profile))
+	pr.POST(Symbol, profilingHandler(pprof.Symbol))
+	pr.GET(Symbol, profilingHandler(pprof.Symbol))
+	pr.GET(Trace, profilingHandler(pprof.Trace))
+	pr.GET(Block, profilingHandler(pprof.Handler("block").ServeHTTP))
+	pr.GET(GoRoutine, profilingHandler(pprof.Handler("goroutine").ServeHTTP))
+	pr.GET(Heap, profilingHandler(pprof.Handler("heap").ServeHTTP))
+	pr.GET(Mutex, profilingHandler(pprof.Handler("mutex").ServeHTTP))
+	pr.GET(ThreadCreate, profilingHandler(pprof.Handler("threadcreate").ServeHTTP))
 }
 
-func profilingHandler(h http.HandlerFunc) gin.HandlerFunc {
-	handler := http.HandlerFunc(h)
+func profilingHandler(handler http.HandlerFunc) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		handler.ServeHTTP(c.Writer, c.Request)
 	}

--- a/pkg/apiserver/server.go
+++ b/pkg/apiserver/server.go
@@ -60,7 +60,7 @@ func (a *ApiServer) Boot(config cfg.Config, logger mon.Logger) error {
 	router := gin.New()
 	tracer := tracing.ProviderTracer(config, logger)
 
-	addProfilingEndpoints(router)
+	AddProfilingEndpoints(router)
 
 	router.GET("/health", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{})

--- a/pkg/apiserver/server_test.go
+++ b/pkg/apiserver/server_test.go
@@ -79,9 +79,8 @@ func (s *ServerTestSuite) TestGetPort_Error() {
 }
 
 func (s *ServerTestSuite) TestBaseProfilingEndpoint() {
-	s.T().Skip("profiling routes are added in Boot, cannot be tested here")
-
 	assert.NotPanics(s.T(), func() {
+		apiserver.AddProfilingEndpoints(s.router)
 		err := s.server.BootWithInterfaces(s.logger, s.router, s.tracer, &apiserver.Settings{})
 		assert.NoError(s.T(), err)
 	})

--- a/pkg/db-repo/repository_test.go
+++ b/pkg/db-repo/repository_test.go
@@ -31,7 +31,7 @@ type OneOfMany struct {
 
 type HasMany struct {
 	db_repo.Model
-	Manies []*Ones `gorm:"association_autoupdate:true;association_autocreate:true;association_save_reference:true;"orm:"assoc_update"`
+	Manies []*Ones `gorm:"association_autoupdate:true;association_autocreate:true;association_save_reference:true;" orm:"assoc_update"`
 }
 
 type Ones struct {

--- a/pkg/ddb/repository_test.go
+++ b/pkg/ddb/repository_test.go
@@ -58,7 +58,10 @@ func TestRepository_GetItem(t *testing.T) {
 		},
 	}
 
-	client, repo := getMocks([]cloud.TestExecution{{output, nil}})
+	client, repo := getMocks([]cloud.TestExecution{{
+		Output: output,
+		Err:    nil,
+	}})
 	client.On("GetItemRequest", input).Return(nil, nil)
 
 	qb := repo.GetItemBuilder().WithHash(1).WithRange("0")
@@ -104,7 +107,10 @@ func TestRepository_GetItem_FromItem(t *testing.T) {
 		},
 	}
 
-	client, repo := getMocks([]cloud.TestExecution{{output, nil}})
+	client, repo := getMocks([]cloud.TestExecution{{
+		Output: output,
+		Err:    nil,
+	}})
 	client.On("GetItemRequest", input).Return(nil, nil)
 
 	item := model{
@@ -142,7 +148,10 @@ func TestRepository_GetItemNotFound(t *testing.T) {
 	}
 	output := &dynamodb.GetItemOutput{}
 
-	client, repo := getMocks([]cloud.TestExecution{{output, nil}})
+	client, repo := getMocks([]cloud.TestExecution{{
+		Output: output,
+		Err:    nil,
+	}})
 	client.On("GetItemRequest", input).Return(nil, nil)
 
 	qb := repo.GetItemBuilder().WithHash(1).WithRange("0")
@@ -179,7 +188,10 @@ func TestRepository_GetItemProjection(t *testing.T) {
 		},
 	}
 
-	client, repo := getMocks([]cloud.TestExecution{{output, nil}})
+	client, repo := getMocks([]cloud.TestExecution{{
+		Output: output,
+		Err:    nil,
+	}})
 	client.On("GetItemRequest", input).Return(nil, nil)
 
 	item := projection{}
@@ -240,7 +252,10 @@ func TestRepository_Query(t *testing.T) {
 		},
 	}
 
-	client, repo := getMocks([]cloud.TestExecution{{output, nil}})
+	client, repo := getMocks([]cloud.TestExecution{{
+		Output: output,
+		Err:    nil,
+	}})
 	client.On("QueryRequest", input).Return(nil, nil)
 
 	result := make([]model, 0)
@@ -270,7 +285,10 @@ func TestRepository_Query(t *testing.T) {
 func TestRepository_Query_Canceled(t *testing.T) {
 	awsErr := awserr.New(request.CanceledErrorCode, "got canceled", nil)
 
-	client, repo := getMocks([]cloud.TestExecution{{nil, awsErr}})
+	client, repo := getMocks([]cloud.TestExecution{{
+		Output: nil,
+		Err:    awsErr,
+	}})
 	client.On("QueryRequest", mock.AnythingOfType("*dynamodb.QueryInput")).Return(nil, nil)
 
 	result := make([]model, 0)
@@ -321,7 +339,10 @@ func TestRepository_BatchGetItems(t *testing.T) {
 		UnprocessedKeys: map[string]*dynamodb.KeysAndAttributes{},
 	}
 
-	client, repo := getMocks([]cloud.TestExecution{{output, nil}})
+	client, repo := getMocks([]cloud.TestExecution{{
+		Output: output,
+		Err:    nil,
+	}})
 	client.On("BatchGetItemRequest", input).Return(nil, nil)
 
 	result := make([]model, 0)
@@ -390,7 +411,10 @@ func TestRepository_BatchWriteItem(t *testing.T) {
 		UnprocessedItems: map[string][]*dynamodb.WriteRequest{},
 	}
 
-	client, repo := getMocks([]cloud.TestExecution{{output, nil}})
+	client, repo := getMocks([]cloud.TestExecution{{
+		Output: output,
+		Err:    nil,
+	}})
 	client.On("BatchWriteItemRequest", input).Return(nil, nil)
 
 	_, err := repo.BatchPutItems(context.Background(), items)
@@ -460,9 +484,18 @@ func TestRepository_BatchWriteItem_Retry(t *testing.T) {
 	}
 
 	client, repo := getMocks([]cloud.TestExecution{
-		{firstOutput, nil},
-		{firstOutput, nil},
-		{secondOutput, nil},
+		{
+			Output: firstOutput,
+			Err:    nil,
+		},
+		{
+			Output: firstOutput,
+			Err:    nil,
+		},
+		{
+			Output: secondOutput,
+			Err:    nil,
+		},
 	})
 
 	client.On("BatchWriteItemRequest", firstInput).Return(nil, nil).Once()
@@ -498,7 +531,10 @@ func TestRepository_PutItem(t *testing.T) {
 	}
 	output := &dynamodb.PutItemOutput{}
 
-	client, repo := getMocks([]cloud.TestExecution{{output, nil}})
+	client, repo := getMocks([]cloud.TestExecution{{
+		Output: output,
+		Err:    nil,
+	}})
 	client.On("PutItemRequest", input).Return(nil, nil)
 
 	res, err := repo.PutItem(context.Background(), nil, item)
@@ -544,7 +580,10 @@ func TestRepository_Update(t *testing.T) {
 		},
 	}
 
-	client, repo := getMocks([]cloud.TestExecution{{output, nil}})
+	client, repo := getMocks([]cloud.TestExecution{{
+		Output: output,
+		Err:    nil,
+	}})
 	client.On("UpdateItemRequest", input).Return(nil, nil)
 
 	updatedItem := &model{
@@ -602,7 +641,10 @@ func TestRepository_DeleteItem(t *testing.T) {
 		},
 	}
 
-	client, repo := getMocks([]cloud.TestExecution{{output, nil}})
+	client, repo := getMocks([]cloud.TestExecution{{
+		Output: output,
+		Err:    nil,
+	}})
 	client.On("DeleteItemRequest", input).Return(nil, nil)
 
 	item := model{


### PR DESCRIPTION
We should always run `go vet` on our code to make sure we are not
introducing stupid mistakes (like copying a mutex, go vet actually saw
the bug we just fixed with coffin). Thus we now always run it on our
code (and now our code actually passes it).