### PR TITLE
sub: added support for backoff settings for subscribers;

### DIFF
--- a/pkg/kvstore/ddb.go
+++ b/pkg/kvstore/ddb.go
@@ -45,6 +45,7 @@ func NewDdbKvStore(config cfg.Config, logger mon.Logger, settings *Settings) KvS
 			ReadCapacityUnits:  5,
 			WriteCapacityUnits: 5,
 		},
+		Backoff: settings.Backoff,
 	})
 
 	return NewDdbKvStoreWithInterfaces(logger, repository, settings)

--- a/pkg/kvstore/kvstore.go
+++ b/pkg/kvstore/kvstore.go
@@ -3,6 +3,7 @@ package kvstore
 import (
 	"context"
 	"github.com/applike/gosoline/pkg/cfg"
+	"github.com/applike/gosoline/pkg/cloud"
 	"github.com/applike/gosoline/pkg/encoding/json"
 	"github.com/applike/gosoline/pkg/mon"
 	"github.com/pkg/errors"
@@ -15,6 +16,7 @@ type Settings struct {
 	Name      string
 	Ttl       time.Duration
 	BatchSize int
+	Backoff   cloud.BackoffSettings
 }
 
 //go:generate mockery -name KvStore

--- a/pkg/sub/factory.go
+++ b/pkg/sub/factory.go
@@ -12,11 +12,12 @@ import (
 )
 
 type Subscription struct {
-	Input       string            `cfg:"input"`
-	Output      string            `cfg:"output"`
-	RunnerCount int               `cfg:"runner_count" default:"10" validate:"min=1"`
-	SourceModel SubscriptionModel `cfg:"source"`
-	TargetModel SubscriptionModel `cfg:"target"`
+	Input       string                `cfg:"input"`
+	Output      string                `cfg:"output"`
+	RunnerCount int                   `cfg:"runner_count" default:"10" validate:"min=1"`
+	SourceModel SubscriptionModel     `cfg:"source"`
+	TargetModel SubscriptionModel     `cfg:"target"`
+	Backoff     cloud.BackoffSettings `cfg:"backoff"`
 }
 
 type SubscriptionModel struct {
@@ -68,6 +69,7 @@ func SubscriberFactory(config cfg.Config, logger mon.Logger, transformerMapType 
 			RunnerCount:   s.RunnerCount,
 			SourceModelId: sourceModelId,
 			TargetModelId: targetModelId,
+			Backoff:       s.Backoff,
 		}
 
 		input, err := getInputByType(config, logger, s, sourceModelId)

--- a/pkg/sub/sub_out_ddb.go
+++ b/pkg/sub/sub_out_ddb.go
@@ -17,6 +17,7 @@ func repoInit(config cfg.Config, logger mon.Logger, settings Settings) func(mode
 				ReadCapacityUnits:  5,
 				WriteCapacityUnits: 5,
 			},
+			Backoff: settings.Backoff,
 		})
 
 		return ddb.NewMetricRepository(config, logger, repo)

--- a/pkg/sub/sub_out_kvstore.go
+++ b/pkg/sub/sub_out_kvstore.go
@@ -25,7 +25,8 @@ func (p *subOutKvstore) Boot(config cfg.Config, logger mon.Logger, settings Sett
 			Family:      settings.TargetModelId.Family,
 			Application: settings.TargetModelId.Application,
 		},
-		Name: settings.TargetModelId.Name,
+		Name:    settings.TargetModelId.Name,
+		Backoff: settings.Backoff,
 	})
 	store.Add(kvstore.NewRedisKvStore)
 	store.Add(kvstore.NewDdbKvStore)

--- a/pkg/sub/subscriber.go
+++ b/pkg/sub/subscriber.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/applike/gosoline/pkg/cfg"
+	"github.com/applike/gosoline/pkg/cloud"
 	"github.com/applike/gosoline/pkg/coffin"
 	"github.com/applike/gosoline/pkg/kernel"
 	"github.com/applike/gosoline/pkg/mdl"
@@ -28,6 +29,7 @@ type Settings struct {
 	RunnerCount   int
 	SourceModelId mdl.ModelId
 	TargetModelId mdl.ModelId
+	Backoff       cloud.BackoffSettings
 }
 
 type Subscriber interface {


### PR DESCRIPTION
Subscribers could easily run into throttling exception or similar if a
traffic spike appears and do not yet retry requests if needed. Instead,
we often simply get an error which is just unneeded noise. This commit
allows you to configure your subscriptions with backoff settings which
propagete to kvstore and ddb outputs.