### PR TITLE
Make sqs queue application configurable

### DIFF
--- a/pkg/stream/input_configurable.go
+++ b/pkg/stream/input_configurable.go
@@ -130,6 +130,8 @@ type snsInputTarget struct {
 
 type snsInputConfiguration struct {
 	ConsumerId        string                `cfg:"id" validate:"required"`
+	Family            string                `cfg:"family" default:""`
+	Application       string                `cfg:"application" default:""`
 	Targets           []snsInputTarget      `cfg:"targets" validate:"min=1"`
 	WaitTime          int64                 `cfg:"wait_time" default:"3" validate:"min=1"`
 	VisibilityTimeout int                   `cfg:"visibility_timeout" default:"30" validate:"min=1"`
@@ -146,6 +148,10 @@ func newSnsInputFromConfig(config cfg.Config, logger mon.Logger, name string) In
 	config.UnmarshalKey(key, &configuration)
 
 	settings := SnsInputSettings{
+		AppId: cfg.AppId{
+			Family:      configuration.Family,
+			Application: configuration.Application,
+		},
 		QueueId:           configuration.ConsumerId,
 		WaitTime:          configuration.WaitTime,
 		VisibilityTimeout: configuration.VisibilityTimeout,

--- a/pkg/stream/input_sns.go
+++ b/pkg/stream/input_sns.go
@@ -10,7 +10,6 @@ import (
 
 type SnsInputSettings struct {
 	cfg.AppId
-	AutoSubscribe     bool
 	QueueId           string                `cfg:"queue_id"`
 	WaitTime          int64                 `cfg:"wait_time"`
 	RedrivePolicy     sqs.RedrivePolicy     `cfg:"redrive_policy"`
@@ -31,7 +30,7 @@ type snsInput struct {
 
 func NewSnsInput(config cfg.Config, logger mon.Logger, s SnsInputSettings, targets []SnsInputTarget) *snsInput {
 	s.PadFromConfig(config)
-	s.AutoSubscribe = config.GetBool("aws_sns_autoSubscribe")
+	autoSubscribe := config.GetBool("aws_sns_autoSubscribe")
 
 	sqsInput := NewSqsInput(config, logger, SqsInputSettings{
 		AppId:             s.AppId,
@@ -47,7 +46,7 @@ func NewSnsInput(config cfg.Config, logger mon.Logger, s SnsInputSettings, targe
 
 	queueArn := sqsInput.GetQueueArn()
 
-	if s.AutoSubscribe {
+	if autoSubscribe {
 		for _, t := range targets {
 			t.PadFromConfig(config)
 


### PR DESCRIPTION
This if needed if you consider the following setup:

Project: awesome-project
Family: your-awesome-family
Env: production
Application: this-is-your-application

And now you want to create a queue for MonitoringEvent messages and get this name:

awesome-project-production-your-awesome-family-this-is-your-application-MonitoringEvent

Oh no, this is now 7 characters too long for the SQS queue name limit of
80 characters! So you shorten the name of application for this queue to "app":

awesome-project-production-your-awesome-family-app-MonitoringEvent

And now you only have 66 characters which is way below the 80 character limit.