### PR TITLE
application: added replacement of - to _ in env key replacer;

### DIFF
--- a/pkg/application/app.go
+++ b/pkg/application/app.go
@@ -36,7 +36,7 @@ func Default(options ...Option) kernel.Kernel {
 		WithConfigErrorHandlers(defaultErrorHandler),
 		WithConfigFile("./config.dist.yml", "yml"),
 		WithConfigFileFlag,
-		WithConfigEnvKeyReplacer(strings.NewReplacer(".", "_")),
+		WithConfigEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_")),
 		WithConfigSanitizers(cfg.TimeSanitizer),
 		WithLoggerFormat(mon.FormatGelfFields),
 		WithLoggerApplicationTag,

--- a/pkg/application/app_test.go
+++ b/pkg/application/app_test.go
@@ -1,0 +1,68 @@
+package application_test
+
+import (
+	"context"
+	"github.com/applike/gosoline/pkg/application"
+	"github.com/applike/gosoline/pkg/cfg"
+	"github.com/applike/gosoline/pkg/kernel"
+	"github.com/applike/gosoline/pkg/mon"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+type testSettings struct {
+	Field string `cfg:"field" default:"def"`
+}
+
+type testModule struct {
+	kernel.EssentialModule
+	t *testing.T
+}
+
+func (m testModule) Boot(config cfg.Config, _ mon.Logger) error {
+	settings := &testSettings{}
+	config.UnmarshalKey("test.settings-struct", settings)
+
+	assert.Equal(m.t, "value", settings.Field)
+
+	return nil
+}
+
+func (m testModule) Run(_ context.Context) error {
+	return nil
+}
+
+func TestDefaultConfigParser(t *testing.T) {
+	err := os.Setenv("TEST_SETTINGS_STRUCT_FIELD", "value")
+	assert.NoError(t, err)
+
+	runTestApp(t, func() {
+		app := application.Default()
+		app.Add("test", testModule{
+			t: t,
+		})
+		app.Run()
+	})
+}
+
+func runTestApp(t *testing.T, f func()) {
+	oldDir, err := os.Getwd()
+	assert.NoError(t, err)
+
+	err = os.Chdir("testdata")
+	assert.NoError(t, err)
+
+	defer func() {
+		err := os.Chdir(oldDir)
+		assert.NoError(t, err)
+	}()
+
+	args := os.Args
+	os.Args = []string{os.Args[0]}
+	defer func() {
+		os.Args = args
+	}()
+
+	f()
+}

--- a/pkg/application/testdata/config.dist.yml
+++ b/pkg/application/testdata/config.dist.yml
@@ -1,0 +1,5 @@
+env: test
+
+app_name: test_app
+app_project: test_project
+app_family: test_family


### PR DESCRIPTION
If you have a key like `redis.your-component.address`, we need to map
the environment variable `REDIS_YOUR_COMPONENT_ADDRESS` to it. The dash
was not replaced before and thus you would have needed to set
`REDIS_YOUR-COMPONENT_ADDRESS`.