### PR TITLE
stream: configure unmarshall

### DIFF
--- a/pkg/stream/input_configurable.go
+++ b/pkg/stream/input_configurable.go
@@ -186,6 +186,7 @@ type sqsInputConfiguration struct {
 	RedrivePolicy     sqs.RedrivePolicy     `cfg:"redrive_policy"`
 	Client            cloud.ClientSettings  `cfg:"client"`
 	Backoff           cloud.BackoffSettings `cfg:"backoff"`
+	Unmarshaller      string                `cfg:"unmarshaller" default:"msg"`
 }
 
 func newSqsInputFromConfig(config cfg.Config, logger mon.Logger, name string) Input {
@@ -207,6 +208,7 @@ func newSqsInputFromConfig(config cfg.Config, logger mon.Logger, name string) In
 		RedrivePolicy:     configuration.RedrivePolicy,
 		Client:            configuration.Client,
 		Backoff:           configuration.Backoff,
+		Unmarshaller:      configuration.Unmarshaller,
 	}
 
 	return NewSqsInput(config, logger, settings)

--- a/pkg/stream/input_sns.go
+++ b/pkg/stream/input_sns.go
@@ -41,8 +41,8 @@ func NewSnsInput(config cfg.Config, logger mon.Logger, s SnsInputSettings, targe
 		RedrivePolicy:     s.RedrivePolicy,
 		Client:            s.Client,
 		Backoff:           s.Backoff,
+		Unmarshaller:      UnmarshallerSns,
 	})
-	sqsInput.SetUnmarshaler(SnsUnmarshaler)
 
 	queueArn := sqsInput.GetQueueArn()
 

--- a/pkg/stream/input_sqs.go
+++ b/pkg/stream/input_sqs.go
@@ -48,16 +48,9 @@ func NewSqsInput(config cfg.Config, logger mon.Logger, s SqsInputSettings) *sqsI
 		Backoff:           s.Backoff,
 	})
 
-	var unmarshaller UnmarshallerFunc
+	unmarshaller, ok := unmarshallers[s.Unmarshaller]
 
-	switch s.Unmarshaller {
-	case UnmarshallerMsg:
-		unmarshaller = MessageUnmarshaller
-	case UnmarshallerRaw:
-		unmarshaller = RawUnmarshaller
-	case UnmarshallerSns:
-		unmarshaller = SnsUnmarshaller
-	default:
+	if !ok {
 		logger.Fatal(fmt.Errorf("unknown unmarshaller %s", s.Unmarshaller), "")
 	}
 

--- a/pkg/stream/input_sqs_test.go
+++ b/pkg/stream/input_sqs_test.go
@@ -40,7 +40,7 @@ func TestSqsInput_Run(t *testing.T) {
 		}
 	}, nil)
 
-	input := stream.NewSqsInputWithInterfaces(logger, queue, stream.SqsInputSettings{
+	input := stream.NewSqsInputWithInterfaces(logger, queue, stream.MessageUnmarshaller, stream.SqsInputSettings{
 		WaitTime:    int64(3),
 		RunnerCount: 3,
 	})
@@ -88,7 +88,7 @@ func TestSqsInput_Run_Failure(t *testing.T) {
 		return []*sqs.Message{}
 	}, nil)
 
-	input := stream.NewSqsInputWithInterfaces(logger, queue, stream.SqsInputSettings{
+	input := stream.NewSqsInputWithInterfaces(logger, queue, stream.MessageUnmarshaller, stream.SqsInputSettings{
 		WaitTime:    int64(3),
 		RunnerCount: 3,
 	})

--- a/pkg/stream/unmarshal.go
+++ b/pkg/stream/unmarshal.go
@@ -14,6 +14,12 @@ const (
 
 type UnmarshallerFunc func(data *string) (*Message, error)
 
+var unmarshallers = map[string]UnmarshallerFunc{
+	UnmarshallerMsg: MessageUnmarshaller,
+	UnmarshallerRaw: RawUnmarshaller,
+	UnmarshallerSns: SnsUnmarshaller,
+}
+
 func MessageUnmarshaller(data *string) (*Message, error) {
 	msg := Message{}
 	err := msg.UnmarshalFromString(*data)

--- a/pkg/stream/unmarshal.go
+++ b/pkg/stream/unmarshal.go
@@ -6,13 +6,25 @@ import (
 	"github.com/applike/gosoline/pkg/sns"
 )
 
-type MessageUnmarshaler func(data *string) (*Message, error)
+const (
+	UnmarshallerMsg = "msg"
+	UnmarshallerRaw = "raw"
+	UnmarshallerSns = "sns"
+)
 
-func BasicUnmarshaler(data *string) (*Message, error) {
+type UnmarshallerFunc func(data *string) (*Message, error)
+
+func MessageUnmarshaller(data *string) (*Message, error) {
 	msg := Message{}
 	err := msg.UnmarshalFromString(*data)
 
 	return &msg, err
+}
+
+func RawUnmarshaller(data *string) (*Message, error) {
+	return &Message{
+		Body: *data,
+	}, nil
 }
 
 func SnsMarshaller(msg *Message) (*string, error) {
@@ -37,7 +49,7 @@ func SnsMarshaller(msg *Message) (*string, error) {
 	return &data, nil
 }
 
-func SnsUnmarshaler(data *string) (*Message, error) {
+func SnsUnmarshaller(data *string) (*Message, error) {
 	bytes := []byte(*data)
 
 	snsMessage := sns.Message{}


### PR DESCRIPTION
Not all stream messages have the message format. Added a configuration mechanism to the unmarshalling of stream inputs.