### PR TITLE
mon: added WithChannel, WithContext and WithFields to ContextEnforcingLogger;

### DIFF
--- a/pkg/mon/logger_context_enforce_test.go
+++ b/pkg/mon/logger_context_enforce_test.go
@@ -41,6 +41,16 @@ func (s *ContextEnforcingLoggerTestSuite) TestInfoWithoutContext() {
 	s.Equal("00:00:00.000 context_missing warn    you should add the context to your logger:mocked trace\n00:00:00.000 default info    this is a info message\n", s.output.String())
 }
 
+func (s *ContextEnforcingLoggerTestSuite) TestInfoWithoutContextWithChannel() {
+	s.logger.WithChannel("channel").Info("this is a info message")
+	s.Equal("00:00:00.000 context_missing warn    you should add the context to your logger:mocked trace\n00:00:00.000 channel info    this is a info message\n", s.output.String())
+}
+
+func (s *ContextEnforcingLoggerTestSuite) TestInfoWithoutContextWithFields() {
+	s.logger.WithFields(mon.Fields{}).Info("this is a info message")
+	s.Equal("00:00:00.000 context_missing warn    you should add the context to your logger:mocked trace\n00:00:00.000 default info    this is a info message\n", s.output.String())
+}
+
 func (s *ContextEnforcingLoggerTestSuite) TestDebugWithoutContext() {
 	s.logger.Debug("this is a info message")
 	s.Empty(s.output.String())


### PR DESCRIPTION
In the past, the ContextEnforcingLogger would happily catch errors like
h.logger.Info(), but it failed on h.logger.WithFields(...).Info(). The
reason was that WithFields would go to the embedded logger interface and
invoke *mon.Logger.WithFields which would return a plain *mon.logger. We
now catch these cases and return a wrapped logger again. For WithContext
we can actually drop our context check as we now know the logger is
using a context.