### PR TITLE
ddb: fix parsing of json tags for ddb key and hash fields;

### DIFF
--- a/pkg/ddb/metadata_factory_test.go
+++ b/pkg/ddb/metadata_factory_test.go
@@ -7,11 +7,77 @@ import (
 )
 
 type TestModel struct {
-	MyName         int `json:"myName"`
-	MyNameWithAttr int `json:"myNameWithAttr,omitempty"`
-	MyNamePlain    int `json:",omitempty"`
-	MyIgnoredField int `json:"-"`
-	DashField      int `json:"-,"`
+	MyName         int    `json:"myName" ddb:"key=hash"`
+	MyNameWithAttr string `json:"myNameWithAttr,omitempty" ddb:"global=hash"`
+	MyNamePlain    string `json:",omitempty" ddb:"key=range"`
+	MyIgnoredField int64  `json:"-"`
+	DashField      int    `json:"-," ddb:"global=range"`
+	DefaultField   uint   `ddb:"global=range"`
+}
+
+type TestModelEmptyDDB struct {
+	Field int `ddb:""`
+}
+
+type TestModelNoKV struct {
+	Field int `ddb:"not a value"`
+}
+
+type TestModelEmptyJSON struct {
+	Field int `json:"" ddb:"key=hash"`
+}
+
+func TestReadAttributes(t *testing.T) {
+	attributes, err := ddb.ReadAttributes(TestModel{})
+	assert.NoError(t, err)
+	assert.Equal(t, ddb.Attributes{
+		"myName": &ddb.Attribute{
+			FieldName:     "MyName",
+			AttributeName: "myName",
+			Tags: map[string]string{
+				"key": "hash",
+			},
+			Type: "N",
+		},
+		"myNameWithAttr": &ddb.Attribute{
+			FieldName:     "MyNameWithAttr",
+			AttributeName: "myNameWithAttr",
+			Tags: map[string]string{
+				"global": "hash",
+			},
+			Type: "S",
+		},
+		"MyNamePlain": &ddb.Attribute{
+			FieldName:     "MyNamePlain",
+			AttributeName: "MyNamePlain",
+			Tags: map[string]string{
+				"key": "range",
+			},
+			Type: "S",
+		},
+		"-": &ddb.Attribute{
+			FieldName:     "DashField",
+			AttributeName: "-",
+			Tags: map[string]string{
+				"global": "range",
+			},
+			Type: "N",
+		},
+		"DefaultField": &ddb.Attribute{
+			FieldName:     "DefaultField",
+			AttributeName: "DefaultField",
+			Tags: map[string]string{
+				"global": "range",
+			},
+			Type: "N",
+		},
+	}, attributes)
+	_, err = ddb.ReadAttributes(TestModelEmptyDDB{})
+	assert.Error(t, err)
+	_, err = ddb.ReadAttributes(TestModelEmptyJSON{})
+	assert.Error(t, err)
+	_, err = ddb.ReadAttributes(TestModelNoKV{})
+	assert.Error(t, err)
 }
 
 func TestMetadataReadFields(t *testing.T) {
@@ -23,5 +89,8 @@ func TestMetadataReadFields(t *testing.T) {
 		"MyNamePlain",
 		// MyIgnoredField is... ignored, so there is no entry for it
 		"-",
+		"DefaultField",
 	}, fields)
+	_, err = ddb.MetadataReadFields(TestModelEmptyJSON{})
+	assert.Error(t, err)
 }


### PR DESCRIPTION
Suppose you have a struct like this:

type MyStruct struct {
    Field string `json:"field,omitempty" ddb:"global=hash"`
}

Previously gosoline would think the json tag for Field would be
"field,omitempty". This is however not what the programmer intended and
thus needs to resolve to "field" instead. Therefore this commit changes
the way we parse these tags to account for these kinds of tags.