### PR TITLE
kvstore: refactored error handling and made chain store return useful results if you are caching missing values;

### DIFF
--- a/pkg/apiserver/auth/token_bearer_test.go
+++ b/pkg/apiserver/auth/token_bearer_test.go
@@ -42,7 +42,7 @@ func makeKvStoreProvider(test *tokenBearerTestCase) (auth.TokenBearerProvider, [
 	repo := new(kvStoreMocks.KvStore)
 
 	if test.bearerId != "" && test.token != "" {
-		repo.On("Get", context.TODO(), test.bearerId, &bearer{}).Run(func(args mock.Arguments) {
+		repo.On("Get", context.Background(), test.bearerId, &bearer{}).Run(func(args mock.Arguments) {
 			m := args.Get(2).(*bearer)
 
 			if test.bearer != nil {
@@ -51,7 +51,7 @@ func makeKvStoreProvider(test *tokenBearerTestCase) (auth.TokenBearerProvider, [
 		}).Return(test.bearer != nil, test.bearerErr).Once()
 	}
 
-	return auth.ProvideTokenBearerFromKVStore(repo, func() auth.TokenBearer {
+	return auth.ProvideTokenBearerFromGetter(repo, func() auth.TokenBearer {
 		return &bearer{}
 	}), []hasExpectations{repo}
 }
@@ -67,7 +67,7 @@ func makeDdbProvider(test *tokenBearerTestCase) (auth.TokenBearerProvider, []has
 
 		repo.On("GetItemBuilder").Return(builder).Once()
 
-		repo.On("GetItem", context.TODO(), builder, &bearer{}).Run(func(args mock.Arguments) {
+		repo.On("GetItem", context.Background(), builder, &bearer{}).Run(func(args mock.Arguments) {
 			m := args.Get(2).(*bearer)
 
 			if test.bearer != nil {

--- a/pkg/kvstore/batch.go
+++ b/pkg/kvstore/batch.go
@@ -25,7 +25,6 @@ func keyChunks(keys []interface{}, size int) [][]interface{} {
 type chunkGetter func(ctx context.Context, resultMap *refl.Map, keys []interface{}) ([]interface{}, error)
 
 func getBatch(ctx context.Context, keys interface{}, result interface{}, getChunk chunkGetter, batchSize int) ([]interface{}, error) {
-	missing := make([]interface{}, 0)
 	keySlice, err := refl.InterfaceToInterfaceSlice(keys)
 
 	if err != nil {
@@ -49,6 +48,7 @@ func getBatch(ctx context.Context, keys interface{}, result interface{}, getChun
 	}
 
 	chunks := keyChunks(keySlice, batchSize)
+	missing := make([]interface{}, 0)
 
 	for _, chunk := range chunks {
 		miss, err := getChunk(ctx, resultMap, chunk)

--- a/pkg/kvstore/ddb_test.go
+++ b/pkg/kvstore/ddb_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/applike/gosoline/pkg/ddb"
 	ddbMocks "github.com/applike/gosoline/pkg/ddb/mocks"
 	"github.com/applike/gosoline/pkg/kvstore"
-	monMocks "github.com/applike/gosoline/pkg/mon/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"testing"
@@ -238,10 +237,9 @@ func TestDdbKvStore_PutBatch(t *testing.T) {
 }
 
 func buildTestableDdbStore() (*kvstore.DdbKvStore, *ddbMocks.Repository) {
-	logger := monMocks.NewLoggerMockedAll()
 	repository := new(ddbMocks.Repository)
 
-	store := kvstore.NewDdbKvStoreWithInterfaces(logger, repository, &kvstore.Settings{
+	store := kvstore.NewDdbKvStoreWithInterfaces(repository, &kvstore.Settings{
 		AppId: cfg.AppId{
 			Project:     "applike",
 			Environment: "test",

--- a/pkg/kvstore/empty.go
+++ b/pkg/kvstore/empty.go
@@ -2,6 +2,7 @@ package kvstore
 
 import (
 	"context"
+	"fmt"
 	"github.com/applike/gosoline/pkg/refl"
 )
 
@@ -28,16 +29,16 @@ func (s *EmptyKvStore) GetBatch(_ context.Context, keys interface{}, _ interface
 	missing, err := refl.InterfaceToInterfaceSlice(keys)
 
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("could not convert keys from %T to []interface{}", keys)
 	}
 
 	return missing, nil
 }
 
-func (s *EmptyKvStore) Put(_ context.Context, key interface{}, value interface{}) error {
+func (s *EmptyKvStore) Put(_ context.Context, _ interface{}, _ interface{}) error {
 	return nil
 }
 
-func (s *EmptyKvStore) PutBatch(ctx context.Context, values interface{}) error {
+func (s *EmptyKvStore) PutBatch(_ context.Context, _ interface{}) error {
 	return nil
 }

--- a/pkg/kvstore/kvstore.go
+++ b/pkg/kvstore/kvstore.go
@@ -19,10 +19,19 @@ type Settings struct {
 
 //go:generate mockery -name KvStore
 type KvStore interface {
+	// Check if a key exists in the store.
 	Contains(ctx context.Context, key interface{}) (bool, error)
+	// Retrieve a value from the store by the given key. If the value does
+	// not exist, false is returned and value is not modified.
+	// value should be a pointer to the model you want to retrieve.
 	Get(ctx context.Context, key interface{}, value interface{}) (bool, error)
+	// Retrieve a set of values from the store. Each value is written to the
+	// map in values at its key. Returns a list of missing keys in the store.
 	GetBatch(ctx context.Context, keys interface{}, values interface{}) ([]interface{}, error)
+	// Write a value to the store
 	Put(ctx context.Context, key interface{}, value interface{}) error
+	// Write a batch of values to the store. Values should be something which
+	// can be converted to map[interface{}]interface{}.
 	PutBatch(ctx context.Context, values interface{}) error
 }
 

--- a/pkg/kvstore/redis_test.go
+++ b/pkg/kvstore/redis_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"github.com/applike/gosoline/pkg/cfg"
 	"github.com/applike/gosoline/pkg/kvstore"
-	monMocks "github.com/applike/gosoline/pkg/mon/mocks"
 	redisMocks "github.com/applike/gosoline/pkg/redis/mocks"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -110,10 +109,9 @@ func TestRedisKvStore_PutBatch(t *testing.T) {
 }
 
 func buildTestableRedisStore() (*kvstore.RedisKvStore, *redisMocks.Client) {
-	logger := monMocks.NewLoggerMockedAll()
 	client := new(redisMocks.Client)
 
-	store := kvstore.NewRedisKvStoreWithInterfaces(logger, client, &kvstore.Settings{
+	store := kvstore.NewRedisKvStoreWithInterfaces(client, &kvstore.Settings{
 		AppId: cfg.AppId{
 			Project:     "applike",
 			Environment: "test",

--- a/pkg/kvstore/uniq.go
+++ b/pkg/kvstore/uniq.go
@@ -13,7 +13,7 @@ func UniqKeys(keys []interface{}) ([]interface{}, error) {
 		keyString, err := CastKeyToString(keys[i])
 
 		if err != nil {
-			return nil, fmt.Errorf("can not build string key: %w", err)
+			return nil, fmt.Errorf("can not build string key from %T %v: %w", keys[i], keys[i], err)
 		}
 
 		if _, ok := seen[keyString]; ok {

--- a/pkg/kvstore/uniq_test.go
+++ b/pkg/kvstore/uniq_test.go
@@ -26,3 +26,14 @@ func TestUniqKeys_IntegerKeys(t *testing.T) {
 	assert.Contains(t, uniqKeys, 1)
 	assert.Contains(t, uniqKeys, 2)
 }
+
+func TestUniqKeys_MixedKeys(t *testing.T) {
+	keys := []interface{}{1, "2", "1"}
+
+	uniqKeys, err := UniqKeys(keys)
+
+	assert.NoError(t, err)
+	assert.Len(t, uniqKeys, 2)
+	assert.Contains(t, uniqKeys, 1)
+	assert.Contains(t, uniqKeys, "2")
+}


### PR DESCRIPTION
In the past, we would return that a value is not missing should the
missingCache contain it and instead return write an empty value to the
out parameter. However, this proved to be a mistake as you would now
have to check whether something was found and whether that something was
actually a valid value. Instead, we now transparently return "nothing
was found" should the cache tell us that we don't need to check for the
value, so there is no difference on the API anymore whether missing
value caching is enabled or not.