### PR TITLE
parquet: added two more dimensions to configure the partitioner;

### DIFF
--- a/pkg/parquet/partitioner.go
+++ b/pkg/parquet/partitioner.go
@@ -35,11 +35,20 @@ type memoryPartitioner struct {
 
 	partitions     map[float64]*Partition
 	partitionCount int
-	interval       time.Duration
+
+	partitionInterval time.Duration
+	bufferInterval    time.Duration
+	maxPartitionSize  int
 }
 
 type PartitionerSettings struct {
-	Interval time.Duration `cfg:"interval"`
+	// at what granularity do we divide the data into partitions? Needs to be at least 1 second.
+	PartitionInterval time.Duration `cfg:"partition_interval" default:"900s" validate:"min=1000000000"`
+	// how long do we buffer elements before we write them out even when the partition
+	// is not yet full. Needs to be at least 1 second.
+	BufferInterval time.Duration `cfg:"buffer_interval" default:"900s" validate:"min=1000000000"`
+	// how many elements can a partition have before we have to flush it (to avoid excessive memory usage)
+	MaxPartitionSize int `cfg:"max_partition_size" default:"50000" validate:"min=1"`
 }
 
 func NewPartitioner(settings *PartitionerSettings) Partitioner {
@@ -48,13 +57,15 @@ func NewPartitioner(settings *PartitionerSettings) Partitioner {
 
 func NewPartitionerWithInterfaces(clock clock.Clock, settings *PartitionerSettings) Partitioner {
 	return &memoryPartitioner{
-		clock:          clock,
-		ticker:         time.NewTicker(settings.Interval),
-		interval:       settings.Interval,
-		outputChannel:  make(chan *Partition),
-		partitions:     map[float64]*Partition{},
-		partitionCount: 0,
-		stop:           make(chan struct{}),
+		clock:             clock,
+		ticker:            time.NewTicker(settings.BufferInterval),
+		partitionInterval: settings.PartitionInterval,
+		bufferInterval:    settings.BufferInterval,
+		maxPartitionSize:  settings.MaxPartitionSize,
+		outputChannel:     make(chan *Partition),
+		partitions:        map[float64]*Partition{},
+		partitionCount:    0,
+		stop:              make(chan struct{}),
 	}
 }
 
@@ -69,8 +80,8 @@ func (p *memoryPartitioner) Ingest(data Partitionable) {
 	timezone := data.GetPartitionTimestamp().Location()
 	timestamp := data.GetPartitionTimestamp().Unix()
 
-	partition := math.Floor(float64(timestamp) / p.interval.Seconds())
-	partitionTimestamp := int64(partition * p.interval.Seconds())
+	partition := math.Floor(float64(timestamp) / p.partitionInterval.Seconds())
+	partitionTimestamp := int64(partition * p.partitionInterval.Seconds())
 
 	if _, ok := p.partitions[partition]; !ok {
 		p.partitions[partition] = &Partition{
@@ -85,6 +96,13 @@ func (p *memoryPartitioner) Ingest(data Partitionable) {
 
 	p.partitions[partition].Elements = append(p.partitions[partition].Elements, data)
 	p.partitions[partition].LastUpdatedAt = p.clock.Now()
+
+	if len(p.partitions[partition].Elements) >= p.maxPartitionSize {
+		p.outputChannel <- p.partitions[partition]
+
+		delete(p.partitions, partition)
+		p.partitionCount--
+	}
 }
 
 func (p *memoryPartitioner) Out() <-chan *Partition {
@@ -158,7 +176,7 @@ func (p *memoryPartitioner) flush(force bool) {
 	for key, part := range p.partitions {
 		age := now.Sub(part.StartedAt)
 
-		if age < p.interval && !force {
+		if age < p.bufferInterval && !force {
 			continue
 		}
 

--- a/pkg/parquet/partitioner_test.go
+++ b/pkg/parquet/partitioner_test.go
@@ -19,7 +19,9 @@ func (t *testDataType) GetPartitionTimestamp() time.Time {
 func TestNewPartitioner(t *testing.T) {
 	assert.NotPanics(t, func() {
 		settings := &parquet.PartitionerSettings{
-			Interval: time.Duration(1) * time.Second,
+			PartitionInterval: time.Second,
+			BufferInterval:    time.Second,
+			MaxPartitionSize:  10,
 		}
 		parquet.NewPartitioner(settings)
 	})
@@ -28,7 +30,9 @@ func TestNewPartitioner(t *testing.T) {
 func TestMemoryPartitioner_Ingest(t *testing.T) {
 	clock := clockwork.NewFakeClockAt(time.Unix(1578500000, 0))
 	partitioner := parquet.NewPartitionerWithInterfaces(clock, &parquet.PartitionerSettings{
-		Interval: 2 * time.Second,
+		PartitionInterval: 2 * time.Second,
+		BufferInterval:    2 * time.Second,
+		MaxPartitionSize:  10,
 	})
 
 	// now creating a new partition
@@ -65,7 +69,9 @@ func TestMemoryPartitioner_Ingest(t *testing.T) {
 
 func TestMemoryPartitioner_StartStop(t *testing.T) {
 	settings := &parquet.PartitionerSettings{
-		Interval: time.Duration(1) * time.Second,
+		PartitionInterval: time.Second,
+		BufferInterval:    time.Second,
+		MaxPartitionSize:  10,
 	}
 	partitioner := parquet.NewPartitioner(settings)
 
@@ -84,7 +90,9 @@ func (t testEvent) GetPartitionTimestamp() time.Time {
 
 func TestMemoryPartitioner_ReceivesAll(t *testing.T) {
 	settings := &parquet.PartitionerSettings{
-		Interval: time.Millisecond * 10,
+		PartitionInterval: time.Millisecond * 10,
+		BufferInterval:    time.Millisecond * 10,
+		MaxPartitionSize:  10_000,
 	}
 	partitioner := parquet.NewPartitioner(settings)
 	partitioner.Start()


### PR DESCRIPTION
You can now specify how large a partition may grow before getting
flushed as well as how the day is divided into partitions. Previously,
only the interval in which partitions got written was specified and also
served as the division of the day into partitions. So if you had your
interval set to 15min and got an event for 8am and 2pm, they ended up in
separate partitions and were then flushed around 15 minutes later. Now
you could for example put a whole day into the same partition and still
write out every 15 minutes, so the two events would end up in the same
partition.