### PR TITLE
mon: replace WithFields(MSI) with WithFields(Fields);

### DIFF
--- a/pkg/cloud/aws_clients_test.go
+++ b/pkg/cloud/aws_clients_test.go
@@ -3,6 +3,7 @@ package cloud_test
 import (
 	configMocks "github.com/applike/gosoline/pkg/cfg/mocks"
 	"github.com/applike/gosoline/pkg/cloud"
+	"github.com/applike/gosoline/pkg/mon"
 	monMocks "github.com/applike/gosoline/pkg/mon/mocks"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -46,7 +47,7 @@ func TestGetServiceDiscoveryClient(t *testing.T) {
 
 func TestPrefixedLogger(t *testing.T) {
 	l := monMocks.NewLoggerMock()
-	l.On("WithFields", map[string]interface{}{
+	l.On("WithFields", mon.Fields{
 		"aws_service": "myService",
 	}).Return(l)
 	l.On("Info", "log")

--- a/pkg/mon/logger.go
+++ b/pkg/mon/logger.go
@@ -73,20 +73,22 @@ type GosoLog interface {
 //go:generate mockery -name Logger
 type Logger interface {
 	Debug(args ...interface{})
-	Debugf(msg string, args ...interface{})
-	Error(err error, msg string)
-	Errorf(err error, msg string, args ...interface{})
-	Fatal(err error, msg string)
-	Fatalf(err error, msg string, args ...interface{})
 	Info(args ...interface{})
-	Infof(msg string, args ...interface{})
-	Panic(err error, msg string)
-	Panicf(err error, msg string, args ...interface{})
 	Warn(args ...interface{})
-	Warnf(msg string, args ...interface{})
+	Error(err error, msg string)
+	Panic(err error, msg string)
+	Fatal(err error, msg string)
+
+	Debugf(format string, args ...interface{})
+	Infof(format string, args ...interface{})
+	Warnf(format string, args ...interface{})
+	Errorf(err error, format string, args ...interface{})
+	Panicf(err error, format string, args ...interface{})
+	Fatalf(err error, format string, args ...interface{})
+
 	WithChannel(channel string) Logger
 	WithContext(ctx context.Context) Logger
-	WithFields(fields map[string]interface{}) Logger
+	WithFields(fields Fields) Logger
 }
 
 type logger struct {
@@ -175,7 +177,7 @@ func (l *logger) WithContext(ctx context.Context) Logger {
 	return cpy
 }
 
-func (l *logger) WithFields(fields map[string]interface{}) Logger {
+func (l *logger) WithFields(fields Fields) Logger {
 	cpy := l.copy()
 	cpy.data.Fields = mergeMapStringInterface(l.data.Fields, fields)
 

--- a/pkg/mon/logger_context_enforce.go
+++ b/pkg/mon/logger_context_enforce.go
@@ -105,7 +105,7 @@ func (l *ContextEnforcingLogger) WithContext(ctx context.Context) Logger {
 	return l.logger.WithContext(ctx)
 }
 
-func (l *ContextEnforcingLogger) WithFields(fields map[string]interface{}) Logger {
+func (l *ContextEnforcingLogger) WithFields(fields Fields) Logger {
 	return &ContextEnforcingLogger{
 		logger:             l.logger.WithFields(fields),
 		stacktraceProvider: l.stacktraceProvider,

--- a/pkg/mon/logger_sampling.go
+++ b/pkg/mon/logger_sampling.go
@@ -49,7 +49,7 @@ func (l *SamplingLogger) WithContext(ctx context.Context) Logger {
 	return l.copy(logger)
 }
 
-func (l *SamplingLogger) WithFields(fields map[string]interface{}) Logger {
+func (l *SamplingLogger) WithFields(fields Fields) Logger {
 	logger := l.Logger.WithFields(fields)
 	return l.copy(logger)
 }

--- a/pkg/mon/mocks/Logger.go
+++ b/pkg/mon/mocks/Logger.go
@@ -18,10 +18,10 @@ func (_m *Logger) Debug(args ...interface{}) {
 	_m.Called(_ca...)
 }
 
-// Debugf provides a mock function with given fields: msg, args
-func (_m *Logger) Debugf(msg string, args ...interface{}) {
+// Debugf provides a mock function with given fields: format, args
+func (_m *Logger) Debugf(format string, args ...interface{}) {
 	var _ca []interface{}
-	_ca = append(_ca, msg)
+	_ca = append(_ca, format)
 	_ca = append(_ca, args...)
 	_m.Called(_ca...)
 }
@@ -31,10 +31,10 @@ func (_m *Logger) Error(err error, msg string) {
 	_m.Called(err, msg)
 }
 
-// Errorf provides a mock function with given fields: err, msg, args
-func (_m *Logger) Errorf(err error, msg string, args ...interface{}) {
+// Errorf provides a mock function with given fields: err, format, args
+func (_m *Logger) Errorf(err error, format string, args ...interface{}) {
 	var _ca []interface{}
-	_ca = append(_ca, err, msg)
+	_ca = append(_ca, err, format)
 	_ca = append(_ca, args...)
 	_m.Called(_ca...)
 }
@@ -44,10 +44,10 @@ func (_m *Logger) Fatal(err error, msg string) {
 	_m.Called(err, msg)
 }
 
-// Fatalf provides a mock function with given fields: err, msg, args
-func (_m *Logger) Fatalf(err error, msg string, args ...interface{}) {
+// Fatalf provides a mock function with given fields: err, format, args
+func (_m *Logger) Fatalf(err error, format string, args ...interface{}) {
 	var _ca []interface{}
-	_ca = append(_ca, err, msg)
+	_ca = append(_ca, err, format)
 	_ca = append(_ca, args...)
 	_m.Called(_ca...)
 }
@@ -59,10 +59,10 @@ func (_m *Logger) Info(args ...interface{}) {
 	_m.Called(_ca...)
 }
 
-// Infof provides a mock function with given fields: msg, args
-func (_m *Logger) Infof(msg string, args ...interface{}) {
+// Infof provides a mock function with given fields: format, args
+func (_m *Logger) Infof(format string, args ...interface{}) {
 	var _ca []interface{}
-	_ca = append(_ca, msg)
+	_ca = append(_ca, format)
 	_ca = append(_ca, args...)
 	_m.Called(_ca...)
 }
@@ -72,10 +72,10 @@ func (_m *Logger) Panic(err error, msg string) {
 	_m.Called(err, msg)
 }
 
-// Panicf provides a mock function with given fields: err, msg, args
-func (_m *Logger) Panicf(err error, msg string, args ...interface{}) {
+// Panicf provides a mock function with given fields: err, format, args
+func (_m *Logger) Panicf(err error, format string, args ...interface{}) {
 	var _ca []interface{}
-	_ca = append(_ca, err, msg)
+	_ca = append(_ca, err, format)
 	_ca = append(_ca, args...)
 	_m.Called(_ca...)
 }
@@ -87,10 +87,10 @@ func (_m *Logger) Warn(args ...interface{}) {
 	_m.Called(_ca...)
 }
 
-// Warnf provides a mock function with given fields: msg, args
-func (_m *Logger) Warnf(msg string, args ...interface{}) {
+// Warnf provides a mock function with given fields: format, args
+func (_m *Logger) Warnf(format string, args ...interface{}) {
 	var _ca []interface{}
-	_ca = append(_ca, msg)
+	_ca = append(_ca, format)
 	_ca = append(_ca, args...)
 	_m.Called(_ca...)
 }
@@ -128,11 +128,11 @@ func (_m *Logger) WithContext(ctx context.Context) mon.Logger {
 }
 
 // WithFields provides a mock function with given fields: fields
-func (_m *Logger) WithFields(fields map[string]interface{}) mon.Logger {
+func (_m *Logger) WithFields(fields mon.Fields) mon.Logger {
 	ret := _m.Called(fields)
 
 	var r0 mon.Logger
-	if rf, ok := ret.Get(0).(func(map[string]interface{}) mon.Logger); ok {
+	if rf, ok := ret.Get(0).(func(mon.Fields) mon.Logger); ok {
 		r0 = rf(fields)
 	} else {
 		if ret.Get(0) != nil {

--- a/pkg/tracing/context_missing.go
+++ b/pkg/tracing/context_missing.go
@@ -33,7 +33,7 @@ func NewContextMissingWarningLogStrategy(logger mon.Logger) *ContextMissingWarnS
 func (c ContextMissingWarnStrategy) ContextMissing(v interface{}) {
 	stacktrace := mon.GetStackTrace(2)
 
-	c.logger.WithFields(map[string]interface{}{
+	c.logger.WithFields(mon.Fields{
 		"stacktrace": stacktrace,
 	}).Warnf("can not trace the action: %s", v)
 }

--- a/pkg/tracing/message_encode_handler_test.go
+++ b/pkg/tracing/message_encode_handler_test.go
@@ -52,7 +52,7 @@ func TestMessageWithTraceEncoder_Decode_Warning(t *testing.T) {
 	}
 
 	logger := new(mocks.Logger)
-	logger.On("WithFields", map[string]interface{}{
+	logger.On("WithFields", mon.Fields{
 		"stacktrace": "mocked trace",
 	}).Return(logger).Once()
 	logger.On("Warnf", "trace id is invalid: %s", "the traceId attribute is invalid: the trace id [1-5e3d557d-d06c248cc50169bd71b44fec] should consist of at least 2 parts")

--- a/pkg/tracing/trace_id_invalid_strategy.go
+++ b/pkg/tracing/trace_id_invalid_strategy.go
@@ -37,7 +37,7 @@ func NewTraceIdErrorWarningStrategyWithInterfaces(logger mon.Logger, stacktraceP
 func (t TraceIdErrorWarningStrategy) TraceIdInvalid(err error) error {
 	stacktrace := t.stacktraceProvider(2)
 
-	t.logger.WithFields(map[string]interface{}{
+	t.logger.WithFields(mon.Fields{
 		"stacktrace": stacktrace,
 	}).Warnf("trace id is invalid: %s", err.Error())
 


### PR DESCRIPTION
WithFields used to accept any map[string]interface{}, but was almost
always called with mon.Fields instead. While the two types are
compatible and client code should not be affected, tests who check what
gets logged are. In those you were in the awkward situation that you
passed mon.Fields in your code under test, but the mock needed to listen
for map[string]interface{}, or it would not match. This is no longer the
case.