### PR TITLE
db: added max idle conns and max open conns config option;

### DIFF
--- a/pkg/db/connection.go
+++ b/pkg/db/connection.go
@@ -20,9 +20,11 @@ type Uri struct {
 }
 
 type Settings struct {
-	Driver             string        `cfg:"driver"`
-	ConnectionLifetime time.Duration `cfg:"connection_lifetime" default:"120s"`
-	ParseTime          bool          `cfg:"parse_time" default:"true"`
+	ConnectionMaxLifetime time.Duration `cfg:"connection_max_lifetime" default:"120s"`
+	Driver                string        `cfg:"driver"`
+	MaxIdleConnections    int           `cfg:"max_idle_connections"` // 0=unlimited
+	MaxOpenConnections    int           `cfg:"max_open_connections"` // 0=unlimited
+	ParseTime             bool          `cfg:"parse_time" default:"true"`
 
 	Uri        Uri               `cfg:"uri"`
 	Migrations MigrationSettings `cfg:"migrations"`
@@ -98,7 +100,9 @@ func NewConnectionWithInterfaces(settings Settings) (*sqlx.DB, error) {
 		return nil, err
 	}
 
-	db.SetConnMaxLifetime(settings.ConnectionLifetime)
+	db.SetConnMaxLifetime(settings.ConnectionMaxLifetime)
+	db.SetMaxIdleConns(settings.MaxIdleConnections)
+	db.SetMaxOpenConns(settings.MaxOpenConnections)
 
 	return db, nil
 }


### PR DESCRIPTION
This should help against `connect: cannot assign requested address`. Please refer to:

http://techblog.en.klab-blogs.com/archives/31093990.html

and

http://dsas.blog.klab.org/archives/2018-02/configure-sql-db.html