### PR TITLE
stream: producer daemon;

### DIFF
--- a/docs/framework/config.all.md
+++ b/docs/framework/config.all.md
@@ -84,6 +84,13 @@ stream:
       encoding: application/json
       compression: application/gzip
       output: sqs-out
+      daemon:
+        enabled: false
+        aggregation_size: 1
+        batch_size: 10
+        buffer_size: 10
+        interval: 1m0s
+        runner_count: 10
 
   input:
     consumer-redis:

--- a/pkg/application/app.go
+++ b/pkg/application/app.go
@@ -51,6 +51,7 @@ func Default(options ...Option) kernel.Kernel {
 		WithKernelSettingsFromConfig,
 		WithApiHealthCheck,
 		WithMetricDaemon,
+		WithProducerDaemon,
 		WithTracing,
 	}
 

--- a/pkg/application/options.go
+++ b/pkg/application/options.go
@@ -269,6 +269,13 @@ func WithMetricDaemon(app *App) {
 	})
 }
 
+func WithProducerDaemon(app *App) {
+	app.addKernelOption(func(config cfg.GosoConf, kernel kernel.GosoKernel) error {
+		kernel.AddFactory(stream.ProducerDaemonFactory)
+		return nil
+	})
+}
+
 func WithTracing(app *App) {
 	app.addLoggerOption(func(config cfg.GosoConf, logger mon.GosoLog) error {
 		tracingHook := tracing.NewLoggerErrorHook()

--- a/pkg/coffin/coffin.go
+++ b/pkg/coffin/coffin.go
@@ -77,6 +77,10 @@ func New() Coffin {
 	}
 }
 
+// WithContext returns a new coffin that is killed when the provided parent
+// context is canceled, and a copy of parent with a replaced Done channel
+// that is closed when either the coffin is dying or the parent is canceled.
+// The returned context may also be obtained via the coffin's Context method.
 func WithContext(parent context.Context) (Coffin, context.Context) {
 	tmb, ctx := tomb.WithContext(parent)
 	cfn := &coffin{
@@ -150,6 +154,15 @@ func (c *coffin) GoWithContextf(ctx context.Context, f func(ctx context.Context)
 	}, msg, args...)
 }
 
+// Kill puts the coffin in a dying state for the given reason,
+// closes the Dying channel, and sets Alive to false.
+//
+// Althoguh Kill may be called multiple times, only the first
+// non-nil error is recorded as the death reason.
+//
+// If reason is ErrDying, the previous reason isn't replaced
+// even if nil. It's a runtime error to call Kill with ErrDying
+// if t is not in a dying state.
 func (c *coffin) Kill(reason error) {
 	c.tomb.Kill(reason)
 }

--- a/pkg/kernel/kernel.go
+++ b/pkg/kernel/kernel.go
@@ -323,7 +323,7 @@ func (k *kernel) boot() bool {
 func (k *kernel) runModule(name string, ms *ModuleState, ctx context.Context) error {
 	defer k.logger.Infof("stopped %s module %s", ms.Config.Type, name)
 
-	k.logger.Infof("running %s module %s", ms.Config.Type, name)
+	k.logger.Infof("running %s module %s in stage %d", ms.Config.Type, name, ms.Config.Stage)
 
 	ms.IsRunning = true
 

--- a/pkg/kernel/kernel_test.go
+++ b/pkg/kernel/kernel_test.go
@@ -29,7 +29,7 @@ func createMocks() (*cfgMocks.Config, *monMocks.Logger, *kernelMocks.FullModule)
 	logger.On("WithChannel", mock.Anything).Return(logger)
 	logger.On("WithFields", mock.Anything).Return(logger)
 	logger.On("Info", mock.Anything)
-	logger.On("Infof", mock.Anything, mock.Anything, mock.Anything)
+	logger.On("Infof", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 
 	module := new(kernelMocks.FullModule)
 	module.On("GetType").Return(kernel.TypeForeground)

--- a/pkg/stream/producer_daemon.go
+++ b/pkg/stream/producer_daemon.go
@@ -1,0 +1,354 @@
+package stream
+
+import (
+	"context"
+	"fmt"
+	"github.com/applike/gosoline/pkg/cfg"
+	"github.com/applike/gosoline/pkg/clock"
+	"github.com/applike/gosoline/pkg/coffin"
+	"github.com/applike/gosoline/pkg/kernel"
+	"github.com/applike/gosoline/pkg/mon"
+	"sync"
+	"time"
+)
+
+const (
+	AttributeAggregate      = "goso.aggregate"
+	metricNameMessageCount  = "MessageCount"
+	metricNameBatchSize     = "BatchSize"
+	metricNameAggregateSize = "AggregateSize"
+)
+
+var producerDaemonLock = sync.Mutex{}
+var producerDaemons = map[string]*ProducerDaemon{}
+
+type AggregateMarshaller func(body interface{}, attributes ...map[string]interface{}) (*Message, error)
+
+type ProducerDaemonSettings struct {
+	Enabled         bool          `cfg:"enabled" default:"false"`
+	Interval        time.Duration `cfg:"interval" default:"1m"`
+	BufferSize      int           `cfg:"buffer_size" default:"10" validate:"min=1"`
+	RunnerCount     int           `cfg:"runner_count" default:"10" validate:"min=1"`
+	BatchSize       int           `cfg:"batch_size" default:"10" validate:"min=1"`
+	AggregationSize int           `cfg:"aggregation_size" default:"1" validate:"min=1"`
+}
+
+type ProducerDaemon struct {
+	kernel.EssentialModule
+
+	name          string
+	lck           sync.Mutex
+	logger        mon.Logger
+	metric        mon.MetricWriter
+	aggregate     []WritableMessage
+	batch         []WritableMessage
+	outCh         chan []WritableMessage
+	output        Output
+	tickerFactory clock.TickerFactory
+	ticker        clock.Ticker
+	marshaller    AggregateMarshaller
+	settings      ProducerDaemonSettings
+}
+
+func ProvideProducerDaemon(config cfg.Config, logger mon.Logger, name string) *ProducerDaemon {
+	producerDaemonLock.Lock()
+	defer producerDaemonLock.Unlock()
+
+	if _, ok := producerDaemons[name]; ok {
+		return producerDaemons[name]
+	}
+
+	producerDaemons[name] = NewProducerDaemon(config, logger, name)
+
+	return producerDaemons[name]
+}
+
+func NewProducerDaemon(config cfg.Config, logger mon.Logger, name string) *ProducerDaemon {
+	key := ConfigurableProducerKey(name)
+	settings := &ProducerSettings{}
+	config.UnmarshalKey(key, settings)
+
+	defaultMetrics := getProducerDaemonDefaultMetrics(name)
+	metric := mon.NewMetricDaemonWriter(defaultMetrics...)
+
+	if settings.Output == "" {
+		settings.Output = name
+	}
+
+	output := NewConfigurableOutput(config, logger, settings.Output)
+
+	return &ProducerDaemon{
+		name:          name,
+		logger:        logger,
+		metric:        metric,
+		batch:         make([]WritableMessage, 0, settings.Daemon.BatchSize),
+		outCh:         make(chan []WritableMessage, settings.Daemon.BufferSize),
+		output:        output,
+		tickerFactory: clock.NewRealTicker,
+		marshaller:    MarshalJsonMessage,
+		settings:      settings.Daemon,
+	}
+}
+
+func NewProducerDaemonWithInterfaces(logger mon.Logger, metric mon.MetricWriter, output Output, tickerFactory clock.TickerFactory, marshaller AggregateMarshaller, name string, settings ProducerDaemonSettings) *ProducerDaemon {
+	return &ProducerDaemon{
+		name:          name,
+		logger:        logger,
+		metric:        metric,
+		batch:         make([]WritableMessage, 0, settings.BatchSize),
+		outCh:         make(chan []WritableMessage, settings.BufferSize),
+		output:        output,
+		tickerFactory: tickerFactory,
+		marshaller:    marshaller,
+		settings:      settings,
+	}
+}
+
+func (d *ProducerDaemon) GetStage() int {
+	return 512
+}
+
+func (d *ProducerDaemon) Boot(_ cfg.Config, _ mon.Logger) error {
+	return nil
+}
+
+func (d *ProducerDaemon) Run(kernelCtx context.Context) error {
+	d.ticker = d.tickerFactory(d.settings.Interval)
+
+	cfn := coffin.New()
+	cfn.GoWithContextf(kernelCtx, d.tickerLoop, "panic during running the ticker loop")
+
+	for i := 0; i < d.settings.RunnerCount; i++ {
+		cfn.GoWithContextf(kernelCtx, d.outputLoop, "panic during running the ticker loop")
+	}
+
+	select {
+	case <-cfn.Dying():
+		if err := d.close(); err != nil {
+			return fmt.Errorf("error on close: %w", err)
+		}
+	case <-kernelCtx.Done():
+		if err := d.close(); err != nil {
+			return fmt.Errorf("error on close: %w", err)
+		}
+	}
+
+	return cfn.Wait()
+}
+
+func (d *ProducerDaemon) WriteOne(ctx context.Context, msg WritableMessage) error {
+	return d.Write(ctx, []WritableMessage{msg})
+}
+
+func (d *ProducerDaemon) Write(_ context.Context, batch []WritableMessage) error {
+	d.lck.Lock()
+	defer d.lck.Unlock()
+
+	var err error
+	d.writeMetricMessageCount(len(batch))
+
+	if batch, err = d.applyAggregation(batch); err != nil {
+		return fmt.Errorf("can not apply aggregation in producer %s: %w", d.name, err)
+	}
+
+	d.batch = append(d.batch, batch...)
+
+	if len(d.batch) < d.settings.BatchSize {
+		return nil
+	}
+
+	d.ticker.Reset()
+	d.flushBatch()
+
+	return nil
+}
+
+func (d *ProducerDaemon) tickerLoop(ctx context.Context) error {
+	var err error
+
+	for {
+		select {
+		case <-ctx.Done():
+			d.ticker.Stop()
+			return nil
+
+		case <-d.ticker.Tick():
+			d.lck.Lock()
+
+			if err = d.flushAll(); err != nil {
+				d.logger.Error(err, "can not flush all messages")
+			}
+
+			d.lck.Unlock()
+		}
+	}
+}
+
+func (d *ProducerDaemon) applyAggregation(batch []WritableMessage) ([]WritableMessage, error) {
+	if d.settings.AggregationSize <= 1 {
+		return batch, nil
+	}
+
+	d.aggregate = append(d.aggregate, batch...)
+
+	if len(d.aggregate) < d.settings.AggregationSize {
+		return nil, nil
+	}
+
+	return d.flushAggregate()
+}
+
+func (d *ProducerDaemon) flushAggregate() ([]WritableMessage, error) {
+	if len(d.aggregate) == 0 {
+		return nil, nil
+	}
+
+	size := d.settings.AggregationSize
+
+	if len(d.aggregate) < size {
+		size = len(d.aggregate)
+	}
+
+	var readyAggregate []WritableMessage
+	readyAggregate, d.aggregate = d.aggregate[:size], d.aggregate[size:]
+
+	d.writeMetricAggregateSize(len(readyAggregate))
+	aggregateMessage, err := BuildAggregateMessage(d.marshaller, readyAggregate)
+
+	if err != nil {
+		return nil, fmt.Errorf("can not marshal aggregate: %w", err)
+	}
+
+	return []WritableMessage{aggregateMessage}, nil
+}
+
+func (d *ProducerDaemon) flushBatch() {
+	if len(d.batch) == 0 {
+		return
+	}
+
+	size := d.settings.BatchSize
+
+	if len(d.batch) < size {
+		size = len(d.batch)
+	}
+
+	var readyBatch []WritableMessage
+	readyBatch, d.batch = d.batch[:size], d.batch[size:]
+
+	d.outCh <- readyBatch
+}
+
+func (d *ProducerDaemon) flushAll() error {
+	var err error
+	var batch []WritableMessage
+
+	if batch, err = d.flushAggregate(); err != nil {
+		return fmt.Errorf("can not flush aggregation: %w", err)
+	}
+
+	d.batch = append(d.batch, batch...)
+	d.flushBatch()
+
+	return nil
+}
+
+func (d *ProducerDaemon) close() error {
+	d.lck.Lock()
+	defer d.lck.Unlock()
+	defer close(d.outCh)
+
+	if err := d.flushAll(); err != nil {
+		return fmt.Errorf("can not flush all messages: %w", err)
+	}
+
+	return nil
+}
+
+func (d *ProducerDaemon) outputLoop(ctx context.Context) error {
+	var err error
+
+	for batch := range d.outCh {
+		if err = d.output.Write(ctx, batch); err != nil {
+			d.logger.Errorf(err, "can not write messages to output in producer %s", d.name)
+		}
+
+		d.writeMetricBatchSize(len(batch))
+	}
+
+	return nil
+}
+
+func (d *ProducerDaemon) writeMetricMessageCount(count int) {
+	d.metric.WriteOne(&mon.MetricDatum{
+		Priority:   mon.PriorityHigh,
+		MetricName: metricNameMessageCount,
+		Dimensions: map[string]string{
+			"ProducerDaemon": d.name,
+		},
+		Unit:  mon.UnitCount,
+		Value: float64(count),
+	})
+}
+
+func (d *ProducerDaemon) writeMetricBatchSize(size int) {
+	d.metric.WriteOne(&mon.MetricDatum{
+		Priority:   mon.PriorityHigh,
+		MetricName: metricNameBatchSize,
+		Dimensions: map[string]string{
+			"ProducerDaemon": d.name,
+		},
+		Unit:  mon.UnitCount,
+		Value: float64(size),
+	})
+}
+
+func (d *ProducerDaemon) writeMetricAggregateSize(size int) {
+	d.metric.WriteOne(&mon.MetricDatum{
+		Priority:   mon.PriorityHigh,
+		MetricName: metricNameAggregateSize,
+		Dimensions: map[string]string{
+			"ProducerDaemon": d.name,
+		},
+		Unit:  mon.UnitCount,
+		Value: float64(size),
+	})
+}
+
+func getProducerDaemonDefaultMetrics(name string) mon.MetricData {
+	return mon.MetricData{
+		{
+			Priority:   mon.PriorityHigh,
+			MetricName: metricNameMessageCount,
+			Dimensions: map[string]string{
+				"ProducerDaemon": name,
+			},
+			Unit:  mon.UnitCount,
+			Value: 0.0,
+		},
+		{
+			Priority:   mon.PriorityHigh,
+			MetricName: metricNameBatchSize,
+			Dimensions: map[string]string{
+				"ProducerDaemon": name,
+			},
+			Unit:  mon.UnitCountAverage,
+			Value: 0.0,
+		},
+		{
+			Priority:   mon.PriorityHigh,
+			MetricName: metricNameAggregateSize,
+			Dimensions: map[string]string{
+				"ProducerDaemon": name,
+			},
+			Unit:  mon.UnitCountAverage,
+			Value: 0.0,
+		},
+	}
+}
+
+func BuildAggregateMessage(marshaller AggregateMarshaller, aggregate []WritableMessage) (WritableMessage, error) {
+	return marshaller(aggregate, map[string]interface{}{
+		AttributeAggregate: true,
+	})
+}

--- a/pkg/stream/producer_daemon_factory.go
+++ b/pkg/stream/producer_daemon_factory.go
@@ -1,0 +1,28 @@
+package stream
+
+import (
+	"fmt"
+	"github.com/applike/gosoline/pkg/cfg"
+	"github.com/applike/gosoline/pkg/kernel"
+	"github.com/applike/gosoline/pkg/mon"
+)
+
+func ProducerDaemonFactory(config cfg.Config, logger mon.Logger) (map[string]kernel.Module, error) {
+	modules := map[string]kernel.Module{}
+	producerMap := config.GetStringMap("stream.producer", map[string]interface{}{})
+
+	for name := range producerMap {
+		key := ConfigurableProducerKey(name)
+		settings := &ProducerSettings{}
+		config.UnmarshalKey(key, settings)
+
+		if !settings.Daemon.Enabled {
+			continue
+		}
+
+		moduleName := fmt.Sprintf("producer-daemon-%s", name)
+		modules[moduleName] = ProvideProducerDaemon(config, logger, name)
+	}
+
+	return modules, nil
+}

--- a/pkg/stream/producer_daemon_test.go
+++ b/pkg/stream/producer_daemon_test.go
@@ -1,0 +1,259 @@
+package stream_test
+
+import (
+	"context"
+	"fmt"
+	"github.com/applike/gosoline/pkg/clock"
+	monMocks "github.com/applike/gosoline/pkg/mon/mocks"
+	"github.com/applike/gosoline/pkg/stream"
+	streamMocks "github.com/applike/gosoline/pkg/stream/mocks"
+	"github.com/stretchr/testify/suite"
+	"testing"
+	"time"
+)
+
+type ProducerDaemonTestSuite struct {
+	suite.Suite
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wait   chan error
+	output *streamMocks.Output
+	ticker *clock.FakeTicker
+	daemon *stream.ProducerDaemon
+}
+
+func (s *ProducerDaemonTestSuite) SetupTest() {
+	s.ctx, s.cancel = context.WithCancel(context.Background())
+	s.wait = make(chan error)
+}
+
+func (s *ProducerDaemonTestSuite) SetupDaemon(batchSize int, aggregationSize int, interval time.Duration, marshaller stream.AggregateMarshaller) {
+	logger := monMocks.NewLoggerMockedAll()
+	metric := monMocks.NewMetricWriterMockedAll()
+
+	s.output = new(streamMocks.Output)
+	s.ticker = clock.NewFakeTicker()
+
+	tickerFactory := func(_ time.Duration) clock.Ticker {
+		return s.ticker
+	}
+
+	s.daemon = stream.NewProducerDaemonWithInterfaces(logger, metric, s.output, tickerFactory, marshaller, "testDaemon", stream.ProducerDaemonSettings{
+		Enabled:         true,
+		Interval:        interval,
+		BufferSize:      1,
+		RunnerCount:     1,
+		BatchSize:       batchSize,
+		AggregationSize: aggregationSize,
+	})
+
+	running := make(chan struct{})
+
+	go func() {
+		close(running)
+		err := s.daemon.Run(s.ctx)
+		s.wait <- err
+	}()
+
+	<-running
+}
+
+func (s *ProducerDaemonTestSuite) stop() error {
+	s.cancel()
+	err := <-s.wait
+	return err
+}
+
+func (s *ProducerDaemonTestSuite) TestRun() {
+	s.SetupDaemon(1, 1, time.Hour, stream.MarshalJsonMessage)
+	err := s.stop()
+
+	s.NoError(err, "there should be no error on run")
+	s.output.AssertExpectations(s.T())
+}
+
+func (s *ProducerDaemonTestSuite) TestWriteBatch() {
+	s.SetupDaemon(2, 1, time.Hour, stream.MarshalJsonMessage)
+
+	messages := []stream.WritableMessage{
+		&stream.Message{Body: "1"},
+		&stream.Message{Body: "2"},
+		&stream.Message{Body: "3"},
+	}
+
+	expected1 := []stream.WritableMessage{
+		&stream.Message{Body: "1"},
+		&stream.Message{Body: "2"},
+	}
+	expected2 := []stream.WritableMessage{
+		&stream.Message{Body: "3"},
+	}
+	s.output.On("Write", s.ctx, expected1).Return(nil)
+	s.output.On("Write", s.ctx, expected2).Return(nil)
+
+	err := s.daemon.Write(context.Background(), messages)
+	s.NoError(err, "there should be no error on write")
+
+	err = s.stop()
+
+	s.NoError(err, "there should be no error on run")
+	s.output.AssertExpectations(s.T())
+}
+
+func (s *ProducerDaemonTestSuite) TestWriteBatchOnClose() {
+	s.SetupDaemon(3, 1, time.Hour, stream.MarshalJsonMessage)
+
+	messages := []stream.WritableMessage{
+		&stream.Message{Body: "1"},
+		&stream.Message{Body: "2"},
+	}
+
+	err := s.daemon.Write(context.Background(), messages)
+	s.NoError(err, "there should be no error on write")
+
+	expected1 := []stream.WritableMessage{
+		&stream.Message{Body: "1"},
+		&stream.Message{Body: "2"},
+	}
+	s.output.On("Write", s.ctx, expected1).Return(nil)
+
+	err = s.stop()
+
+	s.NoError(err, "there should be no error on run")
+	s.output.AssertExpectations(s.T())
+}
+
+func (s *ProducerDaemonTestSuite) TestWriteBatchOnTick() {
+	s.SetupDaemon(3, 1, time.Hour, stream.MarshalJsonMessage)
+
+	messages := []stream.WritableMessage{
+		&stream.Message{Body: "1"},
+		&stream.Message{Body: "2"},
+	}
+
+	err := s.daemon.Write(context.Background(), messages)
+	s.NoError(err, "there should be no error on write")
+
+	expected1 := []stream.WritableMessage{
+		&stream.Message{Body: "1"},
+		&stream.Message{Body: "2"},
+	}
+	s.output.On("Write", s.ctx, expected1).Return(nil)
+
+	s.ticker.Trigger(time.Now())
+
+	err = s.stop()
+
+	s.NoError(err, "there should be no error on run")
+	s.output.AssertExpectations(s.T())
+}
+
+func (s *ProducerDaemonTestSuite) TestWriteBatchOnTickAfterWrite() {
+	s.SetupDaemon(2, 1, time.Hour, stream.MarshalJsonMessage)
+
+	messages := []stream.WritableMessage{
+		&stream.Message{Body: "1"},
+		&stream.Message{Body: "2"},
+		&stream.Message{Body: "3"},
+	}
+
+	expected1 := []stream.WritableMessage{
+		&stream.Message{Body: "1"},
+		&stream.Message{Body: "2"},
+	}
+	s.output.On("Write", s.ctx, expected1).Return(nil)
+
+	err := s.daemon.Write(context.Background(), messages)
+	s.NoError(err, "there should be no error on write")
+
+	expected2 := []stream.WritableMessage{
+		&stream.Message{Body: "3"},
+	}
+	s.output.On("Write", s.ctx, expected2).Return(nil)
+
+	s.ticker.Trigger(time.Now())
+	time.Sleep(time.Millisecond)
+	err = s.stop()
+
+	s.NoError(err, "there should be no error on run")
+	s.output.AssertExpectations(s.T())
+}
+
+func (s *ProducerDaemonTestSuite) TestWriteAggregate() {
+	s.SetupDaemon(2, 3, time.Hour, stream.MarshalJsonMessage)
+
+	messages := []stream.WritableMessage{
+		&stream.Message{Body: "1"},
+		&stream.Message{Body: "2"},
+		&stream.Message{Body: "3"},
+	}
+
+	aggregateMessage, err := stream.MarshalJsonMessage(messages, map[string]interface{}{
+		stream.AttributeAggregate: true,
+	})
+	s.NoError(err)
+
+	expected := []stream.WritableMessage{aggregateMessage}
+	s.output.On("Write", s.ctx, expected).Return(nil)
+
+	err = s.daemon.Write(context.Background(), messages)
+	s.NoError(err, "there should be no error on write")
+
+	err = s.stop()
+
+	s.NoError(err, "there should be no error on run")
+	s.output.AssertExpectations(s.T())
+}
+
+func (s *ProducerDaemonTestSuite) TestAggregateErrorOnWrite() {
+	s.SetupDaemon(2, 3, time.Hour, func(body interface{}, attributes ...map[string]interface{}) (*stream.Message, error) {
+		return nil, fmt.Errorf("aggregate marshal error")
+	})
+
+	messages := []stream.WritableMessage{
+		&stream.Message{Body: "1"},
+		&stream.Message{Body: "2"},
+		&stream.Message{Body: "3"},
+	}
+
+	_, err := stream.MarshalJsonMessage(messages, map[string]interface{}{
+		stream.AttributeAggregate: true,
+	})
+	s.NoError(err)
+
+	err = s.daemon.Write(context.Background(), messages)
+	s.EqualError(err, "can not apply aggregation in producer testDaemon: can not marshal aggregate: aggregate marshal error")
+
+	err = s.stop()
+
+	s.NoError(err, "there should be no error on run")
+	s.output.AssertExpectations(s.T())
+}
+
+func (s *ProducerDaemonTestSuite) TestAggregateErrorOnClose() {
+	s.SetupDaemon(2, 3, time.Hour, func(body interface{}, attributes ...map[string]interface{}) (*stream.Message, error) {
+		return nil, fmt.Errorf("aggregate marshal error")
+	})
+
+	messages := []stream.WritableMessage{
+		&stream.Message{Body: "1"},
+	}
+
+	_, err := stream.MarshalJsonMessage(messages, map[string]interface{}{
+		stream.AttributeAggregate: true,
+	})
+	s.NoError(err)
+
+	err = s.daemon.Write(context.Background(), messages)
+	s.NoError(err, "there should be no error on write")
+
+	err = s.stop()
+
+	s.EqualError(err, "error on close: can not flush all messages: can not flush aggregation: can not marshal aggregate: aggregate marshal error")
+	s.output.AssertExpectations(s.T())
+}
+
+func TestProducerDaemonTestSuite(t *testing.T) {
+	suite.Run(t, new(ProducerDaemonTestSuite))
+}


### PR DESCRIPTION
this pr adds the possibility to add batching and aggregation of messages to the producer.  
by adding the following settings to the producer config:

```
    producer:
        event:
            daemon:
                enabled: true           // enables the asynchronous daemin
                aggregation_size: 1 // how many messages to aggregate (1 means no aggregation)
                batch_size: 10         // how many messages in a batch
                buffer_size: 10         // buffer size of the internal channel
                interval: 1m0s          // if batch_size not achieved in interval, send messages
                runner_count: 10     // worker threads running which send the batches
```

you get a producer which doesn't send the message directly but instead uses a channel to push the message to a daemon, which can aggregate multiple message into one and then sends out these aggregated messages in batches asynchronously. 
