### PR TITLE
stream: allow a few seconds for the producer daemon to write its messages upon shutdown;

### DIFF
--- a/pkg/stream/input_configurable.go
+++ b/pkg/stream/input_configurable.go
@@ -149,7 +149,7 @@ func newSnsInputFromConfig(config cfg.Config, logger mon.Logger, name string) In
 	key := ConfigurableInputKey(name)
 
 	configuration := &SnsInputConfiguration{}
-	config.UnmarshalKey(key, configuration)
+	config.UnmarshalKey(key, configuration, cfg.UnmarshalWithDefaultsFromKey(ConfigKeyStreamBackoff, "backoff"))
 
 	settings := SnsInputSettings{
 		AppId: cfg.AppId{
@@ -200,7 +200,7 @@ func newSqsInputFromConfig(config cfg.Config, logger mon.Logger, name string) In
 	key := ConfigurableInputKey(name)
 
 	configuration := sqsInputConfiguration{}
-	config.UnmarshalKey(key, &configuration)
+	config.UnmarshalKey(key, &configuration, cfg.UnmarshalWithDefaultsFromKey(ConfigKeyStreamBackoff, "backoff"))
 
 	settings := SqsInputSettings{
 		AppId: cfg.AppId{

--- a/pkg/stream/output_configurable.go
+++ b/pkg/stream/output_configurable.go
@@ -61,7 +61,7 @@ type kinesisOutputConfiguration struct {
 func newKinesisOutputFromConfig(config cfg.Config, logger mon.Logger, name string) Output {
 	key := ConfigurableOutputKey(name)
 	settings := &kinesisOutputConfiguration{}
-	config.UnmarshalKey(key, settings)
+	config.UnmarshalKey(key, settings, cfg.UnmarshalWithDefaultsFromKey(ConfigKeyStreamBackoff, "backoff"))
 
 	return NewKinesisOutput(config, logger, &KinesisOutputSettings{
 		StreamName: settings.StreamName,
@@ -114,7 +114,7 @@ func newSnsOutputFromConfig(config cfg.Config, logger mon.Logger, name string) O
 	key := ConfigurableOutputKey(name)
 
 	configuration := SnsOutputConfiguration{}
-	config.UnmarshalKey(key, &configuration)
+	config.UnmarshalKey(key, &configuration, cfg.UnmarshalWithDefaultsFromKey(ConfigKeyStreamBackoff, "backoff"))
 
 	return NewSnsOutput(config, logger, SnsOutputSettings{
 		AppId: cfg.AppId{
@@ -144,7 +144,7 @@ func newSqsOutputFromConfig(config cfg.Config, logger mon.Logger, name string) O
 	key := ConfigurableOutputKey(name)
 
 	configuration := sqsOutputConfiguration{}
-	config.UnmarshalKey(key, &configuration)
+	config.UnmarshalKey(key, &configuration, cfg.UnmarshalWithDefaultsFromKey(ConfigKeyStreamBackoff, "backoff"))
 
 	return NewSqsOutput(config, logger, SqsOutputSettings{
 		AppId: cfg.AppId{

--- a/pkg/stream/producer_daemon.go
+++ b/pkg/stream/producer_daemon.go
@@ -267,10 +267,8 @@ func (d *ProducerDaemon) close() error {
 }
 
 func (d *ProducerDaemon) outputLoop(ctx context.Context) error {
-	var err error
-
 	for batch := range d.outCh {
-		if err = d.output.Write(ctx, batch); err != nil {
+		if err := d.output.Write(ctx, batch); err != nil {
 			d.logger.Errorf(err, "can not write messages to output in producer %s", d.name)
 		}
 

--- a/test/stream/config.dist.yml
+++ b/test/stream/config.dist.yml
@@ -1,0 +1,37 @@
+env: test
+
+app_project: gosoline
+app_family: test
+app_name: producer-daemon-test
+
+aws_sdk_retries: 5
+aws_cloudwatch_endpoint: http://localhost:4566
+aws_kinesis_endpoint: http://localhost:4566
+aws_kinesis_autoCreate: true
+aws_sqs_endpoint: http://localhost:4566
+aws_sqs_autoCreate: true
+
+stream:
+  backoff:
+    enabled: true
+    cancel_delay: 3s
+    max_interval: 250ms
+    max_elapsed_time: 3s
+
+  producer:
+    testDataKinesis:
+      daemon:
+        enabled: true
+        aggregation_size: 7
+    testDataSqs:
+      daemon:
+        enabled: true
+        aggregation_size: 7
+
+  output:
+    testDataKinesis:
+      type: kinesis
+      stream_name: "{app_project}-{env}-{app_family}-{app_name}-testData"
+    testDataSqs:
+      type: sqs
+      queue_id: testData

--- a/test/stream/producer_daemon_test.go
+++ b/test/stream/producer_daemon_test.go
@@ -1,0 +1,118 @@
+// +build integration
+
+package stream_test
+
+import (
+	"context"
+	"fmt"
+	"github.com/applike/gosoline/pkg/application"
+	"github.com/applike/gosoline/pkg/cfg"
+	"github.com/applike/gosoline/pkg/kernel"
+	"github.com/applike/gosoline/pkg/mon"
+	"github.com/applike/gosoline/pkg/stream"
+	pkgTest "github.com/applike/gosoline/pkg/test"
+	"github.com/stretchr/testify/suite"
+	"os"
+	"testing"
+	"time"
+)
+
+type TestData struct {
+	Data string `json:"data"`
+}
+
+type ProducerDaemonTestSuite struct {
+	suite.Suite
+	mocks *pkgTest.Mocks
+}
+
+func (s *ProducerDaemonTestSuite) SetupSuite() {
+	err := os.Setenv("AWS_ACCESS_KEY_ID", "a")
+	s.NoError(err)
+	err = os.Setenv("AWS_SECRET_ACCESS_KEY", "b")
+	s.NoError(err)
+
+	mocks, err := pkgTest.Boot("../test_configs/config.kinesis.test.yml", "../test_configs/config.sns_sqs.test.yml")
+
+	if err != nil {
+		if mocks != nil {
+			mocks.Shutdown()
+		}
+
+		s.Fail("failed to boot mocks: %s", err.Error())
+
+		return
+	}
+
+	s.mocks = mocks
+}
+
+func (s *ProducerDaemonTestSuite) TearDownSuite() {
+	if s.mocks != nil {
+		s.mocks.Shutdown()
+		s.mocks = nil
+	}
+}
+
+func (s *ProducerDaemonTestSuite) SetupTest() {
+	kinesisEndpoint := fmt.Sprintf("http://%s:%d", s.mocks.ProvideKinesisHost("kinesis"), s.mocks.ProvideKinesisPort("kinesis"))
+	sqsEndpoint := fmt.Sprintf("http://%s:%d", s.mocks.ProvideSqsHost("sns_sqs"), s.mocks.ProvideSqsPort("sns_sqs"))
+
+	err := os.Setenv("AWS_KINESIS_ENDPOINT", kinesisEndpoint)
+	s.NoError(err)
+	err = os.Setenv("AWS_SQS_ENDPOINT", sqsEndpoint)
+	s.NoError(err)
+}
+
+func (s *ProducerDaemonTestSuite) TestWriteData() {
+	args := os.Args
+	os.Args = args[:1]
+	defer func() {
+		os.Args = args
+	}()
+
+	app := application.Default(application.WithLoggerHook(s))
+	app.Add("testModule", &testModule{})
+	app.Run()
+}
+
+func (s *ProducerDaemonTestSuite) Fire(level string, msg string, err error, data *mon.Metadata) error {
+	s.NoError(err)
+	s.Contains([]string{"debug", "info", "warn"}, level, "Unexpected log message: [%s] %s %v %v", level, msg, err, data)
+
+	return nil
+}
+
+type testModule struct {
+	kernel.EssentialModule
+
+	producerKinesis stream.Producer
+	producerSqs     stream.Producer
+}
+
+func (m *testModule) Boot(config cfg.Config, logger mon.Logger) error {
+	m.producerKinesis = stream.NewProducer(config, logger, "testDataKinesis")
+	m.producerSqs = stream.NewProducer(config, logger, "testDataSqs")
+
+	return nil
+}
+
+func (m *testModule) Run(ctx context.Context) error {
+	time.Sleep(time.Second)
+
+	for i := 0; i < 13; i++ {
+		if err := m.producerKinesis.WriteOne(ctx, &TestData{}); err != nil {
+			return err
+		}
+
+		if err := m.producerSqs.WriteOne(ctx, &TestData{}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func TestProducerDaemon(t *testing.T) {
+	suite.Run(t, new(ProducerDaemonTestSuite))
+}


### PR DESCRIPTION
When the kernel initiates a shutdown while there are queued messages, we
need to give at least a few seconds to write them to their output,
otherwise we immediately receive a context.Canceled error.