### PR TITLE
apiserver: concurrent request count metric

### DIFF
--- a/pkg/apiserver/server_test.go
+++ b/pkg/apiserver/server_test.go
@@ -21,6 +21,7 @@ import (
 type ServerTestSuite struct {
 	suite.Suite
 	logger mon.Logger
+	metric mon.MetricWriter
 	router *gin.Engine
 	tracer tracing.Tracer
 	server *apiserver.ApiServer
@@ -32,6 +33,7 @@ func TestServerTestSuite(t *testing.T) {
 
 func (s *ServerTestSuite) SetupTest() {
 	s.logger = monMocks.NewLoggerMockedAll()
+	s.metric = monMocks.NewMetricWriterMockedAll()
 
 	gin.SetMode(gin.TestMode)
 	s.router = gin.New()
@@ -48,7 +50,7 @@ func (s *ServerTestSuite) TestLifecycle_Cancel() {
 	cancel()
 
 	s.NotPanics(func() {
-		err := s.server.BootWithInterfaces(s.logger, s.router, s.tracer, &apiserver.Settings{})
+		err := s.server.BootWithInterfaces(s.logger, s.metric, s.router, s.tracer, &apiserver.Settings{})
 		s.NoError(err)
 
 		err = s.server.Run(ctx)
@@ -58,7 +60,7 @@ func (s *ServerTestSuite) TestLifecycle_Cancel() {
 
 func (s *ServerTestSuite) TestGetPort() {
 	s.NotPanics(func() {
-		err := s.server.BootWithInterfaces(s.logger, s.router, s.tracer, &apiserver.Settings{})
+		err := s.server.BootWithInterfaces(s.logger, s.metric, s.router, s.tracer, &apiserver.Settings{})
 		s.NoError(err)
 
 		port, err := s.server.GetPort()
@@ -81,7 +83,7 @@ func (s *ServerTestSuite) TestGetPort_Error() {
 func (s *ServerTestSuite) TestBaseProfilingEndpoint() {
 	s.NotPanics(func() {
 		apiserver.AddProfilingEndpoints(s.router)
-		err := s.server.BootWithInterfaces(s.logger, s.router, s.tracer, &apiserver.Settings{})
+		err := s.server.BootWithInterfaces(s.logger, s.metric, s.router, s.tracer, &apiserver.Settings{})
 		s.NoError(err)
 	})
 

--- a/test/stream/config.dist.yml
+++ b/test/stream/config.dist.yml
@@ -4,6 +4,14 @@ app_project: gosoline
 app_family: test
 app_name: producer-daemon-test
 
+cfg:
+  server:
+    port: 0
+
+api:
+  health:
+    port: 0
+
 aws_sdk_retries: 5
 aws_cloudwatch_endpoint: http://localhost:4566
 aws_kinesis_endpoint: http://localhost:4566


### PR DESCRIPTION
track concurrent request count based on connection states instead of a http middleware