### PR TITLE
stream: change pipeline to only acknowledge messages after processing them;

### DIFF
--- a/pkg/stream/consumer_base.go
+++ b/pkg/stream/consumer_base.go
@@ -45,7 +45,6 @@ type baseConsumer struct {
 	kernel.ApplicationStage
 	ConsumerAcknowledge
 
-	logger  mon.Logger
 	encoder MessageEncoder
 	mw      mon.MetricWriter
 	tracer  tracing.Tracer

--- a/pkg/stream/input.go
+++ b/pkg/stream/input.go
@@ -11,6 +11,7 @@ type Input interface {
 
 //go:generate mockery -name AcknowledgeableInput
 type AcknowledgeableInput interface {
+	Input
 	Ack(msg *Message) error
 	AckBatch(msgs []*Message) error
 }

--- a/pkg/stream/mocks/AcknowledgeableInput.go
+++ b/pkg/stream/mocks/AcknowledgeableInput.go
@@ -2,6 +2,7 @@
 
 package mocks
 
+import context "context"
 import mock "github.com/stretchr/testify/mock"
 import stream "github.com/applike/gosoline/pkg/stream"
 
@@ -36,4 +37,39 @@ func (_m *AcknowledgeableInput) AckBatch(msgs []*stream.Message) error {
 	}
 
 	return r0
+}
+
+// Data provides a mock function with given fields:
+func (_m *AcknowledgeableInput) Data() chan *stream.Message {
+	ret := _m.Called()
+
+	var r0 chan *stream.Message
+	if rf, ok := ret.Get(0).(func() chan *stream.Message); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(chan *stream.Message)
+		}
+	}
+
+	return r0
+}
+
+// Run provides a mock function with given fields: ctx
+func (_m *AcknowledgeableInput) Run(ctx context.Context) error {
+	ret := _m.Called(ctx)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// Stop provides a mock function with given fields:
+func (_m *AcknowledgeableInput) Stop() {
+	_m.Called()
 }

--- a/pkg/stream/mocks/PipelineCallback.go
+++ b/pkg/stream/mocks/PipelineCallback.go
@@ -28,20 +28,20 @@ func (_m *PipelineCallback) Boot(config cfg.Config, logger mon.Logger) error {
 }
 
 // Process provides a mock function with given fields: ctx, messages
-func (_m *PipelineCallback) Process(ctx context.Context, messages []*stream.Message) ([]*stream.Message, error) {
+func (_m *PipelineCallback) Process(ctx context.Context, messages []stream.PipelineInput) ([]stream.PipelineOutput, error) {
 	ret := _m.Called(ctx, messages)
 
-	var r0 []*stream.Message
-	if rf, ok := ret.Get(0).(func(context.Context, []*stream.Message) []*stream.Message); ok {
+	var r0 []stream.PipelineOutput
+	if rf, ok := ret.Get(0).(func(context.Context, []stream.PipelineInput) []stream.PipelineOutput); ok {
 		r0 = rf(ctx, messages)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]*stream.Message)
+			r0 = ret.Get(0).([]stream.PipelineOutput)
 		}
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, []*stream.Message) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, []stream.PipelineInput) error); ok {
 		r1 = rf(ctx, messages)
 	} else {
 		r1 = ret.Error(1)

--- a/pkg/stream/pipeline_test.go
+++ b/pkg/stream/pipeline_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/applike/gosoline/pkg/mon"
 	"github.com/applike/gosoline/pkg/mon/mocks"
 	"github.com/applike/gosoline/pkg/stream"
+	streamMocks "github.com/applike/gosoline/pkg/stream/mocks"
 	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
@@ -14,28 +15,27 @@ import (
 type callback struct {
 }
 
-func (c *callback) Boot(config cfg.Config, logger mon.Logger) error {
+func (c *callback) Boot(_ cfg.Config, _ mon.Logger) error {
 	return nil
 }
 
-func (c *callback) Process(ctx context.Context, messages []*stream.Message) ([]*stream.Message, error) {
-	for _, msg := range messages {
-		msg.Body = "foobaz"
+func (c *callback) Process(_ context.Context, messages []stream.PipelineInput) ([]stream.PipelineOutput, error) {
+	output := make([]stream.PipelineOutput, len(messages))
+
+	for i, input := range messages {
+		for _, msg := range input.Messages {
+			msg.Body = "foobaz"
+		}
+		output[i] = input.CreateOutput(input.Messages)
 	}
 
-	return messages, nil
+	return output, nil
 }
 
-func runPipelineWithSettings(t *testing.T, settings *stream.PipelineSettings, ctx context.Context) {
+func runPipelineWithSettings(t *testing.T, settings *stream.PipelineSettings, input stream.Input, expectedMessages int, ctx context.Context) {
 	logger := mocks.NewLoggerMockedAll()
 	metric := mocks.NewMetricWriterMockedAll()
 	output := stream.NewInMemoryOutput()
-
-	input := stream.NewInMemoryInput(&stream.InMemorySettings{Size: 1})
-	input.Publish(&stream.Message{
-		Body: "foobar",
-	})
-	input.Stop()
 
 	callback := &callback{}
 	pipe := stream.NewPipeline(callback)
@@ -47,15 +47,92 @@ func runPipelineWithSettings(t *testing.T, settings *stream.PipelineSettings, ct
 	assert.NoError(t, err, "the pipeline should run without an error")
 
 	size := output.Size()
-	assert.Equal(t, 1, size, "the output should contain 1 message")
+	assert.Equal(t, expectedMessages, size, "the output should contain %d message(s)", expectedMessages)
 
 	contains := output.ContainsBody("foobaz")
 	assert.True(t, contains, "the output should contain the body 'foobaz'")
 }
 
 func TestPipeline_RunBatchSize(t *testing.T) {
+	input := stream.NewInMemoryInput(&stream.InMemorySettings{Size: 1})
+	input.Publish(&stream.Message{
+		Body: "foobar",
+	})
+	input.Stop()
+
 	runPipelineWithSettings(t, &stream.PipelineSettings{
 		Interval:  time.Hour,
 		BatchSize: 1,
-	}, context.Background())
+	}, input, 1, context.Background())
+}
+
+func TestPipeline_RunAggregate(t *testing.T) {
+	input := new(streamMocks.AcknowledgeableInput)
+
+	aggregateMessage, err := stream.MarshalJsonMessage([]stream.Message{
+		{
+			Body: "a",
+		},
+		{
+			Body: "b",
+		},
+		{
+			Body: "c",
+		},
+		{
+			Body: "d",
+		},
+	}, map[string]interface{}{
+		stream.AttributeAggregate:        true,
+		stream.AttributeSqsReceiptHandle: "receipt-1",
+	})
+	assert.NoError(t, err)
+
+	dataChan := make(chan *stream.Message, 3)
+	dataChan <- aggregateMessage
+	dataChan <- &stream.Message{
+		Attributes: map[string]interface{}{
+			stream.AttributeSqsReceiptHandle: "receipt-2",
+		},
+		Body: "foobar",
+	}
+	dataChan <- &stream.Message{
+		Attributes: map[string]interface{}{
+			stream.AttributeSqsReceiptHandle: "receipt-3",
+		},
+		Body: "abc",
+	}
+	close(dataChan)
+
+	input.On("AckBatch", []*stream.Message{
+		{
+			Attributes: map[string]interface{}{
+				stream.AttributeAggregate:        true,
+				stream.AttributeSqsReceiptHandle: "receipt-1",
+			},
+		},
+	}).Return(nil).Once()
+	input.On("AckBatch", []*stream.Message{
+		{
+			Attributes: map[string]interface{}{
+				stream.AttributeSqsReceiptHandle: "receipt-2",
+			},
+		},
+		{
+			Attributes: map[string]interface{}{
+				stream.AttributeSqsReceiptHandle: "receipt-3",
+			},
+		},
+	}).Return(nil).Once()
+
+	input.On("Run", context.Background()).Return(nil).Once()
+	input.On("Stop").Once()
+	input.On("Data").Return(dataChan)
+
+	runPipelineWithSettings(t, &stream.PipelineSettings{
+		Interval:  time.Hour,
+		BatchSize: 3,
+	}, input, 6, context.Background())
+
+	input.AssertExpectations(t)
 }


### PR DESCRIPTION
This commit completely changes the way a pipeline works around. Instead
of receiving messages and acknowledging them immediately we now only
acknowledge the messages returned by the last pipeline stage (so you
have to keep receipt handles intact). This allows some events from a
batch to be retried later should e.g. some data not be available yet.