### PR TITLE
redis: "hide" the error returned by redis if an element is not found from the executor;

### DIFF
--- a/pkg/cloud/aws/executor.go
+++ b/pkg/cloud/aws/executor.go
@@ -61,7 +61,7 @@ func (b BackoffExecutor) Execute(ctx context.Context, f RequestFunction) (interf
 		req.SetContext(ctx)
 		err := req.Send()
 
-		if req.HTTPResponse.StatusCode >= http.StatusInternalServerError && req.HTTPResponse.StatusCode != http.StatusNotImplemented {
+		if err == nil && req.HTTPResponse.StatusCode >= http.StatusInternalServerError && req.HTTPResponse.StatusCode != http.StatusNotImplemented {
 			return nil, &InvalidStatusError{
 				Status: req.HTTPResponse.StatusCode,
 			}

--- a/pkg/exec/error.go
+++ b/pkg/exec/error.go
@@ -12,9 +12,16 @@ import (
 type ErrorType int
 
 const (
+	// We don't know yet, let the other error checkers decide about this error. If the error is
+	// not marked retryable by another checker, we will not retry it.
 	ErrorUnknown ErrorType = iota
+	// Stop retrying, the error was actually a "success" and needs to be propagated to the caller
+	// ("success" meaning something e.g. was not found, but will not magically appear just because
+	// we retry a few more times)
 	ErrorOk
+	// Immediately stop retrying and return this error to the caller
 	ErrorPermanent
+	// Retry the execution of the action
 	ErrorRetryable
 )
 

--- a/pkg/redis/exec.go
+++ b/pkg/redis/exec.go
@@ -1,6 +1,7 @@
 package redis
 
 import (
+	"errors"
 	"github.com/applike/gosoline/pkg/exec"
 	"github.com/applike/gosoline/pkg/mon"
 	"io"
@@ -25,9 +26,18 @@ func NewBackoffExecutor(logger mon.Logger, settings exec.BackoffSettings, name s
 	checks := []exec.ErrorChecker{
 		RetryableErrorChecker,
 		OOMChecker,
+		NilChecker,
 	}
 
 	return exec.NewBackoffExecutor(logger, executableResource, &settings, checks...)
+}
+
+func NilChecker(_ interface{}, err error) exec.ErrorType {
+	if errors.Is(err, Nil) {
+		return exec.ErrorOk
+	}
+
+	return exec.ErrorUnknown
 }
 
 func OOMChecker(_ interface{}, err error) exec.ErrorType {


### PR DESCRIPTION
Redis returns `redis.Nil` as an error should no element be found. This
however confuses the executor as it thinks the command failed and needs
to be retried. Instead, we have to return nil to the executor and later
restore the error for the caller to ensure the use of the executor stays
invisible to the caller, but we don't retry requests we don't need to.

Also remove a rare crash in the aws executor should an error be returned.