### PR TITLE
apiserver, db-repo: handle record not found errors;

### DIFF
--- a/pkg/apiserver/crud/delete.go
+++ b/pkg/apiserver/crud/delete.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"github.com/applike/gosoline/pkg/apiserver"
+	"github.com/applike/gosoline/pkg/db-repo"
 	"github.com/gin-gonic/gin"
 )
 
@@ -30,6 +31,10 @@ func (dh deleteHandler) Handle(ctx context.Context, request *apiserver.Request) 
 	model := dh.transformer.GetModel()
 
 	err := repo.Read(ctx, id, model)
+
+	if db_repo.IsRecordNotFoundError(err) {
+		return nil, apiserver.ErrRecordNotFound
+	}
 
 	if err != nil {
 		return nil, err

--- a/pkg/apiserver/crud/read.go
+++ b/pkg/apiserver/crud/read.go
@@ -3,11 +3,10 @@ package crud
 import (
 	"context"
 	"github.com/applike/gosoline/pkg/apiserver"
+	"github.com/applike/gosoline/pkg/db-repo"
 	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
 )
-
-var ErrNotFound = errors.New("model not found")
 
 type readHandler struct {
 	transformer BaseHandler
@@ -31,6 +30,10 @@ func (rh readHandler) Handle(ctx context.Context, request *apiserver.Request) (*
 	repo := rh.transformer.GetRepository()
 	model := rh.transformer.GetModel()
 	err := repo.Read(ctx, id, model)
+
+	if db_repo.IsRecordNotFoundError(err) {
+		return nil, apiserver.ErrRecordNotFound
+	}
 
 	if err != nil {
 		return nil, err

--- a/pkg/apiserver/crud/update.go
+++ b/pkg/apiserver/crud/update.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"github.com/applike/gosoline/pkg/apiserver"
 	"github.com/applike/gosoline/pkg/db"
+	"github.com/applike/gosoline/pkg/db-repo"
 	"github.com/gin-gonic/gin"
 	"net/http"
 )
@@ -35,6 +36,10 @@ func (uh updateHandler) Handle(ctx context.Context, request *apiserver.Request) 
 	repo := uh.transformer.GetRepository()
 	model := uh.transformer.GetModel()
 	err := repo.Read(ctx, id, model)
+
+	if db_repo.IsRecordNotFoundError(err) {
+		return nil, apiserver.ErrRecordNotFound
+	}
 
 	if err != nil {
 		return nil, err

--- a/pkg/apiserver/handler.go
+++ b/pkg/apiserver/handler.go
@@ -311,15 +311,7 @@ func handle(ginCtx *gin.Context, handler HandlerWithoutInput, input interface{},
 
 func handleError(ginCtx *gin.Context, errHandler ErrorHandler, statusCode int, ginError gin.Error) {
 	_ = ginCtx.Error(&ginError)
-	resp := errHandler(statusCode, ginError.Err)
-
-	writer, err := mkResponseBodyWriter(resp)
-
-	if err != nil {
-		panic(errors.WithMessage(err, "Error creating writer for error handler"))
-	}
-
-	writer(ginCtx)
+	handleUserError(ginCtx, errHandler, statusCode, ginError.Err)
 }
 
 func handleUserError(ginCtx *gin.Context, errHandler ErrorHandler, statusCode int, err error) {

--- a/pkg/db-repo/repository.go
+++ b/pkg/db-repo/repository.go
@@ -2,6 +2,7 @@ package db_repo
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"github.com/applike/gosoline/pkg/cfg"
 	"github.com/applike/gosoline/pkg/mon"
@@ -24,6 +25,26 @@ const (
 
 var operations = []string{Create, Read, Update, Delete, Query}
 var RecordNotFound = gorm.ErrRecordNotFound
+
+func IsRecordNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if err == RecordNotFound {
+		return true
+	}
+
+	if errs, ok := err.(gorm.Errors); ok {
+		for _, err := range errs {
+			if IsRecordNotFoundError(err) {
+				return true
+			}
+		}
+	}
+
+	return IsRecordNotFoundError(errors.Unwrap(err))
+}
 
 type Settings struct {
 	cfg.AppId


### PR DESCRIPTION
Instead of raising an error and returning a 500 Internal Server Error,
we now return a 404 Not Found should a missing record be requested by a
client.