### PR TITLE
apiserver/crud, validation: introduced own error type for validation failues and respond with HTTP 400 in case of a failure;

### DIFF
--- a/pkg/apiserver/crud/delete.go
+++ b/pkg/apiserver/crud/delete.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"github.com/applike/gosoline/pkg/apiserver"
+	"github.com/applike/gosoline/pkg/validation"
 	"github.com/gin-gonic/gin"
+	"net/http"
 )
 
 type deleteHandler struct {
@@ -36,6 +38,10 @@ func (dh deleteHandler) Handle(ctx context.Context, request *apiserver.Request) 
 	}
 
 	err = repo.Delete(ctx, model)
+
+	if errors.Is(err, &validation.Error{}) {
+		return apiserver.GetErrorHandler()(http.StatusBadRequest, err), nil
+	}
 
 	if err != nil {
 		return nil, err

--- a/pkg/apiserver/crud/update.go
+++ b/pkg/apiserver/crud/update.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"github.com/applike/gosoline/pkg/apiserver"
 	"github.com/applike/gosoline/pkg/db"
+	"github.com/applike/gosoline/pkg/validation"
 	"github.com/gin-gonic/gin"
 	"net/http"
 )
@@ -52,10 +53,12 @@ func (uh updateHandler) Handle(ctx context.Context, request *apiserver.Request) 
 
 	err = repo.Update(ctx, model)
 
-	exists := db.IsDuplicateEntryError(err)
-
-	if exists {
+	if db.IsDuplicateEntryError(err) {
 		return apiserver.NewStatusResponse(http.StatusConflict), nil
+	}
+
+	if errors.Is(err, &validation.Error{}) {
+		return apiserver.GetErrorHandler()(http.StatusBadRequest, err), nil
 	}
 
 	if err != nil {

--- a/pkg/apiserver/error.go
+++ b/pkg/apiserver/error.go
@@ -19,4 +19,8 @@ func WithErrorHandler(handler ErrorHandler) {
 	defaultErrorHandler = handler
 }
 
+func GetErrorHandler() ErrorHandler {
+	return defaultErrorHandler
+}
+
 var defaultErrorHandler = errorHandlerJson

--- a/pkg/validation/error.go
+++ b/pkg/validation/error.go
@@ -1,0 +1,35 @@
+package validation
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Error struct {
+	Errors []error
+}
+
+func (e *Error) Error() string {
+	messages := make([]string, len(e.Errors))
+	for i := 0; i < len(e.Errors); i++ {
+		messages[i] = e.Errors[i].Error()
+	}
+
+	return fmt.Sprintf("validation: %s", strings.Join(messages, "; "))
+}
+
+func (e *Error) Is(err error) bool {
+	_, ok := err.(*Error)
+
+	return ok
+}
+
+func (e *Error) As(target interface{}) bool {
+	targetErr, ok := target.(*Error)
+
+	if ok {
+		*targetErr = *e
+	}
+
+	return ok
+}

--- a/pkg/validation/validator.go
+++ b/pkg/validation/validator.go
@@ -2,12 +2,9 @@ package validation
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"github.com/applike/gosoline/pkg/cfg"
 	"github.com/applike/gosoline/pkg/mon"
 	"github.com/applike/gosoline/pkg/tracing"
-	"strings"
 )
 
 const (
@@ -57,7 +54,7 @@ func (v *validator) AddRule(rule Rule, groups ...string) {
 	}
 }
 
-func (v validator) IsValid(ctx context.Context, model interface{}, groups ...string) error {
+func (v *validator) IsValid(ctx context.Context, model interface{}, groups ...string) error {
 	ctx, span := v.tracer.StartSubSpan(ctx, "validator")
 	defer span.Finish()
 
@@ -76,17 +73,12 @@ func (v validator) IsValid(ctx context.Context, model interface{}, groups ...str
 		return nil
 	}
 
-	messages := make([]string, len(errs))
-	for i := 0; i < len(errs); i++ {
-		messages[i] = errs[i].Error()
+	return &Error{
+		Errors: errs,
 	}
-
-	msg := fmt.Sprintf("validation: %s", strings.Join(messages, "; "))
-
-	return errors.New(msg)
 }
 
-func (v validator) validateGroup(ctx context.Context, model interface{}, group string) []error {
+func (v *validator) validateGroup(ctx context.Context, model interface{}, group string) []error {
 	errs := make([]error, 0)
 
 	if _, ok := v.rules[group]; !ok {


### PR DESCRIPTION
Instead of returning a generic error with some special string we now
return a custom error type. This error is then detected by the
apiserver/crud code after a write to the database fails and returned as
a HTTP 400 response to the client instead of generating a HTTP 500 error
and logging an error.