### PR TITLE
Logger mock refactor and producer daemon fix

### DIFF
--- a/pkg/mon/error.go
+++ b/pkg/mon/error.go
@@ -3,10 +3,8 @@ package mon
 import "fmt"
 
 func WrapErrorAndLog(logger Logger, err error, msg string, args ...interface{}) error {
-	logger.Errorf(err, msg, args...)
-
 	errMsg := fmt.Sprintf(msg, args...)
-	err = fmt.Errorf("%s: %w", errMsg, err)
+	logger.Error(err, errMsg)
 
-	return err
+	return fmt.Errorf("%s: %w", errMsg, err)
 }

--- a/pkg/mon/mocks/factory.go
+++ b/pkg/mon/mocks/factory.go
@@ -1,30 +1,100 @@
 package mocks
 
-import "github.com/stretchr/testify/mock"
+import (
+	"fmt"
+	"github.com/applike/gosoline/pkg/mon"
+	"github.com/stretchr/testify/mock"
+)
 
-func NewLoggerMock(methods ...string) *Logger {
+func NewLoggerMock() *Logger {
 	logger := new(Logger)
 
-	for _, m := range methods {
-		logger.On(m, mock.Anything).Return(logger)
-		logger.On(m, mock.Anything, mock.Anything).Return(logger)
-		logger.On(m, mock.Anything, mock.Anything, mock.Anything).Return(logger)
-		logger.On(m, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(logger)
-		logger.On(m, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(logger)
-		logger.On(m, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(logger)
-	}
+	logger.On("WithChannel", mock.AnythingOfType("string")).Return(logger).Maybe()
+	logger.On("WithContext", mock.Anything).Return(logger).Maybe()
+	logger.On("WithFields", mock.AnythingOfType("mon.Fields")).Return(logger).Maybe()
 
 	return logger
 }
 
 func NewLoggerMockedAll() *Logger {
-	return NewLoggerMock("Debug", "Debugf", "Info", "Infof", "Warn", "Warnf", "Error", "Errorf", "WithChannel", "WithContext", "WithFields")
+	return NewLoggerMockedUntilLevel(mon.Panic)
+}
+
+// return a logger mocked up to the given log level. All other calls will cause an error and fail the test.
+func NewLoggerMockedUntilLevel(level string) *Logger {
+	logger := NewLoggerMock()
+
+	levelMap := map[string]int{
+		mon.Trace: 0,
+		mon.Debug: 1,
+		mon.Info:  2,
+		mon.Warn:  3,
+		mon.Error: 4,
+		mon.Fatal: 5,
+		mon.Panic: 6,
+	}
+
+	levelIndex, ok := levelMap[level]
+
+	if !ok {
+		panic(fmt.Errorf("failed to find level to mock: %s", level))
+	}
+
+	mockLoggerMethod(logger, "Debug", "Debugf", mon.Debug, levelIndex >= levelMap[mon.Debug])
+	mockLoggerMethod(logger, "Info", "Infof", mon.Info, levelIndex >= levelMap[mon.Info])
+	mockLoggerMethod(logger, "Warn", "Warnf", mon.Warn, levelIndex >= levelMap[mon.Warn])
+	mockLoggerMethod(logger, "Error", "Errorf", mon.Error, levelIndex >= levelMap[mon.Error])
+	mockLoggerMethod(logger, "Fatal", "Fatalf", mon.Fatal, levelIndex >= levelMap[mon.Fatal])
+	mockLoggerMethod(logger, "Panic", "Panicf", mon.Panic, levelIndex >= levelMap[mon.Panic])
+
+	return logger
+}
+
+func inspectLogFunction(level string, withFormat bool, allowed bool) func(args mock.Arguments) {
+	return func(args mock.Arguments) {
+		if level == mon.Panic || level == mon.Fatal {
+			err := args.Get(0).(error)
+			var msg string
+			if withFormat {
+				msg = fmt.Sprintf(args.Get(1).(string), args[2:]...)
+			} else {
+				msg = fmt.Sprint(args[1:])
+			}
+			// we have to stop the test, these methods never return
+			panic(fmt.Errorf("panic or fatal logging method called with error '%w' and message '%s'", err, msg))
+		}
+
+		// ensure we use formatting markers exactly when using a method with formatting
+		var msg string
+		if level == mon.Error {
+			msg = fmt.Sprint(args.Get(1))
+		} else if len(args) > 0 {
+			msg = fmt.Sprint(args.Get(0))
+		}
+
+		if !allowed {
+			panic(fmt.Errorf("invalid log message '%s'. Logs of level %s are not allowed", msg, level))
+		}
+	}
+}
+
+func mockLoggerMethod(logger *Logger, method string, methodWithFormat string, level string, allowed bool) {
+	anythings := make(mock.Arguments, 0)
+	f := inspectLogFunction(level, false, allowed)
+	fWithFormat := inspectLogFunction(level, true, allowed)
+
+	for i := 0; i < 10; i++ {
+		anythings = append(anythings, mock.Anything)
+		logger.On(method, anythings...).Run(f).Return(logger).Maybe()
+		logger.On(methodWithFormat, anythings...).Run(fWithFormat).Return(logger).Maybe()
+	}
 }
 
 func NewMetricWriterMockedAll() *MetricWriter {
 	mw := new(MetricWriter)
-	mw.On("Write", mock.Anything).Return()
-	mw.On("WriteOne", mock.Anything).Return()
+	mw.On("GetPriority").Return(mon.PriorityLow).Maybe()
+	mw.On("Write", mock.AnythingOfType("mon.MetricData")).Return().Maybe()
+	mw.On("WriteOne", mock.AnythingOfType("*mon.MetricDatum")).Return().Maybe()
 
 	return mw
 }

--- a/pkg/stream/consumer_batch_test.go
+++ b/pkg/stream/consumer_batch_test.go
@@ -291,7 +291,7 @@ func (s *BatchConsumerTestSuite) TestRun_AggregateMessage() {
 			msgs := args[0].([]*stream.Message)
 			processed = len(msgs)
 		}).
-		Return()
+		Return(nil)
 
 	s.callback.On("Run", mock.AnythingOfType("*context.cancelCtx")).
 		Return(nil)

--- a/pkg/stream/producer_daemon_test.go
+++ b/pkg/stream/producer_daemon_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"fmt"
 	"github.com/applike/gosoline/pkg/clock"
+	"github.com/applike/gosoline/pkg/exec"
+	"github.com/applike/gosoline/pkg/mon"
 	monMocks "github.com/applike/gosoline/pkg/mon/mocks"
 	"github.com/applike/gosoline/pkg/stream"
 	streamMocks "github.com/applike/gosoline/pkg/stream/mocks"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"testing"
 	"time"
@@ -15,12 +18,13 @@ import (
 type ProducerDaemonTestSuite struct {
 	suite.Suite
 
-	ctx    context.Context
-	cancel context.CancelFunc
-	wait   chan error
-	output *streamMocks.Output
-	ticker *clock.FakeTicker
-	daemon *stream.ProducerDaemon
+	ctx      context.Context
+	cancel   context.CancelFunc
+	wait     chan error
+	output   *streamMocks.Output
+	ticker   *clock.FakeTicker
+	executor exec.Executor
+	daemon   *stream.ProducerDaemon
 }
 
 func (s *ProducerDaemonTestSuite) SetupTest() {
@@ -28,12 +32,25 @@ func (s *ProducerDaemonTestSuite) SetupTest() {
 	s.wait = make(chan error)
 }
 
-func (s *ProducerDaemonTestSuite) SetupDaemon(batchSize int, aggregationSize int, interval time.Duration, marshaller stream.AggregateMarshaller) {
-	logger := monMocks.NewLoggerMockedAll()
+func (s *ProducerDaemonTestSuite) SetupDaemon(maxLogLevel string, batchSize int, aggregationSize int, interval time.Duration, marshaller stream.AggregateMarshaller) {
+	logger := monMocks.NewLoggerMockedUntilLevel(maxLogLevel)
 	metric := monMocks.NewMetricWriterMockedAll()
 
 	s.output = new(streamMocks.Output)
 	s.ticker = clock.NewFakeTicker()
+	s.executor = exec.NewBackoffExecutor(logger, &exec.ExecutableResource{
+		Type: "test",
+		Name: "test-output",
+	}, &exec.BackoffSettings{
+		Enabled:             true,
+		Blocking:            true,
+		CancelDelay:         time.Second,
+		InitialInterval:     time.Millisecond * 50,
+		RandomizationFactor: 0.5,
+		Multiplier:          1.5,
+		MaxInterval:         time.Second * 3,
+		MaxElapsedTime:      time.Second * 15,
+	}, exec.CheckRequestCanceled)
 
 	tickerFactory := func(_ time.Duration) clock.Ticker {
 		return s.ticker
@@ -65,8 +82,28 @@ func (s *ProducerDaemonTestSuite) stop() error {
 	return err
 }
 
+func (s *ProducerDaemonTestSuite) expectMessage(msg []stream.WritableMessage) {
+	call := s.output.On("Write", s.ctx, msg)
+	call.Run(func(args mock.Arguments) {
+		ctx := args.Get(0).(context.Context)
+
+		// simulate an executor like the real output would use
+		_, err := s.executor.Execute(ctx, func(ctx context.Context) (interface{}, error) {
+			// return a context canceled error should the context already have been canceled (as the real output would)
+			select {
+			case <-ctx.Done():
+				return nil, context.Canceled
+			default:
+				return nil, nil
+			}
+		})
+
+		call.Return(err)
+	}).Once()
+}
+
 func (s *ProducerDaemonTestSuite) TestRun() {
-	s.SetupDaemon(1, 1, time.Hour, stream.MarshalJsonMessage)
+	s.SetupDaemon(mon.Info, 1, 1, time.Hour, stream.MarshalJsonMessage)
 	err := s.stop()
 
 	s.NoError(err, "there should be no error on run")
@@ -74,7 +111,7 @@ func (s *ProducerDaemonTestSuite) TestRun() {
 }
 
 func (s *ProducerDaemonTestSuite) TestWriteBatch() {
-	s.SetupDaemon(2, 1, time.Hour, stream.MarshalJsonMessage)
+	s.SetupDaemon(mon.Info, 2, 1, time.Hour, stream.MarshalJsonMessage)
 
 	messages := []stream.WritableMessage{
 		&stream.Message{Body: "1"},
@@ -89,8 +126,8 @@ func (s *ProducerDaemonTestSuite) TestWriteBatch() {
 	expected2 := []stream.WritableMessage{
 		&stream.Message{Body: "3"},
 	}
-	s.output.On("Write", s.ctx, expected1).Return(nil)
-	s.output.On("Write", s.ctx, expected2).Return(nil)
+	s.expectMessage(expected1)
+	s.expectMessage(expected2)
 
 	err := s.daemon.Write(context.Background(), messages)
 	s.NoError(err, "there should be no error on write")
@@ -102,7 +139,7 @@ func (s *ProducerDaemonTestSuite) TestWriteBatch() {
 }
 
 func (s *ProducerDaemonTestSuite) TestWriteBatchOnClose() {
-	s.SetupDaemon(3, 1, time.Hour, stream.MarshalJsonMessage)
+	s.SetupDaemon(mon.Info, 3, 1, time.Hour, stream.MarshalJsonMessage)
 
 	messages := []stream.WritableMessage{
 		&stream.Message{Body: "1"},
@@ -116,7 +153,7 @@ func (s *ProducerDaemonTestSuite) TestWriteBatchOnClose() {
 		&stream.Message{Body: "1"},
 		&stream.Message{Body: "2"},
 	}
-	s.output.On("Write", s.ctx, expected1).Return(nil)
+	s.expectMessage(expected1)
 
 	err = s.stop()
 
@@ -125,7 +162,7 @@ func (s *ProducerDaemonTestSuite) TestWriteBatchOnClose() {
 }
 
 func (s *ProducerDaemonTestSuite) TestWriteBatchOnTick() {
-	s.SetupDaemon(3, 1, time.Hour, stream.MarshalJsonMessage)
+	s.SetupDaemon(mon.Info, 3, 1, time.Hour, stream.MarshalJsonMessage)
 
 	messages := []stream.WritableMessage{
 		&stream.Message{Body: "1"},
@@ -139,7 +176,7 @@ func (s *ProducerDaemonTestSuite) TestWriteBatchOnTick() {
 		&stream.Message{Body: "1"},
 		&stream.Message{Body: "2"},
 	}
-	s.output.On("Write", s.ctx, expected1).Return(nil)
+	s.expectMessage(expected1)
 
 	s.ticker.Trigger(time.Now())
 
@@ -150,7 +187,7 @@ func (s *ProducerDaemonTestSuite) TestWriteBatchOnTick() {
 }
 
 func (s *ProducerDaemonTestSuite) TestWriteBatchOnTickAfterWrite() {
-	s.SetupDaemon(2, 1, time.Hour, stream.MarshalJsonMessage)
+	s.SetupDaemon(mon.Info, 2, 1, time.Hour, stream.MarshalJsonMessage)
 
 	messages := []stream.WritableMessage{
 		&stream.Message{Body: "1"},
@@ -162,7 +199,7 @@ func (s *ProducerDaemonTestSuite) TestWriteBatchOnTickAfterWrite() {
 		&stream.Message{Body: "1"},
 		&stream.Message{Body: "2"},
 	}
-	s.output.On("Write", s.ctx, expected1).Return(nil)
+	s.expectMessage(expected1)
 
 	err := s.daemon.Write(context.Background(), messages)
 	s.NoError(err, "there should be no error on write")
@@ -170,7 +207,7 @@ func (s *ProducerDaemonTestSuite) TestWriteBatchOnTickAfterWrite() {
 	expected2 := []stream.WritableMessage{
 		&stream.Message{Body: "3"},
 	}
-	s.output.On("Write", s.ctx, expected2).Return(nil)
+	s.expectMessage(expected2)
 
 	s.ticker.Trigger(time.Now())
 	time.Sleep(time.Millisecond)
@@ -181,7 +218,7 @@ func (s *ProducerDaemonTestSuite) TestWriteBatchOnTickAfterWrite() {
 }
 
 func (s *ProducerDaemonTestSuite) TestWriteAggregate() {
-	s.SetupDaemon(2, 3, time.Hour, stream.MarshalJsonMessage)
+	s.SetupDaemon(mon.Info, 2, 3, time.Hour, stream.MarshalJsonMessage)
 
 	messages := []stream.WritableMessage{
 		&stream.Message{Body: "1"},
@@ -195,7 +232,7 @@ func (s *ProducerDaemonTestSuite) TestWriteAggregate() {
 	s.NoError(err)
 
 	expected := []stream.WritableMessage{aggregateMessage}
-	s.output.On("Write", s.ctx, expected).Return(nil)
+	s.expectMessage(expected)
 
 	err = s.daemon.Write(context.Background(), messages)
 	s.NoError(err, "there should be no error on write")
@@ -207,7 +244,7 @@ func (s *ProducerDaemonTestSuite) TestWriteAggregate() {
 }
 
 func (s *ProducerDaemonTestSuite) TestAggregateErrorOnWrite() {
-	s.SetupDaemon(2, 3, time.Hour, func(body interface{}, attributes ...map[string]interface{}) (*stream.Message, error) {
+	s.SetupDaemon(mon.Info, 2, 3, time.Hour, func(body interface{}, attributes ...map[string]interface{}) (*stream.Message, error) {
 		return nil, fmt.Errorf("aggregate marshal error")
 	})
 
@@ -232,7 +269,7 @@ func (s *ProducerDaemonTestSuite) TestAggregateErrorOnWrite() {
 }
 
 func (s *ProducerDaemonTestSuite) TestAggregateErrorOnClose() {
-	s.SetupDaemon(2, 3, time.Hour, func(body interface{}, attributes ...map[string]interface{}) (*stream.Message, error) {
+	s.SetupDaemon(mon.Info, 2, 3, time.Hour, func(body interface{}, attributes ...map[string]interface{}) (*stream.Message, error) {
 		return nil, fmt.Errorf("aggregate marshal error")
 	})
 
@@ -251,6 +288,43 @@ func (s *ProducerDaemonTestSuite) TestAggregateErrorOnClose() {
 	err = s.stop()
 
 	s.EqualError(err, "error on close: can not flush all messages: can not flush aggregation: can not marshal aggregate: aggregate marshal error")
+	s.output.AssertExpectations(s.T())
+}
+
+func (s *ProducerDaemonTestSuite) TestWriteWithCanceledError() {
+	s.SetupDaemon(mon.Warn, 5, 5, time.Hour, stream.MarshalJsonMessage)
+
+	messages := []stream.WritableMessage{
+		&stream.Message{Body: "1"},
+		&stream.Message{Body: "2"},
+	}
+	aggregateMessage, err := stream.MarshalJsonMessage(messages, map[string]interface{}{
+		stream.AttributeAggregate: true,
+	})
+	s.NoError(err)
+
+	expected := []stream.WritableMessage{aggregateMessage}
+	s.output.On("Write", s.ctx, expected).Run(func(args mock.Arguments) {
+		ctx := args.Get(0).(context.Context)
+		select {
+		case _, ok := <-ctx.Done():
+			s.False(ok, "expected the context to have been canceled")
+		default:
+			s.Fail("expected the context to have been canceled")
+		}
+	}).Return(context.Canceled).Once()
+
+	_, err = stream.MarshalJsonMessage(messages, map[string]interface{}{
+		stream.AttributeAggregate: true,
+	})
+	s.NoError(err)
+
+	err = s.daemon.Write(context.Background(), messages)
+	s.NoError(err, "there should be no error on write")
+
+	err = s.stop()
+
+	s.NoError(err)
 	s.output.AssertExpectations(s.T())
 }
 


### PR DESCRIPTION
mon/mocks: add common error detection to logger mock;

Added `NewLoggerMockedLevel` to allow specifying the maximum log level
you expect to be logged. A common use case is a test where a component
might normally swallow an error, but you need an easy way to ensure no
such error was thrown and logged by your test. Additionally the logger
mock now checks the format of the message and, if formatting marks are
detected, the use of Infof/Warnf/... is enforced. If no such marks are
detected, Info/Warn/... should be used instead.

stream: handle application termination in producer daemon;

Upon termination of the application, we start shutting down the producer
daemon and cancel all contexts. However, we have to delay cancling the
context used to write the message to the output (by one second by
default) to allow the message to still be written. Should we fail to
write the message in that timeframe, we handle the resulting cancel
error by logging a warning.