### PR TITLE
push logger to v0.2.x level

### DIFF
--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -1,0 +1,17 @@
+package log
+
+import "context"
+
+type Fields map[string]interface{}
+
+//go:generate mockery -name Logger
+type Logger interface {
+	Debug(msg string, args ...interface{})
+	Info(msg string, args ...interface{})
+	Warn(msg string, args ...interface{})
+	Error(msg string, args ...interface{})
+
+	WithChannel(channel string) Logger
+	WithContext(ctx context.Context) Logger
+	WithFields(fields Fields) Logger
+}


### PR DESCRIPTION
As the logger from the mon package has some quirks and drawbacks, we want to introduce a new logger package `log` in the v0.2.x release branch with a more clean approach to how logging should work inside the gosoline framework.

lean interface:
```
type Fields map[string]interface{}

type Logger interface {
	Debug(msg string, args ...interface{})
	Info(msg string, args ...interface{})
	Warn(msg string, args ...interface{})
	Error(msg string, args ...interface{})

	WithChannel(channel string) Logger
	WithContext(ctx context.Context) Logger
	WithFields(fields Fields) Logger
}
```

Have only one function for each log level calls instead of e.g. `Info` and `Infof`.
Drop the `err error` parameter from the old interface `Error(err error, msg string)`. Instead use the `fmt.Errorf` function internally to create the error to log.

Drop hooks in favor of more generic handlers to do whatever you want with your log calls:
- write to stdout, files, message brokers, ...
- forward errors to trackers like sentry
- write metrics
- ...

Configurable via cfg package:
```
log:
  default:
    type: stdout
    level: info
    channel: *
    format: console
    timestamp_format: 15:04:05.000
  file:
    type: file
    filename: kernel_issues.log
    level: warn
    channel: kernel
    format: json
    timestamp_format: 15:04:05.000
```