### PR TITLE
exec: improved logging, added error checks for header and tls timeout;

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,4 @@ come in the next weeks:
 * cloud: bundle aws config
 * add error returns to constructors
 * modules: remove boot
+* proper default value merging

--- a/pkg/cloud/aws/error.go
+++ b/pkg/cloud/aws/error.go
@@ -42,10 +42,10 @@ func IsInvalidStatusError(err error) bool {
 
 func CheckInvalidStatusError(_ interface{}, err error) exec.ErrorType {
 	if IsInvalidStatusError(err) {
-		return exec.ErrorRetryable
+		return exec.ErrorTypeRetryable
 	}
 
-	return exec.ErrorUnknown
+	return exec.ErrorTypeUnknown
 }
 
 func IsAwsError(err error, awsCode string) bool {
@@ -68,10 +68,10 @@ func IsAwsErrorCodeRequestCanceled(err error) bool {
 
 func CheckConnectionError(_ interface{}, err error) exec.ErrorType {
 	if IsConnectionError(err) {
-		return exec.ErrorRetryable
+		return exec.ErrorTypeRetryable
 	}
 
-	return exec.ErrorUnknown
+	return exec.ErrorTypeUnknown
 }
 
 func IsConnectionError(err error) bool {
@@ -86,16 +86,16 @@ func IsConnectionError(err error) bool {
 
 func CheckErrorRetryable(_ interface{}, err error) exec.ErrorType {
 	if request.IsErrorRetryable(err) {
-		return exec.ErrorRetryable
+		return exec.ErrorTypeRetryable
 	}
 
-	return exec.ErrorUnknown
+	return exec.ErrorTypeUnknown
 }
 
 func CheckErrorThrottle(_ interface{}, err error) exec.ErrorType {
 	if request.IsErrorThrottle(err) {
-		return exec.ErrorRetryable
+		return exec.ErrorTypeRetryable
 	}
 
-	return exec.ErrorUnknown
+	return exec.ErrorTypeUnknown
 }

--- a/pkg/cloud/aws/error_test.go
+++ b/pkg/cloud/aws/error_test.go
@@ -50,17 +50,17 @@ func TestInvalidStatusError(t *testing.T) {
 				Status: 400,
 			},
 			isInvalidStatusError: true,
-			errorType:            exec.ErrorRetryable,
+			errorType:            exec.ErrorTypeRetryable,
 		},
 		"canceled": {
 			err:                  exec.RequestCanceledError,
 			isInvalidStatusError: false,
-			errorType:            exec.ErrorUnknown,
+			errorType:            exec.ErrorTypeUnknown,
 		},
 		"nil": {
 			err:                  nil,
 			isInvalidStatusError: false,
-			errorType:            exec.ErrorUnknown,
+			errorType:            exec.ErrorTypeUnknown,
 		},
 	} {
 		test := test

--- a/pkg/cloud/aws/executor.go
+++ b/pkg/cloud/aws/executor.go
@@ -54,7 +54,9 @@ func NewBackoffExecutorWithSender(logger mon.Logger, res *exec.ExecutableResourc
 	checks = append(checks, []exec.ErrorChecker{
 		exec.CheckRequestCanceled,
 		exec.CheckUsedClosedConnectionError,
-		exec.CheckTimeOutError,
+		exec.CheckTimeoutError,
+		exec.CheckClientAwaitHeaderTimeoutError,
+		exec.CheckTlsHandshakeTimeoutError,
 		CheckInvalidStatusError,
 		CheckConnectionError,
 		CheckErrorRetryable,

--- a/pkg/ddb/repository.go
+++ b/pkg/ddb/repository.go
@@ -98,10 +98,10 @@ func NewRepository(config cfg.Config, logger mon.Logger, settings *Settings) Rep
 	}
 	executor := aws.NewExecutor(logger, res, &settings.Backoff, func(result interface{}, err error) exec.ErrorType {
 		if isError(err, dynamodb.ErrCodeConditionalCheckFailedException) {
-			return exec.ErrorOk
+			return exec.ErrorTypeOk
 		}
 
-		return exec.ErrorUnknown
+		return exec.ErrorTypeUnknown
 	})
 
 	svc := NewService(config, logger)

--- a/pkg/exec/error_canceled.go
+++ b/pkg/exec/error_canceled.go
@@ -1,0 +1,61 @@
+package exec
+
+import (
+	"context"
+	"errors"
+	"github.com/hashicorp/go-multierror"
+)
+
+const RequestCanceledError = requestCanceledError("RequestCanceled")
+
+type requestCanceledError string
+
+func (e requestCanceledError) Error() string {
+	return string(e)
+}
+
+func CheckRequestCanceled(_ interface{}, err error) ErrorType {
+	if IsRequestCanceled(err) {
+		return ErrorTypePermanent
+	}
+
+	return ErrorTypeUnknown
+}
+
+type RequestCanceledCheck func(err error) bool
+
+var requestCancelChecks = make([]RequestCanceledCheck, 0)
+
+func AddRequestCancelCheck(check RequestCanceledCheck) {
+	requestCancelChecks = append(requestCancelChecks, check)
+}
+
+// Check if the given error was (only) caused by a canceled context - if there is any other error contained in it, we
+// return false. Thus, if IsRequestCanceled returns true, you can (and should) ignore the error and stop processing instead.
+func IsRequestCanceled(err error) bool {
+	if errors.Is(err, context.Canceled) || errors.Is(err, RequestCanceledError) {
+		return true
+	}
+
+	for _, check := range requestCancelChecks {
+		if check(err) {
+			return true
+		}
+	}
+
+	// some functions (like a batched Write) return a multierror which does not properly unwrap
+	// so we check if all these requests failed. If there is any other error, we return false to
+	// trigger normal error handling
+	var multiErr *multierror.Error
+	if errors.As(err, &multiErr) && multiErr != nil {
+		for _, err := range multiErr.Errors {
+			if !IsRequestCanceled(err) {
+				return false
+			}
+		}
+
+		return len(multiErr.Errors) > 0
+	}
+
+	return false
+}

--- a/pkg/exec/error_canceled_test.go
+++ b/pkg/exec/error_canceled_test.go
@@ -1,0 +1,72 @@
+package exec_test
+
+import (
+	"context"
+	"fmt"
+	"github.com/applike/gosoline/pkg/exec"
+	"github.com/hashicorp/go-multierror"
+	"github.com/stretchr/testify/assert"
+	"io"
+	"testing"
+)
+
+func TestIsRequestCanceled(t *testing.T) {
+	for name, test := range map[string]struct {
+		err        error
+		isCanceled bool
+	}{
+		"none": {
+			err:        nil,
+			isCanceled: false,
+		},
+		"other error": {
+			err:        io.EOF,
+			isCanceled: false,
+		},
+		"format error": {
+			err:        fmt.Errorf("error: %d", 42),
+			isCanceled: false,
+		},
+		"simple": {
+			err:        context.Canceled,
+			isCanceled: true,
+		},
+		"simple wrapped": {
+			err:        fmt.Errorf("error %w", context.Canceled),
+			isCanceled: true,
+		},
+		"exec": {
+			err:        exec.RequestCanceledError,
+			isCanceled: true,
+		},
+		"exec wrapped": {
+			err:        fmt.Errorf("error %w", exec.RequestCanceledError),
+			isCanceled: true,
+		},
+		"multierror empty": {
+			err:        multierror.Append(nil),
+			isCanceled: false,
+		},
+		"multierror single": {
+			err:        multierror.Append(nil, context.Canceled),
+			isCanceled: true,
+		},
+		"multierror single wrapped": {
+			err:        multierror.Append(nil, fmt.Errorf("error %w", context.Canceled)),
+			isCanceled: true,
+		},
+		"multierror multiple wrapped": {
+			err:        multierror.Append(nil, fmt.Errorf("error %w", context.Canceled), fmt.Errorf("error %w", exec.RequestCanceledError)),
+			isCanceled: true,
+		},
+		"multierror mixed": {
+			err:        multierror.Append(nil, context.Canceled, io.EOF),
+			isCanceled: false,
+		},
+	} {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.isCanceled, exec.IsRequestCanceled(test.err))
+		})
+	}
+}

--- a/pkg/exec/test_http_client.go
+++ b/pkg/exec/test_http_client.go
@@ -1,0 +1,59 @@
+package exec
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+)
+
+func NewTestHttpClient(timeout time.Duration, trips Trips) http.Client {
+	return http.Client{
+		Timeout:   timeout,
+		Transport: NewTestRoundTripper(trips...),
+	}
+}
+
+type Trips []Trip
+
+type Trip struct {
+	duration time.Duration
+	err      error
+}
+
+func DoTrip(duration time.Duration, err error) Trip {
+	return Trip{
+		duration: duration,
+		err:      err,
+	}
+}
+
+type TestRoundTripper struct {
+	trips   []Trip
+	current int
+}
+
+func NewTestRoundTripper(trips ...Trip) *TestRoundTripper {
+	return &TestRoundTripper{
+		trips:   trips,
+		current: 0,
+	}
+}
+
+func (t *TestRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	defer func() {
+		t.current++
+	}()
+
+	if t.current >= len(t.trips) {
+		return nil, fmt.Errorf("out of trips")
+	}
+
+	trip := t.trips[t.current]
+	time.Sleep(trip.duration)
+
+	if trip.err != nil {
+		return nil, trip.err
+	}
+
+	return &http.Response{}, nil
+}

--- a/pkg/redis/client_test.go
+++ b/pkg/redis/client_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/applike/gosoline/pkg/redis"
 	"github.com/elliotchance/redismock"
 	baseRedis "github.com/go-redis/redis"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"testing"
 	"time"
@@ -47,6 +48,7 @@ func (s *ClientWithMiniRedisTestSuite) TestGetNotFound() {
 	// the logger should fail the test as soon as any logger.Warn or anything gets called
 	// because we want to test the executor not doing that
 	logger := new(mocks.Logger)
+	logger.On("WithFields", mock.Anything).Return(logger).Once()
 	logger.On("WithContext", context.Background()).Return(logger).Once()
 	executor := redis.NewBackoffExecutor(logger, exec.BackoffSettings{
 		Enabled:             true,

--- a/pkg/redis/exec.go
+++ b/pkg/redis/exec.go
@@ -34,26 +34,26 @@ func NewBackoffExecutor(logger mon.Logger, settings exec.BackoffSettings, name s
 
 func NilChecker(_ interface{}, err error) exec.ErrorType {
 	if errors.Is(err, Nil) {
-		return exec.ErrorOk
+		return exec.ErrorTypeOk
 	}
 
-	return exec.ErrorUnknown
+	return exec.ErrorTypeUnknown
 }
 
 func OOMChecker(_ interface{}, err error) exec.ErrorType {
 	if strings.HasPrefix(err.Error(), "OOM") {
-		return exec.ErrorRetryable
+		return exec.ErrorTypeRetryable
 	}
 
-	return exec.ErrorUnknown
+	return exec.ErrorTypeUnknown
 }
 
 func RetryableErrorChecker(_ interface{}, err error) exec.ErrorType {
 	if IsRetryableError(err) {
-		return exec.ErrorRetryable
+		return exec.ErrorTypeRetryable
 	}
 
-	return exec.ErrorUnknown
+	return exec.ErrorTypeUnknown
 }
 
 func IsRetryableError(err error) bool {


### PR DESCRIPTION
- improved logging to detect errors caused by reaching the configured max elapsed time threshold
- added error check for Client.Timeout exceeded while awaiting headers
- added error check for net/http: TLS handshake timeout