### PR TITLE
stream: switch order of go routines started in coffin to avoid premature termination;

### DIFF
--- a/pkg/stream/pipeline.go
+++ b/pkg/stream/pipeline.go
@@ -88,8 +88,8 @@ func (p *Pipeline) Run(ctx context.Context) error {
 	defer p.logger.Info("leaving pipeline")
 	defer p.process(ctx, true)
 
-	p.cfn.GoWithContextf(ctx, p.input.Run, "panic during run of the consumer input")
 	p.cfn.GoWithContextf(ctx, p.read, "panic during consuming")
+	p.cfn.GoWithContextf(ctx, p.input.Run, "panic during run of the consumer input")
 
 	for {
 		select {


### PR DESCRIPTION
In an integration test you could easily have an input which quickly
finishes its `Run` method. With a little bit of bad luck your pipeline
has not yet started the read routine and therefore the coffin dies
before you started all go routines. Switching the order avoids this as
`read` waits until the input produced data or stopped.