### PR TITLE
apiserver: add ctx and error to Definer;

### DIFF
--- a/examples/apiserver/simple-handlers/main.go
+++ b/examples/apiserver/simple-handlers/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"github.com/applike/gosoline/pkg/apiserver"
 	"github.com/applike/gosoline/pkg/apiserver/auth"
 	"github.com/applike/gosoline/pkg/apiserver/crud"
@@ -13,24 +14,31 @@ type myTestStruct struct {
 	Status string `json:"status"`
 }
 
+func apiDefiner(ctx context.Context, config cfg.Config, logger mon.Logger) (*apiserver.Definitions, error) {
+	definitions := &apiserver.Definitions{}
+
+	definitions.GET("/json-from-map", apiserver.CreateHandler(&JsonResponseFromMapHandler{}))
+	definitions.GET("/json-from-struct", apiserver.CreateHandler(&JsonResponseFromStructHandler{}))
+
+	definitions.POST("/json-handler", apiserver.CreateJsonHandler(&JsonInputHandler{}))
+
+	group := definitions.Group("/admin")
+	group.Use(auth.NewChainHandler(map[string]auth.Authenticator{
+		"api-key":    auth.NewConfigKeyAuthenticator(config, logger, auth.ProvideValueFromHeader("X-API-KEY")),
+		"basic-auth": auth.NewBasicAuthAuthenticator(config, logger),
+	}))
+
+	group.GET("/authenticated", apiserver.CreateHandler(&AdminAuthenticatedHandler{}))
+
+	crud.AddCrudHandlers(logger, definitions, 0, "/myEntity", &MyEntityHandler{
+		repo: &MyEntityRepository{},
+	})
+
+	return definitions, nil
+}
+
 func main() {
 	app := application.New(application.WithConfigFile("config.dist.yml", "yml"))
-	app.Add("api", apiserver.New(func(config cfg.Config, logger mon.Logger, definitions *apiserver.Definitions) {
-		definitions.GET("/json-from-map", apiserver.CreateHandler(&JsonResponseFromMapHandler{}))
-		definitions.GET("/json-from-struct", apiserver.CreateHandler(&JsonResponseFromStructHandler{}))
-
-		definitions.POST("/json-handler", apiserver.CreateJsonHandler(&JsonInputHandler{}))
-
-		group := definitions.Group("/admin")
-		group.Use(auth.NewChainHandler(map[string]auth.Authenticator{
-			"api-key":    auth.NewConfigKeyAuthenticator(config, logger, auth.ProvideValueFromHeader("X-API-KEY")),
-			"basic-auth": auth.NewBasicAuthAuthenticator(config, logger),
-		}))
-		group.GET("/authenticated", apiserver.CreateHandler(&AdminAuthenticatedHandler{}))
-
-		crud.AddCrudHandlers(logger, definitions, 0, "/myEntity", &MyEntityHandler{
-			repo: &MyEntityRepository{},
-		})
-	}))
+	app.Add("api", apiserver.New(apiDefiner))
 	app.Run()
 }

--- a/pkg/apiserver/definition.go
+++ b/pkg/apiserver/definition.go
@@ -1,6 +1,7 @@
 package apiserver
 
 import (
+	"context"
 	"fmt"
 	"github.com/applike/gosoline/pkg/cfg"
 	"github.com/applike/gosoline/pkg/mon"
@@ -8,7 +9,7 @@ import (
 	"strings"
 )
 
-type Define func(config cfg.Config, logger mon.Logger, definitions *Definitions)
+type Definer func(ctx context.Context, config cfg.Config, logger mon.Logger) (*Definitions, error)
 
 type Definition struct {
 	group        *Definitions

--- a/pkg/test/suite_apiserver.go
+++ b/pkg/test/suite_apiserver.go
@@ -42,7 +42,7 @@ func (c ApiServerTestCase) request(client *resty.Client) (*resty.Response, error
 
 type TestingSuiteApiServer interface {
 	TestingSuite
-	SetupApiDefinitions() apiserver.Define
+	SetupApiDefinitions() apiserver.Definer
 	SetupTestCases() []ApiServerTestCase
 	TestApiServer(app AppUnderTest, server *apiserver.ApiServer, testCases []ApiServerTestCase)
 }


### PR DESCRIPTION
With the recent refactor of the modules, it's possible to expose errors within handlers created for the apiserver.
This PR provides support to properly handle those errors within the apiserver aswell.