### PR TITLE
ddb: use backoff settings for transactions;

### DIFF
--- a/pkg/ddb/repository_transaction.go
+++ b/pkg/ddb/repository_transaction.go
@@ -35,6 +35,13 @@ func NewTransactionRepository(config cfg.Config, logger mon.Logger) *transaction
 
 	settings.Client.MaxRetries = config.GetInt("aws_sdk_retries")
 
+	backoffSettings := &exec.BackoffSettings{}
+	config.UnmarshalKey("ddb.backoff", backoffSettings)
+
+	if err := cfg.Merge(&settings.Backoff, *backoffSettings); err != nil {
+		logger.Panicf(err, "could not merge backoff settings for transactions")
+	}
+
 	tracer := tracing.ProviderTracer(config, logger)
 	client := ProvideClient(config, logger, settings)
 

--- a/pkg/ddb/repository_transaction_test.go
+++ b/pkg/ddb/repository_transaction_test.go
@@ -46,6 +46,13 @@ func (s *RepositoryTransactionTestSuite) SetupTest() {
 	s.repository = ddb.NewTransactionRepositoryWithInterfaces(s.logger, s.client, s.executor, s.tracer)
 }
 
+func (s *RepositoryTransactionTestSuite) TearDownTest() {
+	s.span.AssertExpectations(s.T())
+	s.client.AssertExpectations(s.T())
+	s.executor.AssertExpectations(s.T())
+	s.tracer.AssertExpectations(s.T())
+}
+
 func (s *RepositoryTransactionTestSuite) TestTransactGetItems() {
 	ctx := context.Background()
 
@@ -157,11 +164,6 @@ func (s *RepositoryTransactionTestSuite) TestTransactGetItems() {
 
 	assert.Equal(s.T(), expectedResult, result)
 	assert.Equal(s.T(), expectedModels, models)
-
-	s.client.AssertExpectations(s.T())
-	s.executor.AssertExpectations(s.T())
-	s.tracer.AssertExpectations(s.T())
-	s.span.AssertExpectations(s.T())
 }
 
 func (s *RepositoryTransactionTestSuite) TestTransactWriteItems_ConditionCheckFailed() {
@@ -355,11 +357,6 @@ func (s *RepositoryTransactionTestSuite) TestTransactWriteItems() {
 	}}
 
 	assert.Equal(s.T(), expected, result)
-
-	s.client.AssertExpectations(s.T())
-	s.executor.AssertExpectations(s.T())
-	s.tracer.AssertExpectations(s.T())
-	s.span.AssertExpectations(s.T())
 }
 
 func buildTransactGetItemBuilder(item *model) ddb.TransactGetItemBuilder {


### PR DESCRIPTION
Backoff should be configurable via the config package