### PR TITLE
cli: added option to run a cli app with more than a single module and allow applying options to a module factory;

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -10,7 +10,7 @@ type kernelSettings struct {
 	KillTimeout time.Duration `cfg:"killTimeout" default:"10s"`
 }
 
-func Run(module kernel.ModuleFactory) {
+func Run(module kernel.ModuleFactory, otherModuleMaps ...map[string]kernel.ModuleFactory) {
 	configOptions := []cfg.Option{
 		cfg.WithErrorHandlers(defaultErrorHandler),
 		cfg.WithConfigFile("./config.dist.yml", "yml"),
@@ -32,5 +32,10 @@ func Run(module kernel.ModuleFactory) {
 
 	k := kernel.New(config, logger, kernel.KillTimeout(settings.KillTimeout))
 	k.Add("cli", module, kernel.ModuleType(kernel.TypeEssential), kernel.ModuleStage(kernel.StageApplication))
+	for _, otherModuleMap := range otherModuleMaps {
+		for name, otherModule := range otherModuleMap {
+			k.Add(name, otherModule)
+		}
+	}
 	k.Run()
 }


### PR DESCRIPTION
If you want to run a cli module which is using the status manager you
have to add a module to the kernel. This commit allows you to run a cli
app with more than a single module so both modules can be specified. It
also allows you to apply options directly to a module factory instead of
a module to allow you to still specify module options when adding a
multi module factory.