### PR TITLE
ddb: change GetItem and BatchGetItem to not return expired items;

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -143,7 +143,6 @@ github.com/fasthttp-contrib/websocket v0.0.0-20160511215533-1f3b11f56072/go.mod 
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
-github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
@@ -213,9 +212,7 @@ github.com/gomodule/redigo v2.0.0+incompatible/go.mod h1:B4C85qUVwatsJoIUNIfCRsp
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
-github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -249,7 +246,6 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/imdario/mergo v0.3.7 h1:Y+UAYTZ7gDEuOfhxKWy+dvb5dRQ6rJjFSdX2HZY1/gI=
 github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
@@ -497,7 +493,6 @@ github.com/stretchr/testify v1.1.4/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -628,7 +623,6 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 h1:SQFwaSi55rU7vdNs9Yr0Z324VNlrF+0wMqRXT4St8ck=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -658,7 +652,6 @@ golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210112080510-489259a85091 h1:DMyOG0U+gKfu8JZzg2UQe9MeaC1X+xQWlAKcRnjxjCw=
 golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -692,7 +685,6 @@ golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -725,12 +717,10 @@ google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzi
 google.golang.org/protobuf v1.23.0 h1:4MY060fB1DLGMB/7MBTLnwQUY6+F09GEiz6SsrNqyzM=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
-gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/go-playground/assert.v1 v1.2.1 h1:xoYuJVE7KT85PYWrN730RguIQO0ePzVRfFMXadIrXTM=
 gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=
@@ -753,11 +743,9 @@ gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637 h1:yiW+nvdHb9LVqSHQBXfZCieqV
 gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637/go.mod h1:BHsqpu/nsuzkT5BpiH1EMZPLyqSMM8JbIavyFACoFNk=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20191120175047-4206685974f2 h1:XZx7nhd5GMaZpmDaEHFVafUZC7ya0fuo7cSJ3UCKYmM=
 gopkg.in/yaml.v3 v3.0.0-20191120175047-4206685974f2/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/ddb/builder_factory.go
+++ b/pkg/ddb/builder_factory.go
@@ -1,5 +1,7 @@
 package ddb
 
+import "github.com/applike/gosoline/pkg/clock"
+
 type BuilderFactory interface {
 	GetItemBuilder() GetItemBuilder
 	QueryBuilder() QueryBuilder
@@ -10,9 +12,10 @@ type BuilderFactory interface {
 
 type builderFactory struct {
 	metadata *Metadata
+	clock    clock.Clock
 }
 
-func NewBuilderFactory(settings *Settings) (BuilderFactory, error) {
+func NewBuilderFactory(settings *Settings, clock clock.Clock) (BuilderFactory, error) {
 	metadataFactory := NewMetadataFactory()
 	metadata, err := metadataFactory.GetMetadata(settings)
 
@@ -22,19 +25,20 @@ func NewBuilderFactory(settings *Settings) (BuilderFactory, error) {
 
 	return &builderFactory{
 		metadata: metadata,
+		clock:    clock,
 	}, nil
 }
 
 func (f *builderFactory) GetItemBuilder() GetItemBuilder {
-	return NewGetItemBuilder(f.metadata)
+	return NewGetItemBuilder(f.metadata, f.clock)
 }
 
 func (f *builderFactory) QueryBuilder() QueryBuilder {
-	return NewQueryBuilder(f.metadata)
+	return NewQueryBuilder(f.metadata, f.clock)
 }
 
 func (f *builderFactory) BatchGetItemsBuilder() BatchGetItemsBuilder {
-	return NewBatchGetItemsBuilder(f.metadata)
+	return NewBatchGetItemsBuilder(f.metadata, f.clock)
 }
 
 func (f *builderFactory) PutItemBuilder() PutItemBuilder {

--- a/pkg/ddb/builder_scan.go
+++ b/pkg/ddb/builder_scan.go
@@ -2,6 +2,7 @@ package ddb
 
 import (
 	"fmt"
+	"github.com/applike/gosoline/pkg/clock"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/dynamodb/expression"
@@ -32,7 +33,6 @@ type scanBuilder struct {
 	filterBuilder
 
 	err            error
-	metadata       *Metadata
 	indexName      *string
 	selected       FieldAware
 	projection     interface{}
@@ -43,9 +43,10 @@ type scanBuilder struct {
 	consistentRead *bool
 }
 
-func NewScanBuilder(metadata *Metadata) ScanBuilder {
+func NewScanBuilder(metadata *Metadata, clock clock.Clock) ScanBuilder {
 	return &scanBuilder{
-		metadata: metadata,
+		filterBuilder: newFilterBuilder(metadata, clock),
+
 		selected: metadata.Main,
 	}
 }
@@ -146,7 +147,7 @@ func (b *scanBuilder) buildExpression(result interface{}) (expression.Expression
 	parameters := 0
 	exprBuilder := expression.NewBuilder()
 
-	if filter := b.buildFilterCondition(b.metadata); filter != nil {
+	if filter := b.buildFilterCondition(); filter != nil {
 		exprBuilder = exprBuilder.WithFilter(*filter)
 		parameters++
 	}

--- a/pkg/ddb/expr_filter.go
+++ b/pkg/ddb/expr_filter.go
@@ -1,23 +1,42 @@
 package ddb
 
 import (
+	"github.com/applike/gosoline/pkg/clock"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
 	"github.com/aws/aws-sdk-go/service/dynamodb/expression"
-	"time"
 )
 
-type filterBuilder struct {
-	filterCondition  *expression.ConditionBuilder
-	disableTtlFilter bool
+type ttlStruct struct {
+	Ttl int64 `json:"ttl"`
 }
 
-func (b *filterBuilder) buildFilterCondition(metadata *Metadata) *expression.ConditionBuilder {
-	ttl := metadata.TimeToLive
+type ttlFilterer interface {
+	PerformFilterCondition(item map[string]*dynamodb.AttributeValue) (bool, error)
+}
+
+type filterBuilder struct {
+	metadata         *Metadata
+	filterCondition  *expression.ConditionBuilder
+	disableTtlFilter bool
+	clock            clock.Clock
+}
+
+func newFilterBuilder(metadata *Metadata, clock clock.Clock) filterBuilder {
+	return filterBuilder{
+		metadata: metadata,
+		clock:    clock,
+	}
+}
+
+func (b *filterBuilder) buildFilterCondition() *expression.ConditionBuilder {
+	ttl := b.metadata.TimeToLive
 
 	if !ttl.Enabled || b.disableTtlFilter {
 		return b.filterCondition
 	}
 
-	now := time.Now().Unix()
+	now := b.clock.Now().Unix()
 	expr := expression.GreaterThan(expression.Name(ttl.Field), expression.Value(now))
 
 	if b.filterCondition == nil {
@@ -27,4 +46,25 @@ func (b *filterBuilder) buildFilterCondition(metadata *Metadata) *expression.Con
 	expr = b.filterCondition.And(expr)
 
 	return &expr
+}
+
+func (b *filterBuilder) PerformFilterCondition(item map[string]*dynamodb.AttributeValue) (bool, error) {
+	ttl := b.metadata.TimeToLive
+
+	if !ttl.Enabled || b.disableTtlFilter {
+		return true, nil
+	}
+
+	now := b.clock.Now().Unix()
+
+	s := &ttlStruct{}
+	err := dynamodbattribute.UnmarshalMap(map[string]*dynamodb.AttributeValue{
+		"ttl": item[ttl.Field],
+	}, s)
+
+	if err != nil {
+		return false, err
+	}
+
+	return s.Ttl > now, nil
 }

--- a/pkg/ddb/mocks/BatchGetItemsBuilder.go
+++ b/pkg/ddb/mocks/BatchGetItemsBuilder.go
@@ -34,6 +34,22 @@ func (_m *BatchGetItemsBuilder) Build(result interface{}) (*dynamodb.BatchGetIte
 	return r0, r1
 }
 
+// DisableTtlFilter provides a mock function with given fields:
+func (_m *BatchGetItemsBuilder) DisableTtlFilter() ddb.BatchGetItemsBuilder {
+	ret := _m.Called()
+
+	var r0 ddb.BatchGetItemsBuilder
+	if rf, ok := ret.Get(0).(func() ddb.BatchGetItemsBuilder); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(ddb.BatchGetItemsBuilder)
+		}
+	}
+
+	return r0
+}
+
 // WithConsistentRead provides a mock function with given fields: consistentRead
 func (_m *BatchGetItemsBuilder) WithConsistentRead(consistentRead bool) ddb.BatchGetItemsBuilder {
 	ret := _m.Called(consistentRead)

--- a/pkg/ddb/mocks/GetItemBuilder.go
+++ b/pkg/ddb/mocks/GetItemBuilder.go
@@ -34,6 +34,22 @@ func (_m *GetItemBuilder) Build(result interface{}) (*dynamodb.GetItemInput, err
 	return r0, r1
 }
 
+// DisableTtlFilter provides a mock function with given fields:
+func (_m *GetItemBuilder) DisableTtlFilter() ddb.GetItemBuilder {
+	ret := _m.Called()
+
+	var r0 ddb.GetItemBuilder
+	if rf, ok := ret.Get(0).(func() ddb.GetItemBuilder); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(ddb.GetItemBuilder)
+		}
+	}
+
+	return r0
+}
+
 // WithConsistentRead provides a mock function with given fields: consistentRead
 func (_m *GetItemBuilder) WithConsistentRead(consistentRead bool) ddb.GetItemBuilder {
 	ret := _m.Called(consistentRead)

--- a/pkg/test/suite/run.go
+++ b/pkg/test/suite/run.go
@@ -3,8 +3,11 @@ package suite
 import (
 	"fmt"
 	"github.com/applike/gosoline/pkg/clock"
+	"github.com/applike/gosoline/pkg/cloud"
 	"github.com/applike/gosoline/pkg/stream"
 	"github.com/applike/gosoline/pkg/test/env"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/stretchr/testify/assert"
 	"reflect"
 	"strings"
@@ -23,6 +26,10 @@ type testCaseDefinition struct {
 var testCaseDefinitions = map[string]testCaseDefinition{}
 
 func Run(t *testing.T, suite TestingSuite, extraOptions ...Option) {
+	cloud.WithDefaultOptions(func(config *aws.Config) {
+		config.Credentials = credentials.NewStaticCredentials("id", "secret", "token")
+	})
+
 	var err error
 	var testCases map[string]testCaseRunner
 	var suiteOptions = suiteApplyOptions(suite, extraOptions)

--- a/test/cloud/aws/dynamodb/client_test.go
+++ b/test/cloud/aws/dynamodb/client_test.go
@@ -154,9 +154,9 @@ func (s *ClientTestSuite) TestMaxElapsedTimeExceeded() {
 	})
 
 	var expectedErr *gosoAws.ErrRetryMaxElapsedTimeExceeded
-	isErrRetryAttempsExceeded := errors.As(err, &expectedErr)
+	isErrRetryAttemptsExceeded := errors.As(err, &expectedErr)
 
-	s.True(isErrRetryAttempsExceeded)
+	s.True(isErrRetryAttemptsExceeded)
 	loggerMock.AssertExpectations(s.T())
 }
 

--- a/test/ddb/config.dist.yml
+++ b/test/ddb/config.dist.yml
@@ -1,0 +1,14 @@
+env: test
+
+app_project: gosoline
+app_family: test
+app_name: ddb-test
+
+aws_sdk_retries: 1
+aws_dynamoDb_endpoint: http://localhost:4566
+aws_dynamoDb_autoCreate: false
+
+ddb:
+  backoff:
+    enabled: true
+    blocking: true

--- a/test/ddb/ddb_test.go
+++ b/test/ddb/ddb_test.go
@@ -3,84 +3,39 @@
 package ddb_test
 
 import (
-	"fmt"
-	cfgMocks "github.com/applike/gosoline/pkg/cfg/mocks"
+	"context"
+	"github.com/applike/gosoline/pkg/clock"
 	"github.com/applike/gosoline/pkg/ddb"
-	"github.com/applike/gosoline/pkg/exec"
 	"github.com/applike/gosoline/pkg/mdl"
-	monMocks "github.com/applike/gosoline/pkg/mon/mocks"
-	pkgTest "github.com/applike/gosoline/pkg/test"
-	"github.com/applike/gosoline/pkg/tracing"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/suite"
-	"os"
+	"github.com/applike/gosoline/pkg/test/suite"
 	"testing"
+	"time"
 )
 
 type TestData struct {
 	Id   string `json:"id" ddb:"key=hash"`
 	Data string `json:"data"`
+	Ttl  int64  `json:"ttl" ddb:"ttl=enabled"`
 }
 
 type DdbTestSuite struct {
 	suite.Suite
-	mocks     *pkgTest.Mocks
-	ddbConfig ddb.Settings
-	repo      ddb.Repository
+	repo  ddb.Repository
+	clock clock.FakeClock
 }
 
-func (s *DdbTestSuite) SetupSuite() {
-	err := os.Setenv("AWS_ACCESS_KEY_ID", "a")
-	s.NoError(err)
-	err = os.Setenv("AWS_SECRET_ACCESS_KEY", "b")
-	s.NoError(err)
+func (s *DdbTestSuite) SetupSuite() []suite.Option {
+	s.clock = clock.NewFakeClockAt(time.Now().UTC())
 
-	mocks, err := pkgTest.Boot("../test_configs/config.dynamodb.test.yml")
-
-	if err != nil {
-		if mocks != nil {
-			mocks.Shutdown()
-		}
-
-		s.Fail("failed to boot mocks: %s", err.Error())
-
-		return
-	}
-
-	s.mocks = mocks
-}
-
-func (s *DdbTestSuite) TearDownSuite() {
-	if s.mocks != nil {
-		s.mocks.Shutdown()
-		s.mocks = nil
+	return []suite.Option{
+		suite.WithClockProvider(s.clock),
+		suite.WithConfigFile("./config.dist.yml"),
+		suite.WithoutAutoDetectedComponents("localstack"),
 	}
 }
 
-func (s *DdbTestSuite) SetupTest() {
-	var err error
-	var ddbEndpoint = fmt.Sprintf("http://%s:%d", s.mocks.ProvideDynamoDbHost("dynamodb"), s.mocks.ProvideDynamoDbPort("dynamodb"))
-
-	config := new(cfgMocks.Config)
-	config.On("GetBool", "aws_dynamoDb_autoCreate").Return(true)
-	config.On("GetInt", "aws_sdk_retries").Return(3)
-	config.On("UnmarshalKey", "tracing", &tracing.TracerSettings{})
-	config.On("GetString", "aws_dynamoDb_endpoint").Return(ddbEndpoint)
-	config.On("UnmarshalKey", "ddb.backoff", &exec.BackoffSettings{}).Run(func(args mock.Arguments) {
-		backoffSettings := args.Get(1).(*exec.BackoffSettings)
-		*backoffSettings = exec.BackoffSettings{
-			Enabled:  true,
-			Blocking: true,
-		}
-	})
-	config.On("GetString", "app_project").Return("gosoline")
-	config.On("GetString", "env").Return("test")
-	config.On("GetString", "app_family").Return("test")
-	config.On("GetString", "app_name").Return("ddb-lock-test")
-
-	logger := monMocks.NewLoggerMockedAll()
-
-	s.ddbConfig = ddb.Settings{
+func (s *DdbTestSuite) SetupTest() error {
+	ddbConfig := ddb.Settings{
 		ModelId: mdl.ModelId{
 			Name: "test-data",
 		},
@@ -90,13 +45,163 @@ func (s *DdbTestSuite) SetupTest() {
 			WriteCapacityUnits: 1,
 		},
 	}
-	s.repo, err = ddb.NewRepository(config, logger, &s.ddbConfig)
-	s.NoError(err)
+	var err error
+	s.repo, err = ddb.NewRepository(s.Env().Config(), s.Env().Logger(), &ddbConfig)
+	if err != nil {
+		return err
+	}
+
+	// check our backoff settings actually got propagated correctly
+	s.True(ddbConfig.Backoff.Blocking)
+	s.True(ddbConfig.Backoff.Enabled)
+
+	return nil
 }
 
-func (s *DdbTestSuite) TestSetValidBackoffConfig() {
-	s.True(s.ddbConfig.Backoff.Blocking)
-	s.True(s.ddbConfig.Backoff.Enabled)
+func (s *DdbTestSuite) TestWriteReadUpdateDeleteItem() {
+	ctx := context.Background()
+
+	_, err := s.repo.PutItem(ctx, nil, s.makeItem("1", "abc", time.Hour))
+	s.NoError(err)
+
+	item := &TestData{}
+	result, err := s.repo.GetItem(ctx, s.repo.GetItemBuilder().WithHash("1"), item)
+	s.NoError(err)
+	s.True(result.IsFound)
+	s.Equal(s.makeItem("1", "abc", time.Hour), item)
+
+	_, err = s.repo.UpdateItem(ctx, s.repo.UpdateItemBuilder().WithHash("1").Set("data", "def"), nil)
+	s.NoError(err)
+
+	item = &TestData{}
+	result, err = s.repo.GetItem(ctx, s.repo.GetItemBuilder().WithHash("1"), item)
+	s.NoError(err)
+	s.True(result.IsFound)
+	s.Equal(s.makeItem("1", "def", time.Hour), item)
+
+	_, err = s.repo.DeleteItem(ctx, s.repo.DeleteItemBuilder().WithHash("1"), &TestData{})
+	s.NoError(err)
+
+	item = &TestData{}
+	result, err = s.repo.GetItem(ctx, s.repo.GetItemBuilder().WithHash("1"), item)
+	s.NoError(err)
+	s.False(result.IsFound)
+}
+
+func (s *DdbTestSuite) TestGetExpiredItem() {
+	ctx := context.Background()
+
+	_, err := s.repo.PutItem(ctx, nil, s.makeItem("1", "abc", time.Second*10))
+	s.NoError(err)
+
+	// expire the record for us (ddb will still carry them)
+	s.clock.Advance(time.Minute)
+
+	item := &TestData{}
+	result, err := s.repo.GetItem(ctx, s.repo.GetItemBuilder().WithHash("1"), item)
+	s.NoError(err)
+	s.False(result.IsFound)
+}
+
+func (s *DdbTestSuite) TestBatch() {
+	ctx := context.Background()
+
+	_, err := s.repo.BatchPutItems(ctx, []*TestData{
+		s.makeItem("1", "abc", time.Hour),
+		s.makeItem("2", "def", time.Second*10),
+		s.makeItem("3", "xyz", time.Hour),
+	})
+	s.NoError(err)
+
+	var items []*TestData
+	_, err = s.repo.BatchGetItems(ctx, s.repo.BatchGetItemsBuilder().WithHashKeys([]string{"1", "2"}), &items)
+	s.NoError(err)
+	s.Equal(len(items), 2)
+	if items[0].Id == "2" {
+		items[0], items[1] = items[1], items[0]
+	}
+	s.Equal([]*TestData{
+		s.makeItem("1", "abc", time.Hour),
+		s.makeItem("2", "def", time.Second*10),
+	}, items)
+
+	// expire one record
+	s.clock.Advance(time.Minute)
+
+	items = make([]*TestData, 0)
+	_, err = s.repo.BatchGetItems(ctx, s.repo.BatchGetItemsBuilder().WithHashKeys([]string{"1", "2"}), &items)
+	s.NoError(err)
+	s.Equal([]*TestData{
+		s.makeItem("1", "abc", time.Hour-time.Minute),
+	}, items)
+
+	_, err = s.repo.BatchDeleteItems(ctx, []*TestData{
+		s.makeItem("1", "abc", time.Hour),
+		s.makeItem("2", "def", time.Second*10),
+		s.makeItem("3", "xyz", time.Hour),
+	})
+	s.NoError(err)
+
+	items = make([]*TestData, 0)
+	_, err = s.repo.BatchGetItems(ctx, s.repo.BatchGetItemsBuilder().WithHashKeys([]string{"1", "2", "3"}), &items)
+	s.NoError(err)
+	s.Equal(len(items), 0)
+}
+
+func (s *DdbTestSuite) TestScan() {
+	ctx := context.Background()
+
+	_, err := s.repo.PutItem(ctx, nil, s.makeItem("1", "abc", time.Hour))
+	s.NoError(err)
+
+	_, err = s.repo.PutItem(ctx, nil, s.makeItem("2", "def", time.Second*10))
+	s.NoError(err)
+
+	// expire the records for us (ddb will still carry them)
+	s.clock.Advance(time.Minute)
+
+	var items []*TestData
+	result, err := s.repo.Scan(ctx, s.repo.ScanBuilder(), &items)
+	s.NoError(err)
+	s.Equal(int64(1), result.ItemCount)
+	s.Equal([]*TestData{
+		s.makeItem("1", "abc", time.Hour-time.Minute),
+	}, items)
+}
+
+func (s *DdbTestSuite) TestQuery() {
+	ctx := context.Background()
+
+	_, err := s.repo.PutItem(ctx, nil, s.makeItem("1", "abc", time.Hour))
+	s.NoError(err)
+
+	_, err = s.repo.PutItem(ctx, nil, s.makeItem("2", "def", time.Second*10))
+	s.NoError(err)
+
+	// expire the records for us (ddb will still carry them)
+	s.clock.Advance(time.Minute)
+
+	var items []*TestData
+	result, err := s.repo.Query(ctx, s.repo.QueryBuilder().WithHash("1"), &items)
+	s.NoError(err)
+	s.Equal(int64(1), result.ItemCount)
+	s.Equal([]*TestData{
+		s.makeItem("1", "abc", time.Hour-time.Minute),
+	}, items)
+
+	items = make([]*TestData, 0)
+	result, err = s.repo.Query(ctx, s.repo.QueryBuilder().WithHash("2"), &items)
+	s.NoError(err)
+	s.Equal(int64(0), result.ItemCount)
+	s.Equal(0, len(items))
+}
+
+func (s *DdbTestSuite) makeItem(id string, data string, ttl time.Duration) *TestData {
+	return &TestData{
+		Id:   id,
+		Data: data,
+		Ttl:  s.clock.Now().Add(ttl).Unix(),
+	}
 }
 
 func TestDdb(t *testing.T) {


### PR DESCRIPTION
DynamoDB features a TTL field on items, but still returns expired items
from the database if you query for them before they are deleted (the
deletion will happen up to two days after an item expires). Thus we
already had logic in gosoline to filter items from a Query or Scan which
have expired but are still returned by DDB. This commit extends this
behavior such that we also filter items from GetItem or BatchGetItems if
they did expire.

This commit also updates the ddb integration test to use the new test
framework and actually adds some tests.