### PR TITLE
stream: avoid panic on closed channel in producer daemon;

### DIFF
--- a/pkg/stream/output_channel.go
+++ b/pkg/stream/output_channel.go
@@ -1,0 +1,60 @@
+package stream
+
+import (
+	"github.com/applike/gosoline/pkg/mon"
+	"sync"
+)
+
+type OutputChannel interface {
+	Read() ([]WritableMessage, bool)
+	Write(msg []WritableMessage)
+	Close()
+}
+
+type outputChannel struct {
+	logger mon.Logger
+	ch     chan []WritableMessage
+	closed bool
+	lck    sync.RWMutex
+}
+
+func NewOutputChannel(logger mon.Logger, bufferSize int) OutputChannel {
+	return &outputChannel{
+		logger: logger,
+		ch:     make(chan []WritableMessage, bufferSize),
+	}
+}
+
+func (c *outputChannel) Read() ([]WritableMessage, bool) {
+	msg, ok := <-c.ch
+
+	return msg, ok
+}
+
+func (c *outputChannel) Write(msg []WritableMessage) {
+	c.lck.RLock()
+	defer c.lck.RUnlock()
+
+	if c.closed {
+		// this can happen if we still get some traffic while everything is already shutting down.
+		// this is okay as far as the producer daemon is concerned, if your data can't handle this,
+		// you can't use the producer daemon anyway
+		c.logger.Warnf("dropped batch of %d messages: channel is already closed", len(msg))
+
+		return
+	}
+
+	c.ch <- msg
+}
+
+func (c *outputChannel) Close() {
+	c.lck.Lock()
+	defer c.lck.Unlock()
+
+	if !c.closed {
+		c.closed = true
+		close(c.ch)
+	} else {
+		c.logger.Warn("duplicate close to output channel: channel is already closed")
+	}
+}

--- a/pkg/stream/output_channel_test.go
+++ b/pkg/stream/output_channel_test.go
@@ -1,0 +1,52 @@
+package stream_test
+
+import (
+	"github.com/applike/gosoline/pkg/mon"
+	monMocks "github.com/applike/gosoline/pkg/mon/mocks"
+	"github.com/applike/gosoline/pkg/stream"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestOutputChannel_Simple(t *testing.T) {
+	logger := monMocks.NewLoggerMock()
+
+	msg := []stream.WritableMessage{
+		stream.NewMessage("hello"),
+		stream.NewMessage("world"),
+	}
+
+	ch := stream.NewOutputChannel(logger, 1)
+	ch.Write(msg)
+	ch.Close()
+
+	// should be able to read the message again
+	readMsg, ok := ch.Read()
+	assert.True(t, ok, "should be able to read message from channel")
+	assert.Equal(t, msg, readMsg, "read message should match expected message")
+
+	_, ok = ch.Read()
+	assert.False(t, ok, "should not be able to read from empty channel")
+
+	logger.AssertExpectations(t)
+}
+
+func TestOutputChannel_WriteAfterClose(t *testing.T) {
+	logger := monMocks.NewLoggerMockedUntilLevel(mon.Warn)
+
+	msg := []stream.WritableMessage{
+		stream.NewMessage("hello"),
+		stream.NewMessage("world"),
+	}
+
+	ch := stream.NewOutputChannel(logger, 1)
+	ch.Close()
+	// should not crash to write after close
+	ch.Write(msg)
+
+	_, ok := ch.Read()
+	assert.False(t, ok, "message written after close should be dropped")
+
+	// should not crash to call this a second time
+	ch.Close()
+}

--- a/pkg/stream/producer_daemon_test.go
+++ b/pkg/stream/producer_daemon_test.go
@@ -328,6 +328,24 @@ func (s *ProducerDaemonTestSuite) TestWriteWithCanceledError() {
 	s.output.AssertExpectations(s.T())
 }
 
+func (s *ProducerDaemonTestSuite) TestWriteAfterClose() {
+	s.SetupDaemon(mon.Warn, 1, 2, time.Hour, stream.MarshalJsonMessage)
+
+	messages := []stream.WritableMessage{
+		&stream.Message{Body: "1"},
+		&stream.Message{Body: "2"},
+	}
+
+	err := s.stop()
+
+	s.NoError(err)
+
+	err = s.daemon.Write(context.Background(), messages)
+	s.NoError(err, "there should be no error on write")
+
+	s.output.AssertExpectations(s.T())
+}
+
 func TestProducerDaemonTestSuite(t *testing.T) {
 	suite.Run(t, new(ProducerDaemonTestSuite))
 }


### PR DESCRIPTION
When we get writes after the producer daemon already started shutting
down, we might try to write to a closed channel. Therefore we now check
whether the channel has already been closed and, if so, drop the write
and log a warning, avoiding the panic we would otherwise get.