### PR TITLE
stream, test: Allow multiple tests to use a single inMemory output or producer daemon;

### DIFF
--- a/pkg/stream/input_in_memory.go
+++ b/pkg/stream/input_in_memory.go
@@ -5,9 +5,13 @@ import (
 	"sync"
 )
 
+var inMemoryInputsLock sync.Mutex
 var inMemoryInputs = make(map[string]*InMemoryInput)
 
 func ResetInMemoryInputs() {
+	inMemoryInputsLock.Lock()
+	defer inMemoryInputsLock.Unlock()
+
 	for _, inp := range inMemoryInputs {
 		inp.Reset()
 	}
@@ -25,6 +29,9 @@ type InMemoryInput struct {
 }
 
 func ProvideInMemoryInput(name string, settings *InMemorySettings) *InMemoryInput {
+	inMemoryInputsLock.Lock()
+	defer inMemoryInputsLock.Unlock()
+
 	if input, ok := inMemoryInputs[name]; ok {
 		return input
 	}

--- a/pkg/stream/producer_daemon.go
+++ b/pkg/stream/producer_daemon.go
@@ -53,6 +53,13 @@ type ProducerDaemon struct {
 	settings      ProducerDaemonSettings
 }
 
+func ResetProducerDaemons() {
+	producerDaemonLock.Lock()
+	defer producerDaemonLock.Unlock()
+
+	producerDaemons = map[string]*ProducerDaemon{}
+}
+
 func ProvideProducerDaemon(config cfg.Config, logger mon.Logger, name string) (*ProducerDaemon, error) {
 	producerDaemonLock.Lock()
 	defer producerDaemonLock.Unlock()

--- a/pkg/test/suite/run.go
+++ b/pkg/test/suite/run.go
@@ -135,6 +135,8 @@ func runTestCaseWithSharedEnvironment(t *testing.T, suite TestingSuite, suiteOpt
 		}
 
 		stream.ResetInMemoryInputs()
+		stream.ResetInMemoryOutputs()
+		stream.ResetProducerDaemons()
 	}
 }
 


### PR DESCRIPTION
If you write a test case to publish a message somewhere and then confirm
it was correctly published, everything was fine. If you now add a second
such test case, suddenly the output contains a second message and you
might get the wrong message in the Assert function of your test case.
This commit fixes this by resetting inMemory outputs between tests so
they no longer share this state.

The same story basically holds true for producer daemons.