### PR TITLE
db-repo: expose and config orm db settings;

### DIFF
--- a/pkg/db-repo/orm.go
+++ b/pkg/db-repo/orm.go
@@ -19,14 +19,21 @@ type OrmSettings struct {
 	Application string              `cfg:"application" default:"{app_name}"`
 }
 
+type OrmConfig struct {
+	DbName string `cfg:"db" default:"default"`
+}
+
 func NewOrm(config cfg.Config, logger mon.Logger) (*gorm.DB, error) {
-	dbClient, err := db.NewClient(config, logger, "default")
+	dbName := OrmConfig{}
+	config.UnmarshalKey("orm", &dbName)
+
+	dbClient, err := db.NewClient(config, logger, dbName.DbName)
 	if err != nil {
 		return nil, fmt.Errorf("can not create dbClient: %w", err)
 	}
 
 	settings := OrmSettings{}
-	config.UnmarshalKey("db.default", &settings)
+	config.UnmarshalKey(fmt.Sprintf("db.%s", dbName.DbName), &settings)
 
 	application := settings.Application
 

--- a/test/db_repo_change_history_test.go
+++ b/test/db_repo_change_history_test.go
@@ -4,6 +4,7 @@ package test_test
 
 import (
 	"context"
+	"fmt"
 	"github.com/applike/gosoline/pkg/cfg"
 	"github.com/applike/gosoline/pkg/db-repo"
 	"github.com/applike/gosoline/pkg/mdl"
@@ -39,9 +40,12 @@ func (s *DbRepoChangeHistoryTestSuite) SetupSuite() {
 	_ = config.Option(
 		cfg.WithConfigFile("test_configs/config.mysql.test.yml", "yml"),
 		cfg.WithConfigFile("test_configs/config.db_repo_change_history.test.yml", "yml"),
+	)
+
+	config.Option(
 		cfg.WithConfigMap(map[string]interface{}{
-			"db.default.uri.port": s.mocks.ProvideMysqlPort("mysql"),
-			"db.default.uri.host": s.mocks.ProvideMysqlHost("mysql"),
+			fmt.Sprintf("db.%s.uri.port", config.GetString("orm.db")): s.mocks.ProvideMysqlPort("mysql"),
+			fmt.Sprintf("db.%s.uri.host", config.GetString("orm.db")): s.mocks.ProvideMysqlHost("mysql"),
 		}),
 	)
 

--- a/test/test_configs/config.db_repo_change_history.test.yml
+++ b/test/test_configs/config.db_repo_change_history.test.yml
@@ -3,8 +3,11 @@ app_project: gosoline
 app_family: integration-test
 app_name: db-repo-change-history-test
 
+orm:
+  db: myDb
+
 db:
-  default:
+  myDb:
     driver: mysql
     max_connection_lifetime: 120
     parse_time: true

--- a/test/test_configs/config.fixtures_mysql.test.yml
+++ b/test/test_configs/config.fixtures_mysql.test.yml
@@ -3,6 +3,9 @@ app_project: gosoline
 app_family: integration-test
 app_name: fixture-loader
 
+orm:
+  db: default
+
 db:
   default:
     driver: mysql


### PR DESCRIPTION
This makes the db connection used by the ORM configurable by an explicit setting.