### PR TITLE
stream: reduce runtime of a test and ensure we stop an input before the app terminates;

### DIFF
--- a/pkg/stream/consumer_batch_test.go
+++ b/pkg/stream/consumer_batch_test.go
@@ -88,7 +88,7 @@ func (s *BatchConsumerTestSuite) TestRun_ProcessOnStop() {
 
 	s.input.Input.
 		On("Stop").
-		Return()
+		Once()
 
 	s.input.AcknowledgeableInput.
 		On("AckBatch", mock.AnythingOfType("[]*stream.Message")).
@@ -137,7 +137,7 @@ func (s *BatchConsumerTestSuite) TestRun_BatchSizeReached() {
 
 	s.input.Input.
 		On("Stop").
-		Return()
+		Once()
 
 	processed := 0
 
@@ -218,6 +218,9 @@ func (s *BatchConsumerTestSuite) TestRun_InputRunError() {
 	s.input.Input.
 		On("Data").
 		Return(s.data)
+	s.input.Input.
+		On("Stop").
+		Once()
 
 	s.input.Input.
 		On("Run", mock.AnythingOfType("*context.cancelCtx")).
@@ -241,6 +244,8 @@ func (s *BatchConsumerTestSuite) TestRun_InputRunError() {
 func (s *BatchConsumerTestSuite) TestRun_CallbackRunError() {
 	s.input.Input.On("Data").
 		Return(s.data)
+	s.input.Input.On("Stop").
+		Once()
 
 	s.input.Input.On("Run", mock.AnythingOfType("*context.cancelCtx")).
 		Run(func(args mock.Arguments) {
@@ -287,7 +292,6 @@ func (s *BatchConsumerTestSuite) TestRun_AggregateMessage() {
 
 	s.input.Input.
 		On("Stop").
-		Return().
 		Once()
 
 	processed := 0

--- a/pkg/stream/consumer_test.go
+++ b/pkg/stream/consumer_test.go
@@ -65,7 +65,7 @@ func (s *ConsumerTestSuite) TestGetModelNil() {
 		})
 		s.stop()
 	}).Return(nil)
-	s.input.On("Stop")
+	s.input.On("Stop").Once()
 
 	s.callback.On("GetModel", mock.AnythingOfType("map[string]interface {}")).Return(func(_ map[string]interface{}) interface{} {
 		return nil
@@ -87,7 +87,7 @@ func (s *ConsumerTestSuite) TestRun() {
 		s.data <- stream.NewJsonMessage(`"foobar"`)
 		s.stop()
 	}).Return(nil)
-	s.input.On("Stop")
+	s.input.On("Stop").Once()
 
 	consumed := make([]*string, 0)
 	s.callback.On("Consume", mock.AnythingOfType("*context.cancelCtx"), mock.AnythingOfType("*string"), map[string]interface{}{}).
@@ -131,7 +131,7 @@ func (s *ConsumerTestSuite) TestRun_ContextCancel() {
 			once.Do(func() {
 				close(stopped)
 			})
-		})
+		}).Once()
 
 	s.callback.On("Run", mock.AnythingOfType("*context.cancelCtx")).
 		Return(nil)
@@ -170,6 +170,8 @@ func (s *ConsumerTestSuite) TestRun_InputRunError() {
 func (s *ConsumerTestSuite) TestRun_CallbackRunError() {
 	s.input.On("Data").
 		Return(s.data)
+	s.input.On("Stop").
+		Once()
 
 	s.input.On("Run", mock.AnythingOfType("*context.cancelCtx")).
 		Run(func(args mock.Arguments) {
@@ -201,7 +203,7 @@ func (s *ConsumerTestSuite) TestRun_CallbackRunPanic() {
 
 	s.input.
 		On("Stop").
-		Return()
+		Once()
 
 	consumed := make([]*string, 0)
 
@@ -257,7 +259,7 @@ func (s *ConsumerTestSuite) TestRun_AggregateMessage() {
 		}).Return(nil)
 
 	s.input.On("Stop").
-		Return()
+		Once()
 
 	consumed := make([]string, 0)
 	s.callback.On("Run", mock.AnythingOfType("*context.cancelCtx")).

--- a/pkg/stream/producer_daemon_aggregator.go
+++ b/pkg/stream/producer_daemon_aggregator.go
@@ -132,6 +132,8 @@ func (a *producerDaemonAggregator) write(encodedMessage []byte) error {
 		if err != nil {
 			return fmt.Errorf("failed to write separator to buffer: %w", err)
 		}
+
+		a.uncompressedBytes += 1
 	}
 
 	_, err := a.writer.Write(encodedMessage)
@@ -141,7 +143,7 @@ func (a *producerDaemonAggregator) write(encodedMessage []byte) error {
 	}
 
 	a.messageCount++
-	a.uncompressedBytes += len(encodedMessage) + 1
+	a.uncompressedBytes += len(encodedMessage)
 
 	return nil
 }


### PR DESCRIPTION
This commit is mainly a bugfix for an annoying issue we had with some integration tests. Under load the inMemory input would sometimes report it was sending messages on a closed channel. Why? Because the input was reset for the next test before the last go routine of the test returned, thus affecting the state of the next test. We now combat this by having the consumer no longer spawn a lone go routine, but instead add it to a coffin and then closing the input from there, ensuring we wait for that go routine before finishing the test and resetting the inputs.