### PR TITLE
db_repo: add query crossing model verification and error;

### DIFF
--- a/pkg/db-repo/repository.go
+++ b/pkg/db-repo/repository.go
@@ -224,11 +224,7 @@ func (r *repository) isQueryableModel(model interface{}) bool {
 		modelType = modelType.Elem()
 	}
 
-	if strings.ToLower(modelType.Name())  != strings.ToLower(r.GetMetadata().ModelId.Name) {
-		return false
-	}
-
-	return true
+	return strings.EqualFold(modelType.Name(), r.GetMetadata().ModelId.Name)
 }
 
 func (r *repository) Query(ctx context.Context, qb *QueryBuilder, result interface{}) error {
@@ -236,7 +232,7 @@ func (r *repository) Query(ctx context.Context, qb *QueryBuilder, result interfa
 	defer span.Finish()
 
 	db := r.orm.New()
-	
+
 	db = db.Table(r.GetMetadata().TableName)
 
 	for _, j := range qb.joins {

--- a/pkg/db-repo/repository.go
+++ b/pkg/db-repo/repository.go
@@ -27,10 +27,10 @@ const (
 )
 
 var (
-	operations = []string{Create, Read, Update, Delete, Query}
-	ErrCrossQuery = fmt.Errorf("cross querying wrong model from repo")
+	operations     = []string{Create, Read, Update, Delete, Query}
+	ErrCrossQuery  = fmt.Errorf("cross querying wrong model from repo")
 	ErrCrossCreate = fmt.Errorf("cross creating wrong model from repo")
-	ErrCrossRead = fmt.Errorf("cross reading wrong model from repo")
+	ErrCrossRead   = fmt.Errorf("cross reading wrong model from repo")
 	ErrCrossDelete = fmt.Errorf("cross deleting wrong model from repo")
 	ErrCrossUpdate = fmt.Errorf("cross updating wrong model from repo")
 )

--- a/pkg/db-repo/repository.go
+++ b/pkg/db-repo/repository.go
@@ -264,6 +264,11 @@ func (r *repository) checkResultModel(result interface{}) error {
 }
 
 func (r *repository) Query(ctx context.Context, qb *QueryBuilder, result interface{}) error {
+	err := r.checkResultModel(result)
+	if err != nil {
+		return err
+	}
+
 	_, span := r.startSubSpan(ctx, "Query")
 	defer span.Finish()
 
@@ -297,11 +302,6 @@ func (r *repository) Query(ctx context.Context, qb *QueryBuilder, result interfa
 	if qb.page != nil {
 		db = db.Offset(qb.page.offset)
 		db = db.Limit(qb.page.limit)
-	}
-
-	err := r.checkResultModel(result)
-	if err != nil {
-		return err
 	}
 
 	db = db.Table(r.GetMetadata().TableName)

--- a/test/db_repo_change_history_test.go
+++ b/test/db_repo_change_history_test.go
@@ -69,9 +69,9 @@ var TestModel2Metadata = db_repo.Metadata{
 	TableName:  "test_model2",
 	PrimaryKey: "test_model2.id",
 	Mappings: db_repo.FieldMappings{
-		"testModel2.id":   db_repo.NewFieldMapping("test_model2.id"),
-		"testModel2.name": db_repo.NewFieldMapping("test_model2.name"),
-		"testModel2.foo": db_repo.NewFieldMapping("test_model2.foo"),
+		"testModel2.id":           db_repo.NewFieldMapping("test_model2.id"),
+		"testModel2.name":         db_repo.NewFieldMapping("test_model2.name"),
+		"testModel2.foo":          db_repo.NewFieldMapping("test_model2.foo"),
 		"testModel2.changeAuthor": db_repo.NewFieldMapping("test_model2.change_author"),
 	},
 }
@@ -84,20 +84,20 @@ var TestHistoryModel2Metadata = db_repo.Metadata{
 	TableName:  "test_model2_history_entries",
 	PrimaryKey: "test_model2_history_entries.id",
 	Mappings: db_repo.FieldMappings{
-		"testModel2HistoryEntry.id":   db_repo.NewFieldMapping("test_model2_history_entries.id"),
-		"testModel2HistoryEntry.name": db_repo.NewFieldMapping("test_model2_history_entries.name"),
-		"testModel2HistoryEntry.foo": db_repo.NewFieldMapping("test_model2_history_entries.foo"),
+		"testModel2HistoryEntry.id":           db_repo.NewFieldMapping("test_model2_history_entries.id"),
+		"testModel2HistoryEntry.name":         db_repo.NewFieldMapping("test_model2_history_entries.name"),
+		"testModel2HistoryEntry.foo":          db_repo.NewFieldMapping("test_model2_history_entries.foo"),
 		"testModel2HistoryEntry.changeAuthor": db_repo.NewFieldMapping("test_model2_history_entries.change_author"),
 	},
 }
 
 type DbRepoChangeHistoryTestSuite struct {
 	suite.Suite
-	logger mon.Logger
-	config cfg.Config
-	mocks  *test.Mocks
-	modelRepo   db_repo.Repository
-	modelHistoryRepo   db_repo.Repository
+	logger           mon.Logger
+	config           cfg.Config
+	mocks            *test.Mocks
+	modelRepo        db_repo.Repository
+	modelHistoryRepo db_repo.Repository
 }
 
 func TestDbChangelogTestSuite(t *testing.T) {

--- a/test/db_repo_change_history_test.go
+++ b/test/db_repo_change_history_test.go
@@ -13,12 +13,91 @@ import (
 	"testing"
 )
 
+type TestModel1 struct {
+	db_repo.Model
+	Name *string
+}
+
+type TestModel1HistoryEntry struct {
+	db_repo.ChangeHistoryModel
+	TestModel1
+}
+
+var TestModel1Metadata = db_repo.Metadata{
+	ModelId: mdl.ModelId{
+		Application: "application",
+		Name:        "testModel1",
+	},
+	TableName:  "test_model1",
+	PrimaryKey: "test_model1.id",
+	Mappings: db_repo.FieldMappings{
+		"testModel1.id":   db_repo.NewFieldMapping("test_model1.id"),
+		"testModel1.name": db_repo.NewFieldMapping("test_model1.name"),
+	},
+}
+
+var TestHistoryModel1Metadata = db_repo.Metadata{
+	ModelId: mdl.ModelId{
+		Application: "application",
+		Name:        "testModel1HistoryEntry",
+	},
+	TableName:  "test_model1_history_entries",
+	PrimaryKey: "test_model1_history_entries.id",
+	Mappings: db_repo.FieldMappings{
+		"testModel1HistoryEntry.id":   db_repo.NewFieldMapping("test_model1_history_entries.id"),
+		"testModel1HistoryEntry.name": db_repo.NewFieldMapping("test_model1_history_entries.name"),
+	},
+}
+
+type TestModel2 struct {
+	db_repo.Model
+	Name         *string
+	Foo          *string
+	ChangeAuthor *string
+}
+
+type TestModel2HistoryEntry struct {
+	db_repo.ChangeHistoryModel
+	TestModel2
+}
+
+var TestModel2Metadata = db_repo.Metadata{
+	ModelId: mdl.ModelId{
+		Application: "application",
+		Name:        "testModel2",
+	},
+	TableName:  "test_model2",
+	PrimaryKey: "test_model2.id",
+	Mappings: db_repo.FieldMappings{
+		"testModel2.id":   db_repo.NewFieldMapping("test_model2.id"),
+		"testModel2.name": db_repo.NewFieldMapping("test_model2.name"),
+		"testModel2.foo": db_repo.NewFieldMapping("test_model2.foo"),
+		"testModel2.changeAuthor": db_repo.NewFieldMapping("test_model2.change_author"),
+	},
+}
+
+var TestHistoryModel2Metadata = db_repo.Metadata{
+	ModelId: mdl.ModelId{
+		Application: "application",
+		Name:        "testModel2HistoryEntry",
+	},
+	TableName:  "test_model2_history_entries",
+	PrimaryKey: "test_model2_history_entries.id",
+	Mappings: db_repo.FieldMappings{
+		"testModel2HistoryEntry.id":   db_repo.NewFieldMapping("test_model2_history_entries.id"),
+		"testModel2HistoryEntry.name": db_repo.NewFieldMapping("test_model2_history_entries.name"),
+		"testModel2HistoryEntry.foo": db_repo.NewFieldMapping("test_model2_history_entries.foo"),
+		"testModel2HistoryEntry.changeAuthor": db_repo.NewFieldMapping("test_model2_history_entries.change_author"),
+	},
+}
+
 type DbRepoChangeHistoryTestSuite struct {
 	suite.Suite
 	logger mon.Logger
 	config cfg.Config
 	mocks  *test.Mocks
-	repo   db_repo.Repository
+	modelRepo   db_repo.Repository
+	modelHistoryRepo   db_repo.Repository
 }
 
 func TestDbChangelogTestSuite(t *testing.T) {
@@ -47,9 +126,6 @@ func (s *DbRepoChangeHistoryTestSuite) SetupSuite() {
 
 	s.config = config
 	s.logger = mon.NewLogger()
-
-	s.repo, err = db_repo.New(s.config, s.logger, db_repo.Settings{})
-	s.NoError(err)
 }
 
 func (s *DbRepoChangeHistoryTestSuite) TearDownSuite() {
@@ -57,36 +133,37 @@ func (s *DbRepoChangeHistoryTestSuite) TearDownSuite() {
 }
 
 func (s *DbRepoChangeHistoryTestSuite) TestChangeHistoryMigration_Migrate_CreateTable() {
+	var err error
 
-	type TestModel1 struct {
-		db_repo.Model
-		Name *string
-	}
+	s.modelRepo, err = db_repo.New(s.config, s.logger, db_repo.Settings{
+		Metadata: TestModel1Metadata,
+	})
+	s.NoError(err)
 
-	type TestModel1HistoryEntry struct {
-		db_repo.ChangeHistoryModel
-		TestModel1
-	}
+	s.modelHistoryRepo, err = db_repo.New(s.config, s.logger, db_repo.Settings{
+		Metadata: TestHistoryModel1Metadata,
+	})
+	s.NoError(err)
 
-	err := db_repo.MigrateChangeHistory(s.config, s.logger, &TestModel1{})
+	err = db_repo.MigrateChangeHistory(s.config, s.logger, &TestModel1{})
 	s.NoError(err)
 
 	model := &TestModel1{
 		Name: mdl.String("name1"),
 	}
 
-	err = s.repo.Create(context.Background(), model)
+	err = s.modelRepo.Create(context.Background(), model)
 	s.NoError(err)
 
 	model.Name = mdl.String("name2")
-	err = s.repo.Update(context.Background(), model)
+	err = s.modelRepo.Update(context.Background(), model)
 	s.NoError(err)
 
-	err = s.repo.Delete(context.Background(), model)
+	err = s.modelRepo.Delete(context.Background(), model)
 	s.NoError(err)
 
 	entries := make([]*TestModel1HistoryEntry, 0)
-	err = s.repo.Query(context.Background(), &db_repo.QueryBuilder{}, &entries)
+	err = s.modelHistoryRepo.Query(context.Background(), &db_repo.QueryBuilder{}, &entries)
 	s.NoError(err)
 	s.Equal(3, len(entries), "expected 3 change history entries")
 
@@ -104,20 +181,19 @@ func (s *DbRepoChangeHistoryTestSuite) TestChangeHistoryMigration_Migrate_Create
 }
 
 func (s *DbRepoChangeHistoryTestSuite) TestChangeHistoryMigration_Migrate_UpdateTable() {
+	var err error
 
-	type TestModel2 struct {
-		db_repo.Model
-		Name         *string
-		Foo          *string
-		ChangeAuthor *string
-	}
+	s.modelRepo, err = db_repo.New(s.config, s.logger, db_repo.Settings{
+		Metadata: TestModel2Metadata,
+	})
+	s.NoError(err)
 
-	type TestModel2HistoryEntry struct {
-		db_repo.ChangeHistoryModel
-		TestModel2
-	}
+	s.modelHistoryRepo, err = db_repo.New(s.config, s.logger, db_repo.Settings{
+		Metadata: TestHistoryModel2Metadata,
+	})
+	s.NoError(err)
 
-	err := db_repo.MigrateChangeHistory(s.config, s.logger, &TestModel2{})
+	err = db_repo.MigrateChangeHistory(s.config, s.logger, &TestModel2{})
 	s.NoError(err)
 
 	model := &TestModel2{
@@ -126,18 +202,18 @@ func (s *DbRepoChangeHistoryTestSuite) TestChangeHistoryMigration_Migrate_Update
 		ChangeAuthor: mdl.String("john@example.com"),
 	}
 
-	err = s.repo.Create(context.Background(), model)
+	err = s.modelRepo.Create(context.Background(), model)
 	s.NoError(err)
 
 	model.Foo = mdl.String("foo2")
-	err = s.repo.Update(context.Background(), model)
+	err = s.modelRepo.Update(context.Background(), model)
 	s.NoError(err)
 
-	err = s.repo.Delete(context.Background(), model)
+	err = s.modelRepo.Delete(context.Background(), model)
 	s.NoError(err)
 
 	entries := make([]*TestModel2HistoryEntry, 0)
-	err = s.repo.Query(context.Background(), &db_repo.QueryBuilder{}, &entries)
+	err = s.modelHistoryRepo.Query(context.Background(), &db_repo.QueryBuilder{}, &entries)
 	s.NoError(err)
 	s.Equal(3, len(entries), "expected 3 change history entries")
 

--- a/test/db_repo_query_test.go
+++ b/test/db_repo_query_test.go
@@ -1,0 +1,128 @@
+//+build integration
+
+package test_test
+
+import (
+	"context"
+	"github.com/applike/gosoline/pkg/cfg"
+	"github.com/applike/gosoline/pkg/db-repo"
+	"github.com/applike/gosoline/pkg/mdl"
+	"github.com/applike/gosoline/pkg/mon"
+	"github.com/applike/gosoline/pkg/test"
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+var TestModelMetadata = db_repo.Metadata{
+	ModelId: mdl.ModelId{
+		Application: "application",
+		Name:        "testModel",
+	},
+	TableName:  "test_models",
+	PrimaryKey: "test_models.id",
+	Mappings: db_repo.FieldMappings{
+		"testModel.id":   db_repo.NewFieldMapping("test_models.id"),
+		"testModel.name": db_repo.NewFieldMapping("test_models.name"),
+	},
+}
+
+type TestModel struct {
+	db_repo.Model
+	Name *string
+}
+
+type DbRepoQueryTestSuite struct {
+	suite.Suite
+	logger mon.Logger
+	config cfg.Config
+	mocks  *test.Mocks
+	repo   db_repo.Repository
+}
+
+func TestDbRepoQueryTestSuite(t *testing.T) {
+	suite.Run(t, new(DbRepoQueryTestSuite))
+}
+
+func (s *DbRepoQueryTestSuite) SetupSuite() {
+	setup(s.T())
+	mocks, err := test.Boot("test_configs/config.mysql.test.yml")
+
+	if !s.NoError(err) {
+		return
+	}
+
+	s.mocks = mocks
+
+	config := cfg.New()
+	_ = config.Option(
+		cfg.WithConfigFile("test_configs/config.mysql.test.yml", "yml"),
+		cfg.WithConfigFile("test_configs/config.db_repo_query.test.yml", "yml"),
+		cfg.WithConfigMap(map[string]interface{}{
+			"db.default.uri.port": s.mocks.ProvideMysqlPort("mysql"),
+			"db.default.uri.host": s.mocks.ProvideMysqlHost("mysql"),
+		}),
+	)
+
+	s.config = config
+	s.logger = mon.NewLogger()
+
+	s.repo, err = db_repo.New(s.config, s.logger, db_repo.Settings{
+		Metadata: TestModelMetadata,
+	})
+
+	s.NoError(err)
+}
+
+func (s *DbRepoQueryTestSuite) TearDownSuite() {
+	s.mocks.Shutdown()
+}
+
+func (s *DbRepoQueryTestSuite) TestQueryCorrectModel() {
+	ctx := context.Background()
+
+	model := &TestModel{
+		Name: mdl.String("name1"),
+	}
+
+	err := s.repo.Create(ctx, model)
+	s.NoError(err)
+
+	model = &TestModel{
+		Name: mdl.String("name2"),
+	}
+
+	err = s.repo.Create(ctx, model)
+	s.NoError(err)
+
+	where := &TestModel{
+		Name: mdl.String("name1"),
+	}
+
+	qb := db_repo.NewQueryBuilder()
+	qb.Where(where)
+
+	models := make([]TestModel, 0)
+	err = s.repo.Query(ctx, qb, &models)
+	s.NoError(err)
+	s.Equal(1, len(models), "expected 1 test model")
+}
+
+func (s *DbRepoQueryTestSuite) TestQueryWrongModel() {
+	ctx := context.Background()
+
+	type WrongTestModel struct {
+		db_repo.Model
+		WrongName *string
+	}
+
+	where := &WrongTestModel{
+		WrongName: mdl.String("name1"),
+	}
+
+	qb := db_repo.NewQueryBuilder()
+	qb.Where(where)
+
+	models := make([]TestModel, 0)
+	err := s.repo.Query(ctx, qb, &models)
+	s.EqualError(err, "cross querying wrong model from repo")
+}

--- a/test/db_repo_query_test.go
+++ b/test/db_repo_query_test.go
@@ -105,6 +105,16 @@ func (s *DbRepoQueryTestSuite) TestQueryCorrectModel() {
 	err = s.repo.Query(ctx, qb, &models)
 	s.NoError(err)
 	s.Equal(1, len(models), "expected 1 test model")
+
+	whereStr := "name = ?"
+
+	qb = db_repo.NewQueryBuilder()
+	qb.Where(whereStr, mdl.String("name2"))
+
+	models = make([]TestModel, 0)
+	err = s.repo.Query(ctx, qb, &models)
+	s.NoError(err)
+	s.Equal(1, len(models), "expected 1 test model")
 }
 
 func (s *DbRepoQueryTestSuite) TestQueryWrongModel() {

--- a/test/db_repo_query_test.go
+++ b/test/db_repo_query_test.go
@@ -82,6 +82,142 @@ func (s *DbRepoQueryTestSuite) TearDownSuite() {
 	s.mocks.Shutdown()
 }
 
+func (s *DbRepoQueryTestSuite) TestCreateCorrectModel() {
+	ctx := context.Background()
+
+	model := &TestModel{
+		Name: mdl.String("nameCreate1"),
+	}
+
+	err := s.repo.Create(ctx, model)
+	s.NoError(err)
+
+	where := &TestModel{
+		Name: mdl.String("nameCreate1"),
+	}
+
+	qb := db_repo.NewQueryBuilder()
+	qb.Where(where)
+
+	models := make([]TestModel, 0)
+	err = s.repo.Query(ctx, qb, &models)
+	s.NoError(err)
+	s.Equal(1, len(models), "expected 1 test model")
+}
+
+func (s *DbRepoQueryTestSuite) TestCreateWrongModel() {
+	ctx := context.Background()
+
+	model := &WrongTestModel{
+		WrongName: mdl.String("nameCreateWrong1"),
+	}
+
+	err := s.repo.Create(ctx, model)
+	s.EqualError(err, "cross creating wrong model from repo")
+}
+
+func (s *DbRepoQueryTestSuite) TestReadCorrectModel() {
+	ctx := context.Background()
+
+	model := &TestModel{
+		Name: mdl.String("nameRead1"),
+	}
+
+	readModel := &TestModel{}
+
+	err := s.repo.Create(ctx, model)
+	s.NoError(err)
+
+	err = s.repo.Read(ctx, model.GetId(), readModel)
+	s.NoError(err)
+	s.Equal(model.Name, readModel.Name, "expected names to match")
+}
+
+func (s *DbRepoQueryTestSuite) TestReadWrongModel() {
+	ctx := context.Background()
+
+	model := &WrongTestModel{}
+
+	err := s.repo.Read(ctx, mdl.Uint(1), model)
+	s.EqualError(err, "cross reading wrong model from repo")
+}
+
+func (s *DbRepoQueryTestSuite) TestUpdateCorrectModel() {
+	ctx := context.Background()
+
+	model := &TestModel{
+		Name: mdl.String("nameUpdate1"),
+	}
+
+	err := s.repo.Create(ctx, model)
+	s.NoError(err)
+
+	where := &TestModel{
+		Name: mdl.String("nameUpdate1"),
+	}
+
+	qb := db_repo.NewQueryBuilder()
+	qb.Where(where)
+
+	models := make([]TestModel, 0)
+	err = s.repo.Query(ctx, qb, &models)
+	s.NoError(err)
+	s.Equal(1, len(models), "expected 1 test model")
+
+	model.Name = mdl.String("nameUpdate1Updated")
+
+	err = s.repo.Update(ctx, model)
+	s.NoError(err)
+
+	where = &TestModel{
+		Name: mdl.String("nameUpdate1Updated"),
+	}
+
+	qb = db_repo.NewQueryBuilder()
+	qb.Where(where)
+
+	models = make([]TestModel, 0)
+	err = s.repo.Query(ctx, qb, &models)
+	s.NoError(err)
+	s.Equal(1, len(models), "expected 1 test model")
+}
+
+func (s *DbRepoQueryTestSuite) TestUpdateWrongModel() {
+	ctx := context.Background()
+
+	model := &WrongTestModel{
+		WrongName: mdl.String("nameUpdateWrong1"),
+	}
+
+	err := s.repo.Update(ctx, model)
+	s.EqualError(err, "cross updating wrong model from repo")
+}
+
+func (s *DbRepoQueryTestSuite) TestDeleteCorrectModel() {
+	ctx := context.Background()
+
+	model := &TestModel{
+		Name: mdl.String("nameDelete1"),
+	}
+
+	err := s.repo.Create(ctx, model)
+	s.NoError(err)
+
+	err = s.repo.Delete(ctx, model)
+	s.NoError(err)
+}
+
+func (s *DbRepoQueryTestSuite) TestDeleteWrongModel() {
+	ctx := context.Background()
+
+	model := &WrongTestModel{
+		WrongName: mdl.String("nameUpdateWrong1"),
+	}
+
+	err := s.repo.Delete(ctx, model)
+	s.EqualError(err, "cross deleting wrong model from repo")
+}
+
 func (s *DbRepoQueryTestSuite) TestQueryCorrectModel() {
 	ctx := context.Background()
 

--- a/test/db_repo_query_test.go
+++ b/test/db_repo_query_test.go
@@ -44,7 +44,7 @@ type DbRepoQueryTestSuite struct {
 	repo   db_repo.Repository
 }
 
-func TestDbRepoQueryTestSuite(t *testing.T) {
+func TestDbRepoTestSuite(t *testing.T) {
 	suite.Run(t, new(DbRepoQueryTestSuite))
 }
 
@@ -288,7 +288,7 @@ func (s *DbRepoQueryTestSuite) TestQueryWrongResultModel() {
 	s.EqualError(err, "result slice has to be pointer to slice")
 
 	err = s.repo.Query(ctx, qb, &models)
-	s.EqualError(err, "cross querying result slice has to of same model")
+	s.EqualError(err, "cross querying result slice has to be of same model")
 }
 
 func (s *DbRepoQueryTestSuite) TestQueryWrongModel() {

--- a/test/db_repo_query_test.go
+++ b/test/db_repo_query_test.go
@@ -135,4 +135,15 @@ func (s *DbRepoQueryTestSuite) TestQueryWrongModel() {
 	models := make([]TestModel, 0)
 	err := s.repo.Query(ctx, qb, &models)
 	s.EqualError(err, "cross querying wrong model from repo")
+
+	whereStruct := WrongTestModel{
+		WrongName: mdl.String("name1"),
+	}
+
+	qb = db_repo.NewQueryBuilder()
+	qb.Where(whereStruct)
+
+	models = make([]TestModel, 0)
+	err = s.repo.Query(ctx, qb, &models)
+	s.EqualError(err, "cross querying wrong model from repo")
 }

--- a/test/test_configs/config.db_repo_query.test.yml
+++ b/test/test_configs/config.db_repo_query.test.yml
@@ -1,0 +1,24 @@
+env: test
+app_project: gosoline
+app_family: integration-test
+app_name: db-query-test
+
+db:
+  default:
+    driver: mysql
+    max_connection_lifetime: 120
+    parse_time: true
+    uri:
+      host: 127.0.0.1
+      port: 3306
+      user: root
+      password: gosoline
+      database: myDbName
+    migrations:
+      enabled: true
+      table_prefixed: false
+      path: file://test_fixtures/migrations_db_repo_query/
+
+change_history:
+  table_suffix: history_entries
+  change_author_column: change_author

--- a/test/test_fixtures/migrations_db_repo_query/1_create_tables.up.sql
+++ b/test/test_fixtures/migrations_db_repo_query/1_create_tables.up.sql
@@ -1,0 +1,8 @@
+create table test_models
+(
+    id int unsigned auto_increment
+        primary key,
+    name varchar(255) null,
+    updated_at timestamp null,
+    created_at timestamp null
+);


### PR DESCRIPTION
This adds a verification in db_repo.Query and triggers an error if the model being queried is different than the repo metadat.