### PR TITLE
apiserver: improve bind error message if the client lost the connection;

### DIFF
--- a/pkg/apiserver/middleware_logger.go
+++ b/pkg/apiserver/middleware_logger.go
@@ -1,9 +1,11 @@
 package apiserver
 
 import (
+	"errors"
 	"fmt"
 	"github.com/applike/gosoline/pkg/log"
 	"github.com/gin-gonic/gin"
+	"io"
 	"strings"
 	"time"
 )
@@ -60,7 +62,11 @@ func LoggingMiddleware(logger log.Logger) gin.HandlerFunc {
 		for _, e := range ginCtx.Errors {
 			switch e.Type {
 			case gin.ErrorTypeBind:
-				ctxLogger.Warn("%s %s %s - bind error - %v", method, path, req.Proto, e.Err)
+				if errors.Is(e.Err, io.EOF) || errors.Is(e.Err, io.ErrUnexpectedEOF) {
+					ctxLogger.Warn("%s %s %s - network error - client has gone away - %v", method, path, req.Proto, e.Err)
+				} else {
+					ctxLogger.Warn("%s %s %s - bind error - %v", method, path, req.Proto, e.Err)
+				}
 			case gin.ErrorTypeRender:
 				ctxLogger.Warn("%s %s %s - render error - %v", method, path, req.Proto, e.Err)
 			default:

--- a/test/apiserver/config.dist.compressed.yml
+++ b/test/apiserver/config.dist.compressed.yml
@@ -5,7 +5,7 @@ app_family: test
 app_name: compression-test
 
 api:
-  port: 8088
+  port: 0
   mode: release
   compression:
     level: default

--- a/test/apiserver/config.dist.eofBind.yml
+++ b/test/apiserver/config.dist.eofBind.yml
@@ -2,7 +2,7 @@ env: test
 
 app_project: gosoline
 app_family: test
-app_name: validation-test
+app_name: eof-bind-test
 
 api:
   port: 0

--- a/test/apiserver/eof_bind_test.go
+++ b/test/apiserver/eof_bind_test.go
@@ -1,0 +1,130 @@
+// +build integration
+
+package apiserver
+
+import (
+	"context"
+	"fmt"
+	"github.com/applike/gosoline/pkg/apiserver"
+	"github.com/applike/gosoline/pkg/cfg"
+	"github.com/applike/gosoline/pkg/http"
+	"github.com/applike/gosoline/pkg/log"
+	"github.com/applike/gosoline/pkg/test/suite"
+	"github.com/go-resty/resty/v2"
+	netHttp "net/http"
+	"testing"
+	"time"
+)
+
+type eofBindHandler struct{}
+
+type EofBindTestSuite struct {
+	suite.Suite
+}
+
+func (s *EofBindTestSuite) SetupSuite() []suite.Option {
+	return []suite.Option{
+		suite.WithLogLevel("debug"),
+		suite.WithConfigFile("./config.dist.eofBind.yml"),
+		suite.WithSharedEnvironment(),
+		suite.WithoutAutoDetectedComponents("localstack"),
+	}
+}
+
+func (s *EofBindTestSuite) SetupApiDefinitions() apiserver.Definer {
+	return func(ctx context.Context, config cfg.Config, logger log.Logger) (*apiserver.Definitions, error) {
+		d := &apiserver.Definitions{}
+		d.POST("/bind", apiserver.CreateJsonHandler(&eofBindHandler{}))
+
+		return d, nil
+	}
+}
+
+type bindHandler struct {
+	suite.Suite
+}
+
+func (b bindHandler) Channels() []string {
+	return nil
+}
+
+func (b bindHandler) Level() int {
+	return log.LevelPriority(log.LevelWarn)
+}
+
+func (b bindHandler) Log(_ time.Time, _ int, msg string, args []interface{}, _ error, _ log.Data) error {
+	formattedMsg := fmt.Sprintf(msg, args...)
+
+	b.NotEqual("POST /bind HTTP/1.1 - bind error - EOF", formattedMsg)
+	b.NotEqual("POST /bind HTTP/1.1 - bind error - unexpected EOF", formattedMsg)
+	b.Contains([]string{
+		"POST /bind HTTP/1.1 - network error - client has gone away - EOF",
+		"POST /bind HTTP/1.1 - network error - client has gone away - unexpected EOF",
+	}, formattedMsg)
+
+	return nil
+}
+
+func (s *EofBindTestSuite) TestEofBind() *suite.ApiServerTestCase {
+	// language=JSON
+	expectedBody := `{"err":"EOF"}`
+
+	err := s.Env().Logger().Option(log.WithHandlers(bindHandler{
+		Suite: s.Suite,
+	}))
+	s.NoError(err)
+
+	return &suite.ApiServerTestCase{
+		Method: netHttp.MethodPost,
+		Url:    "/bind",
+		Headers: map[string]string{
+			http.HdrContentType: http.ContentTypeApplicationJson,
+		},
+		Body:               []byte{},
+		ExpectedStatusCode: netHttp.StatusBadRequest,
+		ValidateResponse: func(res *resty.Response) error {
+			s.Equal(expectedBody, string(res.Body()))
+
+			return nil
+		},
+	}
+}
+
+func (s *EofBindTestSuite) TestUnexpectedEofBind() *suite.ApiServerTestCase {
+	// language=JSON
+	expectedBody := `{"err":"unexpected EOF"}`
+
+	err := s.Env().Logger().Option(log.WithHandlers(bindHandler{
+		Suite: s.Suite,
+	}))
+	s.NoError(err)
+
+	return &suite.ApiServerTestCase{
+		Method: netHttp.MethodPost,
+		Url:    "/bind",
+		Headers: map[string]string{
+			http.HdrContentType: http.ContentTypeApplicationJson,
+		},
+		Body:               []byte{'{'},
+		ExpectedStatusCode: netHttp.StatusBadRequest,
+		ValidateResponse: func(res *resty.Response) error {
+			s.Equal(expectedBody, string(res.Body()))
+
+			return nil
+		},
+	}
+}
+
+func (h eofBindHandler) GetInput() interface{} {
+	return &map[string]interface{}{}
+}
+
+func (h eofBindHandler) Handle(_ context.Context, request *apiserver.Request) (*apiserver.Response, error) {
+	body := request.Body.(*map[string]interface{})
+
+	return apiserver.NewJsonResponse(*body), nil
+}
+
+func TestEofBindTestSuite(t *testing.T) {
+	suite.Run(t, &EofBindTestSuite{})
+}


### PR DESCRIPTION
If a client sends a request, but then loses the connection, we would log `bind error - EOF` without really making clear what happened. How we instead log `network error - client has gone away - EOF`, which is hopefully easier to understand.
