### PR TITLE
Add expected number of redirects to api test cases & implement follow_redirects for http client

### DIFF
--- a/pkg/test/env/components_container.go
+++ b/pkg/test/env/components_container.go
@@ -23,16 +23,26 @@ func (c *ComponentsContainer) Add(typ string, name string, component Component) 
 	c.components[typ][name] = component
 }
 
-func (c *ComponentsContainer) Get(typ string, name string) (Component, error) {
-	if _, ok := c.components[typ]; !ok {
-		return nil, fmt.Errorf("there is no component with name %s of type %s", name, typ)
+func (c *ComponentsContainer) Get(componentType string, name string) (Component, error) {
+	if _, ok := c.components[componentType]; !ok {
+		var components []string
+		for component := range c.components {
+			components = append(components, component)
+		}
+
+		return nil, fmt.Errorf("there is no component with name %s of type %s (there are only: %v)", name, componentType, components)
 	}
 
-	if _, ok := c.components[typ][name]; !ok {
-		return nil, fmt.Errorf("there is no component with name %s of type %s", name, typ)
+	if _, ok := c.components[componentType][name]; !ok {
+		var components []string
+		for component := range c.components[componentType] {
+			components = append(components, component)
+		}
+
+		return nil, fmt.Errorf("there is no component with name %s of type %s (there are only: %v)", name, componentType, components)
 	}
 
-	return c.components[typ][name], nil
+	return c.components[componentType][name], nil
 }
 
 func (c *ComponentsContainer) GetAll() []Component {


### PR DESCRIPTION
http: implemented `follow_redirects` config setting and moved rest of client to `http_client` config;
    
    This commit deprecates the `http_client_retry_count` and
    `http_client_request_timeout` config settings (replacing them with
    warnings for now) and instead moves them to the `http_client` object
    with default values of 30 seconds and 5 retries. It also implements the
    `follow_redirects` config setting in the `http_client` object, allowing
    you to turn off following redirects if needed (it defaults to follow
    redirects).

http: implemented `follow_redirects` config setting and moved rest of client to `http_client` config;
    
    This commit deprecates the `http_client_retry_count` and
    `http_client_request_timeout` config settings (replacing them with
    warnings for now) and instead moves them to the `http_client` object
    with default values of 30 seconds and 5 retries. It also implements the
    `follow_redirects` config setting in the `http_client` object, allowing
    you to turn off following redirects if needed (it defaults to follow
    redirects).
