### PR TITLE
log: Do not write to map fields from handler as they should be read only;

### DIFF
--- a/pkg/log/handler_sentry.go
+++ b/pkg/log/handler_sentry.go
@@ -2,9 +2,10 @@ package log
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/applike/gosoline/pkg/cfg"
 	"github.com/getsentry/sentry-go"
-	"time"
 )
 
 func init() {
@@ -74,7 +75,9 @@ func (h *HandlerSentry) Log(_ time.Time, _ int, _ string, _ []interface{}, err e
 		eventId := h.hub.CaptureException(err)
 
 		if eventId != nil {
-			data.Fields["sentry_event_id"] = *eventId
+			data.Fields = mergeFields(data.Fields, map[string]interface{}{
+				"sentry_event_id": *eventId,
+			})
 		}
 	})
 

--- a/pkg/log/options.go
+++ b/pkg/log/options.go
@@ -12,9 +12,7 @@ func WithContextFieldsResolver(resolvers ...ContextFieldsResolver) Option {
 
 func WithFields(tags map[string]interface{}) Option {
 	return func(logger *gosoLogger) error {
-		for k, v := range tags {
-			logger.data.Fields[k] = v
-		}
+		logger.data.Fields = mergeFields(logger.data.Fields, tags)
 
 		return nil
 	}


### PR DESCRIPTION
The sentry handler is writing the event id to the logger fields so subsequent log messages carry that event id. However, it was doing that in an unsafe way as it simply modified the map. This is however not allowed as the map could be read by another thread at the same time, for example if that thread is currently executing `WithFields`. Instead, we now build a completely new map with the sentry event id included. This way we can't be writing to a map which is also read at the same time and should be fine.

@j4k4 Am I correct that the intention of the code is to set the sentry_event_id field before the log message gets written to stdout (or where ever it should end up in the end)? Was a little bit confused about a handler modifying the state of the logger like that, but at least now it should be thread safe (currently testing it on quite some scale, so we hopefully should know in a few hours if this is really the case)?