### PR TITLE
improved cloud/aws http client timeout default settings

### DIFF
--- a/pkg/application/options.go
+++ b/pkg/application/options.go
@@ -93,10 +93,10 @@ func WithConfigFileFlag(app *App) {
 	})
 }
 
-func WithConfigMap(configMap map[string]interface{}) Option {
+func WithConfigMap(configMap map[string]interface{}, mergeOptions ...cfg.MergeOption) Option {
 	return func(app *App) {
 		app.addConfigOption(func(config cfg.GosoConf) error {
-			return config.Option(cfg.WithConfigMap(configMap))
+			return config.Option(cfg.WithConfigMap(configMap, mergeOptions...))
 		})
 	}
 }

--- a/pkg/cloud/aws/awsv2.go
+++ b/pkg/cloud/aws/awsv2.go
@@ -53,6 +53,7 @@ func UnmarshalClientSettings(config cfg.Config, settings ClientSettingsAware, se
 	config.UnmarshalKey(clientsKey, settings, []cfg.UnmarshalDefaults{
 		cfg.UnmarshalWithDefaultsFromKey("cloud.aws.defaults.region", "region"),
 		cfg.UnmarshalWithDefaultsFromKey("cloud.aws.defaults.endpoint", "endpoint"),
+		cfg.UnmarshalWithDefaultsFromKey("cloud.aws.defaults.http_client", "http_client"),
 		cfg.UnmarshalWithDefaultsFromKey(defaultClientKey, "."),
 	}...)
 

--- a/pkg/cloud/aws/awsv2_test.go
+++ b/pkg/cloud/aws/awsv2_test.go
@@ -5,7 +5,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/justtrackio/gosoline/pkg/cfg"
 	"github.com/justtrackio/gosoline/pkg/cloud/aws"
+	"github.com/justtrackio/gosoline/pkg/exec"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,4 +35,52 @@ func TestExponentialBackoffDelayer(t *testing.T) {
 	}
 
 	assert.True(t, i < 100)
+}
+
+func TestUnmarshalClientSettings(t *testing.T) {
+	config := cfg.New()
+
+	err := config.Option(cfg.WithConfigMap(map[string]interface{}{
+		"cloud.aws.defaults.http_client": map[string]interface{}{
+			"timeout": "1s",
+		},
+		"cloud.aws.cloudwatch.clients.metrics.http_client": map[string]interface{}{
+			"timeout": "2s",
+		},
+	}))
+	assert.NoError(t, err)
+
+	settings := &aws.ClientSettings{}
+	aws.UnmarshalClientSettings(config, settings, "cloudwatch", "default")
+	assert.Equal(t, &aws.ClientSettings{
+		Region:   "eu-central-1",
+		Endpoint: "http://localhost:4566",
+		HttpClient: aws.ClientHttpSettings{
+			Timeout: time.Second,
+		},
+		Backoff: exec.BackoffSettings{
+			CancelDelay:     0,
+			InitialInterval: time.Millisecond * 50,
+			MaxAttempts:     10,
+			MaxElapsedTime:  time.Minute * 10,
+			MaxInterval:     time.Second * 10,
+		},
+	}, settings)
+
+	settings = &aws.ClientSettings{}
+	aws.UnmarshalClientSettings(config, settings, "cloudwatch", "metrics")
+	assert.Equal(t, &aws.ClientSettings{
+		Region:   "eu-central-1",
+		Endpoint: "http://localhost:4566",
+		HttpClient: aws.ClientHttpSettings{
+			Timeout: time.Second * 2,
+		},
+		Backoff: exec.BackoffSettings{
+			CancelDelay:     0,
+			InitialInterval: time.Millisecond * 50,
+			MaxAttempts:     10,
+			MaxElapsedTime:  time.Minute * 10,
+			MaxInterval:     time.Second * 10,
+		},
+	}, settings)
 }

--- a/pkg/kvstore/ddb.go
+++ b/pkg/kvstore/ddb.go
@@ -35,6 +35,7 @@ func NewDdbKvStore(ctx context.Context, config cfg.Config, logger log.Logger, se
 	name := DdbBaseName(settings)
 
 	repository, err := ddb.NewRepository(ctx, config, logger, &ddb.Settings{
+		ClientName: name,
 		ModelId: mdl.ModelId{
 			Project:     settings.Project,
 			Environment: settings.Environment,


### PR DESCRIPTION
cloud/aws: added more default handling for http client timeout settings
kvstore: using dedicated client names for ddb stores
