### PR TITLE
test/suite: make fixtures available in subscriber test cases and added options when asserting subscriber results

### DIFF
--- a/test/stream/retry_handler_sqs/callback.go
+++ b/test/stream/retry_handler_sqs/callback.go
@@ -3,9 +3,9 @@ package retry_handler_sqs
 import (
 	"context"
 	"fmt"
+	"maps"
 	"sync"
 
-	"github.com/justtrackio/gosoline/pkg/funk"
 	"github.com/justtrackio/gosoline/pkg/test/suite"
 )
 
@@ -27,8 +27,8 @@ func (c *Callback) Consume(_ context.Context, model DataModel, attributes map[st
 	defer c.lck.Unlock()
 
 	// clone the attributes and remove the sqs specific ones to make for simpler checks later
-	// we need to make a clone because deleting the message idea is a Bad Idea™ as it is needed to acknowledge the message
-	attributes = funk.MergeMaps(attributes)
+	// we need to make a clone because deleting the message id is a Bad Idea™ as it is needed to acknowledge the message
+	attributes = maps.Clone(attributes)
 	delete(attributes, "sqsMessageId")
 	delete(attributes, "sqsReceiptHandle")
 	delete(attributes, "sqsApproximateReceiveCount")


### PR DESCRIPTION
The subscriber test cases were created before initializing the app running them in the past. This makes it impossible to access fixtures from a call like `WithFixtureSetFactory` as the factory hasn't been run at that point. We now first run the fixture set factories before constructing the test case to allow for this.

Additionally, we now support test cases which assert that a specific model was not not persisted (for example, if you don't want to store all events). You can now pass `suite.WithExpectFound` or `suite.WithExpectNotFound` to the fetcher passed to the `Assert` method as optional arguments.