### PR TITLE
log: instead of reading the channel settings at app start, read them on demand

### DIFF
--- a/docs/docs/how-to/logging/implement-a-log-handler.mdx
+++ b/docs/docs/how-to/logging/implement-a-log-handler.mdx
@@ -33,6 +33,7 @@ import (
 
 	"github.com/justtrackio/gosoline/pkg/cfg"
 	"github.com/justtrackio/gosoline/pkg/log"
+	"github.com/justtrackio/gosoline/pkg/mdl"
 )
 ```
 
@@ -62,17 +63,19 @@ This handler struct stores the log `channel`. To use your handler, you must impl
 
 ### Implement the `Channels` method
 
-Create a getter for the log channels:
+Create a function which returns the log level for a given channel name:
 
 ```go
-func (h *MyCustomHandler) Channels() log.Channels {
-	return log.Channels{
-	    h.channel: log.PriorityInfo,
+func (h *MyCustomHandler) ChannelLevel(name string) (level *int, err error) {
+	if name == h.channel {
+		return mdl.Box(log.PriorityDebug), nil
 	}
+
+	return nil, nil
 }
 ```
 
-This returns an array of channels, including the one stored on `MyCustomHandler`.
+This checks if the requested channel is the channel we want to override, and, if so, returns a hardcoded value. Otherwise, we return nothing to indicate that the return value of the `Level` method should be used.
 
 ### Implement the `Level` method
 
@@ -92,7 +95,8 @@ Create a getter for the log message:
 
 ```go
 func (h *MyCustomHandler) Log(timestamp time.Time, level int, msg string, args []any, err error, data log.Data) error {
-	fmt.Printf("%s happenend at %s", msg, timestamp.Format(time.RFC822))
+	fmt.Printf("%s happened at %s", msg, timestamp.Format(time.RFC822))
+
 	return nil
 }
 ```
@@ -109,7 +113,9 @@ func MyCustomHandlerFactory(config cfg.Config, name string) (log.Handler, error)
 	settings := &MyCustomHandlerSettings{}
 
 	// 2
-	log.UnmarshalHandlerSettingsFromConfig(config, name, settings)
+	if err := log.UnmarshalHandlerSettingsFromConfig(config, name, settings); err != nil {
+		return nil, fmt.Errorf("can not unmarshal handler settings: %w", err)
+	}
 
 	// 3
 	return &MyCustomHandler{

--- a/docs/docs/how-to/logging/src/complex-logger/main.go
+++ b/docs/docs/how-to/logging/src/complex-logger/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/justtrackio/gosoline/pkg/cfg"
 	"github.com/justtrackio/gosoline/pkg/clock"
 	// 1
 	"github.com/justtrackio/gosoline/pkg/log"
@@ -14,7 +15,7 @@ func main() {
 	ctx := context.Background()
 
 	// 2
-	handler := log.NewHandlerIoWriter(log.LevelDebug, log.Channels{}, log.FormatterConsole, "15:04:05.000", os.Stdout)
+	handler := log.NewHandlerIoWriter(cfg.New(), log.LevelDebug, log.FormatterConsole, "main", "15:04:05.000", os.Stdout)
 	logger := log.NewLoggerWithInterfaces(clock.NewRealClock(), []log.Handler{handler})
 
 	if err := logger.Option(log.WithContextFieldsResolver(log.ContextFieldsResolver)); err != nil {

--- a/docs/docs/how-to/logging/src/config-logger/config.dist.yml
+++ b/docs/docs/how-to/logging/src/config-logger/config.dist.yml
@@ -12,9 +12,9 @@ log:
             type: iowriter
             channels:
                 metrics:
-                  level: error
+                    level: error
                 formatter:
-                  level: error
+                    level: error
             formatter: console
             level: info
             timestamp_format: 15:04:05.000

--- a/docs/docs/how-to/logging/src/log-handler/main.go
+++ b/docs/docs/how-to/logging/src/log-handler/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/justtrackio/gosoline/pkg/cfg"
 	"github.com/justtrackio/gosoline/pkg/log"
+	"github.com/justtrackio/gosoline/pkg/mdl"
 )
 
 type MyCustomHandlerSettings struct {
@@ -16,10 +17,12 @@ type MyCustomHandler struct {
 	channel string
 }
 
-func (h *MyCustomHandler) Channels() log.Channels {
-	return log.Channels{
-		h.channel: log.PriorityDebug,
+func (h *MyCustomHandler) ChannelLevel(name string) (level *int, err error) {
+	if name == h.channel {
+		return mdl.Box(log.PriorityDebug), nil
 	}
+
+	return nil, nil
 }
 
 func (h *MyCustomHandler) Level() int {

--- a/docs/docs/how-to/logging/src/minimal-logger/main.go
+++ b/docs/docs/how-to/logging/src/minimal-logger/main.go
@@ -4,13 +4,14 @@ import (
 	"os"
 
 	// 1
+	"github.com/justtrackio/gosoline/pkg/cfg"
 	"github.com/justtrackio/gosoline/pkg/log"
 )
 
 func main() {
 	// 2
 	logHandler := log.NewHandlerIoWriter(
-		log.LevelInfo, log.Channels{}, log.FormatterConsole, "", os.Stdout,
+		cfg.New(), log.LevelInfo, log.FormatterConsole, "main", "", os.Stdout,
 	)
 
 	// 3

--- a/docs/docs/reference/package-log.mdx
+++ b/docs/docs/reference/package-log.mdx
@@ -237,7 +237,7 @@ Adds additional handlers to the logger.
 
 ```go
 type Handler interface {
-	Channels() []string
+	ChannelLevel(name string) (level *int, err error)
 	Level() int
 	Log(timestamp time.Time, level int, msg string, args []any, err error, data Data) error
 }
@@ -245,7 +245,7 @@ type Handler interface {
 
 #### Description
 
-- `Channels() []string` and `Level() int` are called on every log action to check if the handler should be applied. 
+- `ChannelLevel(name string) (level *int, err error)` and `Level() int` are called on every log action to check if the handler should be applied.
 - `Log` does the actual logging afterwards.
 
 ## Log configurations
@@ -267,7 +267,7 @@ Multitool, which is able to write logs to everything which implements the `io.Wr
 | Setting          | Description                                                        | Default      |
 |------------------|--------------------------------------------------------------------|--------------|
 | level            | Levels of this and higher priority will get logged                 | info         |
-| channels         | Messages logged into these channels will be handled                | []           |
+| channels         | Messages logged into these channels will be handled                | {}           |
 | formatter        | Which format should be used by this handler                        | console      |
 | timestamp_format | A golang time format string to control the format of the timestamp | 15:04:05.000 |
 | writer           | Which io.writer implementation to use                              | stdout       |
@@ -280,7 +280,7 @@ log:
     main:
       type: iowriter
       level: info
-      channels: []
+      channels: {}
       formatter: console
       timestamp_format: 15:04:05.000
       writer: stdout
@@ -294,7 +294,7 @@ log:
     main:
       type: iowriter
       level: info
-      channels: *
+      channels: {}
       formatter: console
       timestamp_format: 15:04:05.000
       writer: file

--- a/docs/docs/reference/src/log/custom_handler.go
+++ b/docs/docs/reference/src/log/custom_handler.go
@@ -6,11 +6,14 @@ import (
 
 	"github.com/justtrackio/gosoline/pkg/cfg"
 	"github.com/justtrackio/gosoline/pkg/log"
+	"github.com/justtrackio/gosoline/pkg/mdl"
 )
 
 type MyCustomHandlerSettings struct {
-	Channel log.Channels `cfg:"channel"`
+	Channel Channels `cfg:"channel"`
 }
+
+type Channels map[string]string
 
 func MyCustomHandlerFactory(config cfg.Config, name string) (log.Handler, error) {
 	settings := &MyCustomHandlerSettings{}
@@ -24,11 +27,16 @@ func MyCustomHandlerFactory(config cfg.Config, name string) (log.Handler, error)
 }
 
 type MyCustomHandler struct {
-	channels log.Channels
+	channels Channels
 }
 
-func (h *MyCustomHandler) Channels() log.Channels {
-	return h.channels
+func (h *MyCustomHandler) ChannelLevel(name string) (level *int, err error) {
+	levelName, ok := h.channels[name]
+	if !ok {
+		return nil, nil
+	}
+
+	return mdl.Box(log.LevelPriority(levelName)), nil
 }
 
 func (h *MyCustomHandler) Level() int {

--- a/docs/docs/reference/src/log/main.go
+++ b/docs/docs/reference/src/log/main.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 
+	"github.com/justtrackio/gosoline/pkg/cfg"
 	"github.com/justtrackio/gosoline/pkg/log"
 )
 
@@ -11,14 +12,19 @@ func main() {
 	// will create an empty logger with a real clock and no handlers assigned
 	logger := log.NewLogger()
 
+	// create an empty config
+	config := cfg.New()
+
 	// create a handler which writes messages to stdout
 	handler := log.NewHandlerIoWriter(
+		// pass our config to look up if we should log messages in a specific channel
+		config,
 		// the min log level to write (trace, debug, info, warn, error)
 		log.LevelDebug,
-		// configuration of channels to filter for, if empty handler default will be used
-		log.Channels{},
 		// how to format the message. this will format in a console friendly way. log.FormatterJson would format log message as json
 		log.FormatterConsole,
+		// name of our handler. will be used to check if we should filter a channel
+		"main",
 		// how to format the log time. uses the structure of the `time` package
 		"15:04:05.000",
 		// the io.Writer to write to. this case it's stdout

--- a/docs/docs/reference/src/log/usage.go
+++ b/docs/docs/reference/src/log/usage.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/justtrackio/gosoline/pkg/cfg"
 	"github.com/justtrackio/gosoline/pkg/clock"
 	"github.com/justtrackio/gosoline/pkg/log"
 )
 
 func Usage() {
-	handler := log.NewHandlerIoWriter(log.LevelDebug, log.Channels{}, log.FormatterConsole, "15:04:05.000", os.Stdout)
+	handler := log.NewHandlerIoWriter(cfg.New(), log.LevelDebug, log.FormatterConsole, "main", "15:04:05.000", os.Stdout)
 	logger := log.NewLoggerWithInterfaces(clock.NewRealClock(), []log.Handler{handler})
 
 	if err := logger.Option(log.WithContextFieldsResolver(log.ContextFieldsResolver)); err != nil {

--- a/pkg/application/error.go
+++ b/pkg/application/error.go
@@ -3,6 +3,7 @@ package application
 import (
 	"os"
 
+	"github.com/justtrackio/gosoline/pkg/cfg"
 	"github.com/justtrackio/gosoline/pkg/clock"
 	"github.com/justtrackio/gosoline/pkg/log"
 	"github.com/justtrackio/gosoline/pkg/metric"
@@ -15,7 +16,7 @@ func withDefaultErrorHandler(handler ErrorHandler) {
 }
 
 var defaultErrorHandler = func(msg string, args ...any) {
-	writerHandler := log.NewHandlerIoWriter(log.LevelInfo, log.Channels{}, log.FormatterJson, "2006-01-02T15:04:05.999Z07:00", os.Stdout)
+	writerHandler := log.NewHandlerIoWriter(cfg.New(), log.LevelInfo, log.FormatterJson, "app", "2006-01-02T15:04:05.999Z07:00", os.Stdout)
 	metricHandler := metric.NewLoggerHandler()
 
 	logger := log.NewLoggerWithInterfaces(clock.Provider, []log.Handler{

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -31,7 +31,7 @@ func Run(module kernel.ModuleFactory, otherModuleMaps ...map[string]kernel.Modul
 		return
 	}
 
-	logger, err := newCliLogger()
+	logger, err := newCliLogger(config)
 	if err != nil {
 		defaultErrorHandler("can not initialize the logger: %w", err)
 

--- a/pkg/cli/logger.go
+++ b/pkg/cli/logger.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/justtrackio/gosoline/pkg/cfg"
 	"github.com/justtrackio/gosoline/pkg/clock"
 	"github.com/justtrackio/gosoline/pkg/log"
 )
 
-func newCliLogger() (log.Logger, error) {
+func newCliLogger(config cfg.Config) (log.Logger, error) {
 	var err error
 	var writer io.Writer
 
@@ -16,7 +17,7 @@ func newCliLogger() (log.Logger, error) {
 		return nil, fmt.Errorf("can not create io file writer for logger: %w", err)
 	}
 
-	handler := log.NewHandlerIoWriter(log.LevelInfo, log.Channels{}, log.FormatterConsole, "", writer)
+	handler := log.NewHandlerIoWriter(config, log.LevelInfo, log.FormatterConsole, "cli", "", writer)
 	logger := log.NewLoggerWithInterfaces(clock.Provider, []log.Handler{handler})
 
 	return logger, nil

--- a/pkg/lambda/error.go
+++ b/pkg/lambda/error.go
@@ -3,6 +3,7 @@ package lambda
 import (
 	"os"
 
+	"github.com/justtrackio/gosoline/pkg/cfg"
 	"github.com/justtrackio/gosoline/pkg/clock"
 	"github.com/justtrackio/gosoline/pkg/log"
 	"github.com/justtrackio/gosoline/pkg/metric"
@@ -15,7 +16,7 @@ func WithDefaultErrorHandler(handler ErrorHandler) {
 }
 
 var defaultErrorHandler = func(msg string, args ...any) {
-	writerHandler := log.NewHandlerIoWriter(log.LevelInfo, log.Channels{}, log.FormatterJson, "2006-01-02T15:04:05.999Z07:00", os.Stdout)
+	writerHandler := log.NewHandlerIoWriter(cfg.New(), log.LevelInfo, log.FormatterJson, "lambda", "2006-01-02T15:04:05.999Z07:00", os.Stdout)
 	metricHandler := metric.NewLoggerHandler()
 
 	logger := log.NewLoggerWithInterfaces(clock.Provider, []log.Handler{

--- a/pkg/log/builtin.go
+++ b/pkg/log/builtin.go
@@ -3,6 +3,7 @@ package log
 import (
 	"os"
 
+	"github.com/justtrackio/gosoline/pkg/cfg"
 	"github.com/justtrackio/gosoline/pkg/clock"
 )
 
@@ -13,5 +14,5 @@ func NewCliLogger() Logger {
 }
 
 func NewCliHandler() Handler {
-	return NewHandlerIoWriter(LevelInfo, Channels{}, FormatterConsole, "15:04:05.000", os.Stdout)
+	return NewHandlerIoWriter(cfg.New(), LevelInfo, FormatterConsole, "cli", "15:04:05.000", os.Stdout)
 }

--- a/pkg/log/handler.go
+++ b/pkg/log/handler.go
@@ -8,12 +8,10 @@ import (
 )
 
 type Handler interface {
-	Channels() Channels
+	ChannelLevel(name string) (level *int, err error)
 	Level() int
 	Log(timestamp time.Time, level int, msg string, args []any, err error, data Data) error
 }
-
-type Channels map[string]int
 
 type HandlerFactory func(config cfg.Config, name string) (Handler, error)
 

--- a/pkg/log/handler_sentry.go
+++ b/pkg/log/handler_sentry.go
@@ -39,8 +39,8 @@ func (h *HandlerSentry) WithContext(name string, context map[string]any) {
 	})
 }
 
-func (h *HandlerSentry) Channels() Channels {
-	return Channels{}
+func (h *HandlerSentry) ChannelLevel(string) (level *int, err error) {
+	return nil, nil
 }
 
 func (h *HandlerSentry) Level() int {

--- a/pkg/log/logger_context_enforce_test.go
+++ b/pkg/log/logger_context_enforce_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/justtrackio/gosoline/pkg/cfg"
 	"github.com/justtrackio/gosoline/pkg/clock"
 	"github.com/justtrackio/gosoline/pkg/log"
 	"github.com/stretchr/testify/suite"
@@ -22,7 +23,7 @@ func (s *ContextEnforcingLoggerTestSuite) SetupTest() {
 	s.clock = clock.NewFakeClock()
 	s.output = &bytes.Buffer{}
 	s.base = log.NewLoggerWithInterfaces(s.clock, []log.Handler{
-		log.NewHandlerIoWriter(log.LevelInfo, log.Channels{}, log.FormatterConsole, "15:04:05.000", s.output),
+		log.NewHandlerIoWriter(cfg.New(), log.LevelInfo, log.FormatterConsole, "test", "15:04:05.000", s.output),
 	})
 
 	s.logger = log.NewContextEnforcingLoggerWithInterfaces(s.base, log.GetMockedStackTrace, s.base)

--- a/pkg/log/logger_test.go
+++ b/pkg/log/logger_test.go
@@ -3,22 +3,41 @@ package log_test
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/justtrackio/gosoline/pkg/cfg"
 	"github.com/justtrackio/gosoline/pkg/clock"
+	"github.com/justtrackio/gosoline/pkg/funk"
 	"github.com/justtrackio/gosoline/pkg/log"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestLoggerIoWriter(t *testing.T) {
+	config := cfg.New(map[string]any{
+		"log": map[string]any{
+			"handlers": map[string]any{
+				"main": map[string]any{
+					"channels": map[string]any{
+						"main": map[string]any{
+							"level": log.LevelInfo,
+						},
+						"error_channel": map[string]any{
+							"level": log.LevelError,
+						},
+						"forbidden": map[string]any{
+							"level": log.LevelNone,
+						},
+					},
+				},
+			},
+		},
+	})
+
 	buf := &bytes.Buffer{}
-	handler := log.NewHandlerIoWriter(log.LevelInfo, log.Channels{
-		"main":          log.PriorityInfo,
-		"error_channel": log.PriorityError,
-		"forbidden":     log.PriorityNone,
-	}, log.FormatterJson, time.RFC3339, buf)
+	handler := log.NewHandlerIoWriter(config, log.LevelInfo, log.FormatterJson, "main", time.RFC3339, buf)
 	cl := clock.NewFakeClock()
 
 	logger := log.NewLoggerWithInterfaces(cl, []log.Handler{handler})
@@ -49,16 +68,55 @@ func TestLoggerIoWriter(t *testing.T) {
 	assert.JSONEq(t, `{"channel":"main","context":{},"err":"something went wrong: random error","fields":{},"level":4,"level_name":"error","message":"something went wrong: random error","timestamp":"1984-04-04T00:03:00Z"}`, lines[4])
 }
 
+func TestConfigureLoggerIoChannels(t *testing.T) {
+	buf := &bytes.Buffer{}
+
+	log.AddHandlerIoWriterFactory("buffer", func(config cfg.Config, configKey string) (io.Writer, error) {
+		return buf, nil
+	})
+
+	t.Setenv("LOG_HANDLERS_MAIN_CHANNELS_VERBOSE_LEVEL", log.LevelNone)
+	t.Setenv("LOG_HANDLERS_MAIN_CHANNELS_DEBUG_LEVEL", log.LevelDebug)
+
+	config := cfg.New(map[string]any{
+		"log": map[string]any{
+			"handlers": map[string]any{
+				"main": map[string]any{
+					"type":   "iowriter",
+					"writer": "buffer",
+					"channels": map[string]any{
+						"debug": map[string]any{
+							"level": log.LevelInfo,
+						},
+					},
+				},
+			},
+		},
+	})
+
+	err := config.Option(cfg.WithEnvKeyReplacer(cfg.DefaultEnvKeyReplacer))
+	assert.NoError(t, err)
+
+	handlers, err := log.NewHandlersFromConfig(config)
+	assert.NoError(t, err)
+
+	logger := log.NewLogger()
+	err = logger.Option(log.WithHandlers(handlers...))
+	assert.NoError(t, err)
+
+	logger.WithChannel("default").Info("should be logged")
+	logger.WithChannel("debug").Debug("should also be logged")
+	logger.WithChannel("verbose").Warn("should not be logged")
+
+	lines := getLogLines(buf)
+
+	assert.Len(t, lines, 2)
+	assert.Contains(t, lines[0], "should be logged")
+	assert.Contains(t, lines[1], "should also be logged")
+}
+
 func getLogLines(buf *bytes.Buffer) []string {
-	lines := make([]string, 0)
-
-	for _, line := range strings.Split(buf.String(), "\n") {
-		if len(line) == 0 {
-			continue
-		}
-
-		lines = append(lines, line)
-	}
-
-	return lines
+	return funk.Filter(strings.Split(buf.String(), "\n"), func(s string) bool {
+		return s != ""
+	})
 }

--- a/pkg/metric/logger_handler.go
+++ b/pkg/metric/logger_handler.go
@@ -28,8 +28,8 @@ type LoggerHandler struct {
 	writer Writer
 }
 
-func (h LoggerHandler) Channels() log.Channels {
-	return log.Channels{}
+func (h LoggerHandler) ChannelLevel(string) (level *int, err error) {
+	return nil, nil
 }
 
 func (h LoggerHandler) Level() int {

--- a/pkg/test/env/environment.go
+++ b/pkg/test/env/environment.go
@@ -124,7 +124,7 @@ func (e *Environment) init(options ...Option) error {
 		return fmt.Errorf("can not apply post processor on config: %w", err)
 	}
 
-	if logger, err = NewRecordingConsoleLogger(e.loggerOptions...); err != nil {
+	if logger, err = NewRecordingConsoleLogger(config, e.loggerOptions...); err != nil {
 		return fmt.Errorf("can apply logger option: %w", err)
 	}
 

--- a/pkg/test/env/logging.go
+++ b/pkg/test/env/logging.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/justtrackio/gosoline/pkg/cfg"
 	"github.com/justtrackio/gosoline/pkg/clock"
 	"github.com/justtrackio/gosoline/pkg/funk"
 	"github.com/justtrackio/gosoline/pkg/log"
@@ -63,14 +64,14 @@ func prepareLoggerSettings(options ...LoggerOption) (*LoggerSettings, error) {
 	return settings, nil
 }
 
-func NewRecordingConsoleLogger(options ...LoggerOption) (RecordingLogger, error) {
+func NewRecordingConsoleLogger(config cfg.Config, options ...LoggerOption) (RecordingLogger, error) {
 	settings, err := prepareLoggerSettings(options...)
 	if err != nil {
 		return nil, err
 	}
 
 	cl := clock.NewRealClock()
-	handler := log.NewHandlerIoWriter(settings.Level, log.Channels{}, log.FormatterConsole, "15:04:05.000", os.Stdout)
+	handler := log.NewHandlerIoWriter(config, settings.Level, log.FormatterConsole, "test", "15:04:05.000", os.Stdout)
 
 	logger := log.NewLoggerWithInterfaces(cl, []log.Handler{handler})
 
@@ -110,8 +111,8 @@ func (r recordingLogger) Reset() {
 	}
 }
 
-func (h handlerInMemoryWriter) Channels() log.Channels {
-	return log.Channels{}
+func (h handlerInMemoryWriter) ChannelLevel(string) (level *int, err error) {
+	return nil, nil
 }
 
 func (h handlerInMemoryWriter) Level() int {

--- a/pkg/tracing/logging.go
+++ b/pkg/tracing/logging.go
@@ -33,8 +33,8 @@ func NewLoggerErrorHandler() *LoggerErrorHandler {
 	return &LoggerErrorHandler{}
 }
 
-func (h *LoggerErrorHandler) Channels() log.Channels {
-	return log.Channels{}
+func (h *LoggerErrorHandler) ChannelLevel(string) (level *int, err error) {
+	return nil, nil
 }
 
 func (h *LoggerErrorHandler) Level() int {

--- a/test/httpserver/eof_bind_test.go
+++ b/test/httpserver/eof_bind_test.go
@@ -47,8 +47,8 @@ type bindHandler struct {
 	suite.Suite
 }
 
-func (b bindHandler) Channels() log.Channels {
-	return nil
+func (b bindHandler) ChannelLevel(string) (level *int, err error) {
+	return nil, nil
 }
 
 func (b bindHandler) Level() int {


### PR DESCRIPTION
We have a problem in our config when reading `map[string]T` values as we don't know what are valid keys for that map. As we don't have a one to one mapping from environment variables to config setting names, we don't know if a variable `FOO_BAR_BAZ` should set the nested `bar` value for key `FOO`, `Foo`, `foo`, or if we even set the value for `foo-bar`.

Instead, we now wait until we log a message in a channel to check if we should log for it and only then look up the (now known) config value.