### PR TITLE
stream: adds option to ack aggregate messages after processing;

### DIFF
--- a/pkg/stream/consumer.go
+++ b/pkg/stream/consumer.go
@@ -128,9 +128,14 @@ func (c *Consumer) processAggregateMessage(ctx context.Context, cdata *consumerD
 		return
 	}
 
-	c.Acknowledge(ctx, cdata, true)
+	if c.settings.AggregateMessageMode == AggregateMessageModeAtMostOnce {
+		c.Acknowledge(ctx, cdata, true)
+	}
 	for _, m := range batch {
 		_ = c.process(ctx, m, false) // we can't natively retry aggregate messages
+	}
+	if c.settings.AggregateMessageMode == AggregateMessageModeAtLeastOnce {
+		c.Acknowledge(ctx, cdata, true)
 	}
 
 	duration := c.clock.Now().Sub(start)

--- a/pkg/stream/consumer_settings.go
+++ b/pkg/stream/consumer_settings.go
@@ -9,13 +9,19 @@ import (
 	"github.com/justtrackio/gosoline/pkg/stream/health"
 )
 
+const (
+	AggregateMessageModeAtLeastOnce = "atLeastOnce"
+	AggregateMessageModeAtMostOnce  = "atMostOnce"
+)
+
 type ConsumerSettings struct {
-	Input       string                     `cfg:"input" default:"consumer" validate:"required"`
-	RunnerCount int                        `cfg:"runner_count" default:"1" validate:"min=1"`
-	Encoding    EncodingType               `cfg:"encoding" default:"application/json"`
-	IdleTimeout time.Duration              `cfg:"idle_timeout" default:"10s"`
-	Retry       ConsumerRetrySettings      `cfg:"retry"`
-	Healthcheck health.HealthCheckSettings `cfg:"healthcheck"`
+	Input                string                     `cfg:"input" default:"consumer" validate:"required"`
+	RunnerCount          int                        `cfg:"runner_count" default:"1" validate:"min=1"`
+	Encoding             EncodingType               `cfg:"encoding" default:"application/json"`
+	IdleTimeout          time.Duration              `cfg:"idle_timeout" default:"10s"`
+	Retry                ConsumerRetrySettings      `cfg:"retry"`
+	Healthcheck          health.HealthCheckSettings `cfg:"healthcheck"`
+	AggregateMessageMode string                     `cfg:"aggregate_message_mode" default:"atMostOnce" validate:"oneof=atLeastOnce atMostOnce"`
 }
 
 type ConsumerRetrySettings struct {

--- a/pkg/stream/consumer_settings_test.go
+++ b/pkg/stream/consumer_settings_test.go
@@ -29,6 +29,7 @@ func TestReadConsumerSettings_Empty(t *testing.T) {
 		Healthcheck: health.HealthCheckSettings{
 			Timeout: 5 * time.Minute,
 		},
+		AggregateMessageMode: stream.AggregateMessageModeAtMostOnce,
 	}, settings)
 }
 
@@ -55,6 +56,7 @@ func TestReadConsumerSettings_ReadKernelKillTimeout(t *testing.T) {
 		Healthcheck: health.HealthCheckSettings{
 			Timeout: 5 * time.Minute,
 		},
+		AggregateMessageMode: stream.AggregateMessageModeAtMostOnce,
 	}, settings)
 }
 
@@ -75,6 +77,7 @@ func TestReadConsumerSettings_SpecifyAll(t *testing.T) {
 					"healthcheck": map[string]any{
 						"timeout": "3m",
 					},
+					"aggregate_message_mode": "atLeastOnce",
 				},
 			},
 		},
@@ -99,5 +102,6 @@ func TestReadConsumerSettings_SpecifyAll(t *testing.T) {
 		Healthcheck: health.HealthCheckSettings{
 			Timeout: 3 * time.Minute,
 		},
+		AggregateMessageMode: stream.AggregateMessageModeAtLeastOnce,
 	}, settings)
 }

--- a/pkg/stream/consumer_test.go
+++ b/pkg/stream/consumer_test.go
@@ -102,6 +102,7 @@ func (s *ConsumerTestSuite) SetupTest() {
 		Healthcheck: health.HealthCheckSettings{
 			Timeout: time.Minute,
 		},
+		AggregateMessageMode: stream.AggregateMessageModeAtMostOnce,
 	}
 
 	healthCheckTimer := clock.NewHealthCheckTimerWithInterfaces(clock.NewFakeClock(), settings.Healthcheck.Timeout)


### PR DESCRIPTION
Currently, aggregate messages are acknowledged before handling in pkg/stream/consumer.go(processAggregateMessage). This PR adds `AckAggAfterProcess`, which allows acknowledging aggregate messages after processing them. This is to ensure messages aren't lost if the container goes away during the processing of an aggregate message.