### PR TITLE
refl: get all tag names from struct

### DIFF
--- a/pkg/refl/tags.go
+++ b/pkg/refl/tags.go
@@ -1,8 +1,15 @@
 package refl
 
 import (
+	"reflect"
+	"regexp"
+	"sort"
 	"strings"
+
+	"github.com/justtrackio/gosoline/pkg/funk"
 )
+
+var tagKeyRegex = regexp.MustCompile(`(\w+):"[^"]*"`)
 
 // GetTags reads the values of tags with the name tagName.
 // Tag values get extracted until the first comma.
@@ -32,4 +39,42 @@ func GetTags(v any, tagName string) []string {
 	}
 
 	return availableFields
+}
+
+// GetTagNames returns a sorted list of distinct struct tag keys present on the fields of the given value.
+// Works with structs, pointers to structs, and slices of structs. Returns an empty slice for nil or non-structs.
+func GetTagNames(v any) []string {
+	if v == nil {
+		return []string{}
+	}
+
+	// handle typed nil pointer
+	if rv := reflect.ValueOf(v); rv.Kind() == reflect.Ptr && rv.IsNil() {
+		return []string{}
+	}
+
+	typ := ResolveBaseType(v)
+	if typ == nil || typ.Kind() != reflect.Struct {
+		return []string{}
+	}
+
+	set := make(funk.Set[string])
+	for i := 0; i < typ.NumField(); i++ {
+		raw := string(typ.Field(i).Tag)
+		if raw == "" {
+			continue
+		}
+
+		allMatches := tagKeyRegex.FindAllStringSubmatch(raw, -1)
+		for _, match := range allMatches {
+			if len(match) > 1 {
+				set.Add(match[1])
+			}
+		}
+	}
+
+	names := set.ToSlice()
+	sort.Strings(names)
+
+	return names
 }


### PR DESCRIPTION
This pull request adds a new utility function for extracting all unique struct tag keys from Go structs, along with comprehensive tests to ensure its correctness. The changes enhance the `refl` package's ability to introspect struct tags, making it easier to work with various serialization and mapping libraries.

**New functionality for struct tag introspection:**

* Added the `GetTagNames` function to `pkg/refl/tags.go`, which returns a sorted list of distinct struct tag keys present on the fields of a struct, pointer to struct, or slice of structs. Handles nil and non-struct inputs gracefully.
* Imported `reflect` and `sort` packages in `pkg/refl/tags.go` to support the new function's implementation.

**Testing improvements:**

* Added a comprehensive test `TestGetTagNames` in `pkg/refl/tags_test.go` to verify correct behavior for various struct layouts, including multiple tags per field, duplicate tag keys, empty tag values, structs without tags, and nil pointers.