### PR TITLE
kinesis: handle stream already being created case

### DIFF
--- a/pkg/ddb/service.go
+++ b/pkg/ddb/service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"slices"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -142,7 +143,7 @@ func (s *Service) CreateTable(ctx context.Context) (*Metadata, error) {
 	_, err = s.client.CreateTable(ctx, input)
 
 	var errResourceInUseException *types.ResourceInUseException
-	if errors.As(err, &errResourceInUseException) {
+	if errors.As(err, &errResourceInUseException) && strings.Contains(err.Error(), "already exists") {
 		return metadata, nil
 	}
 


### PR DESCRIPTION
This pull request improves the error handling logic for AWS resource creation in both the Kinesis and DynamoDB service implementations. The main change is to ensure that the code only treats "already exists" errors as non-fatal, allowing other types of `ResourceInUseException` errors to propagate correctly.

**Error handling improvements:**

* Updated the Kinesis service's `Create` method to check that a `ResourceInUseException` contains "already exists" in the error message before treating it as non-fatal, and logs a specific message when this occurs.
* Modified the DynamoDB service's `CreateTable` method to similarly check for "already exists" in the error message when handling `ResourceInUseException`, ensuring only the intended error is ignored.

**Dependency updates:**

* Added the `strings` package import in both `pkg/cloud/aws/kinesis/service.go` and `pkg/ddb/service.go` to support the new error message checks. [[1]](diffhunk://#diff-edee1e9ac7a8f94a441345e6ef8ce3722283dabe94e8a3fc03f35e01cbb62f8aR7) [[2]](diffhunk://#diff-b19b8b4367ebe180e7714de27f771e00fc202157c50ad831b6e68d2196070c0eR9)