### PR TITLE
fixtures: skip fixtures which return nil after transform for subscribers

### DIFF
--- a/pkg/mdlsub/fixtures.go
+++ b/pkg/mdlsub/fixtures.go
@@ -129,6 +129,10 @@ func (f FixtureSet) Write(ctx context.Context) error {
 			return fmt.Errorf("failed to transform model %s: %w", f.source.String(), err)
 		}
 
+		if model == nil {
+			continue
+		}
+
 		if err = output.Persist(ctx, model, res.spec.CrudType); err != nil {
 			return fmt.Errorf("failed to persist model %s: %w", f.source.String(), err)
 		}


### PR DESCRIPTION
This pull request introduces a small but important change to the `FixtureSet.Write` method to improve its robustness. Now, if the transformed `model` is `nil`, the loop will skip persisting that entry instead of attempting to persist a nil value.

* Prevents persisting `nil` models by adding a check to continue the loop if `model` is `nil` in `fixtures.go`.…ers;