### PR TITLE
mapx: enable keys with dots

### DIFF
--- a/pkg/mapx/key_split.go
+++ b/pkg/mapx/key_split.go
@@ -1,0 +1,36 @@
+package mapx
+
+func SplitUnescapedDotN(s string, n int) []string {
+	if n == 0 {
+		return nil
+	}
+
+	var parts []string
+	var current []rune
+	escaped := false
+
+	for _, r := range s {
+		if r == '\\' && !escaped {
+			escaped = true
+
+			continue
+		}
+
+		if r == '.' && !escaped && (n < 0 || len(parts) < n-1) {
+			parts = append(parts, string(current))
+			current = current[:0]
+
+			continue
+		}
+
+		if escaped {
+			current = append(current, '\\')
+			escaped = false
+		}
+		current = append(current, r)
+	}
+
+	parts = append(parts, string(current))
+
+	return parts
+}

--- a/pkg/mapx/key_split_test.go
+++ b/pkg/mapx/key_split_test.go
@@ -1,0 +1,46 @@
+package mapx_test
+
+import (
+	"testing"
+
+	"github.com/justtrackio/gosoline/pkg/mapx"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSplitUnescapedDotN(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		n    int
+		want []string
+	}{
+		// Basic behavior
+		{"simple no limit", "a.b.c", -1, []string{"a", "b", "c"}},
+		{"simple with limit", "a.b.c", 2, []string{"a", "b.c"}},
+		{"simple n=1", "a.b.c", 1, []string{"a.b.c"}},
+		{"simple n=0", "a.b.c", 0, nil},
+
+		// Escaped dots
+		{"escaped middle no limit", "a\\.b.c", -1, []string{"a\\.b", "c"}},
+		{"escaped middle limited", "a\\.b.c.d", 3, []string{"a\\.b", "c", "d"}},
+		{"escaped dot only", "a\\.b\\.c", -1, []string{"a\\.b\\.c"}},
+		{"escaped at start", "\\.a.b", -1, []string{"\\.a", "b"}},
+		{"escaped at end", "a.b\\.", -1, []string{"a", "b\\."}},
+
+		// Mix escaped + unescaped
+		{"mixed escapes", "a\\.b.c\\.d.e", -1, []string{"a\\.b", "c\\.d", "e"}},
+		{"mixed escapes limited", "a\\.b.c\\.d.e", 2, []string{"a\\.b", "c\\.d.e"}},
+
+		// Edge structure
+		{"no dots", "abc", -1, []string{"abc"}},
+		{"leading dot", ".a.b", -1, []string{"", "a", "b"}},
+		{"trailing dot", "a.b.", -1, []string{"a", "b", ""}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mapx.SplitUnescapedDotN(tt.in, tt.n)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/mapx/map.go
+++ b/pkg/mapx/map.go
@@ -168,7 +168,11 @@ func (m *MapX) prepareInput(value any) any {
 
 func (m *MapX) access(current any, selector string, value any, mode *OpMode) any {
 	selector = strings.Trim(selector, ".")
-	selSegs := strings.SplitN(selector, PathSeparator, 2)
+	selSegs := SplitUnescapedDotN(selector, 2)
+
+	if len(selSegs) > 1 {
+		selSegs = []string{selSegs[0], strings.Join(selSegs[1:], ".")}
+	}
 
 	thisSel := selSegs[0]
 	index := -1

--- a/pkg/mapx/map_test.go
+++ b/pkg/mapx/map_test.go
@@ -104,6 +104,16 @@ func (s *MapTestSuite) TestSetMap() {
 	s.Equal(msi, actual)
 }
 
+func (s *MapTestSuite) TestSetKeyWithDots() {
+	s.m.Set(`key\.with\.dots`, "value")
+
+	keys := s.m.Keys()
+	s.Equal([]string{`key\.with\.dots`}, keys)
+
+	actual := s.m.Get(`key\.with\.dots`).Data()
+	s.Equal("value", actual)
+}
+
 func (s *MapTestSuite) TestSetSliceOffset() {
 	s.m.Set("sl[1]", 1)
 


### PR DESCRIPTION
This pull request introduces a new utility function for splitting map keys on unescaped dots, updates the key parsing logic in the main map accessor, and adds comprehensive tests to ensure correct handling of escaped dots in keys. The changes improve how keys containing literal dots (escaped with backslashes) are processed, preventing accidental splitting and supporting more flexible key formats.

### Key parsing improvements

* Added the new `SplitUnescapedDotN` function in `pkg/mapx/key_split.go`, which splits a string on unescaped dots, with support for a split limit and correct handling of backslash escapes.
* Updated the key selector logic in `MapX.access` (in `pkg/mapx/map.go`) to use `SplitUnescapedDotN` instead of `strings.SplitN`, ensuring keys with escaped dots are parsed correctly.

### Testing and validation

* Added a thorough unit test for `SplitUnescapedDotN` in `pkg/mapx/key_split_test.go`, covering various edge cases including escaped dots, split limits, and leading/trailing dots.
* Added a new test case in `MapTestSuite` (`pkg/mapx/map_test.go`) to verify that keys containing escaped dots are handled as single keys and not split, ensuring correct set/get behavior.