### PR TITLE
mapx: allow root access

### DIFF
--- a/pkg/mapx/map.go
+++ b/pkg/mapx/map.go
@@ -73,6 +73,10 @@ func (m *MapX) Get(key string) *MapXNode {
 }
 
 func (m *MapX) doGet(key string) *MapXNode {
+	if key == "." {
+		return &MapXNode{value: m.msn}
+	}
+
 	val := m.access(m.msn, key, nil, &OpMode{})
 
 	return &MapXNode{value: val}

--- a/pkg/mapx/map_test.go
+++ b/pkg/mapx/map_test.go
@@ -205,6 +205,9 @@ func (s *MapTestSuite) TestGet() {
 	s.Equal([]any{1, 2}, msi.Get("sl1").Data())
 	s.Equal(2, msi.Get("sl1[1]").Data())
 	s.Equal(nil, msi.Get("sl1[2]").Data())
+
+	root := msi.Get(".").Data()
+	s.Equal(data, root)
 }
 
 func (s *MapTestSuite) TestMergeRootEmpty() {


### PR DESCRIPTION
This pull request introduces a small but important enhancement to the `MapX` data structure, allowing retrieval of the root node using the special key `"."`. A corresponding test has also been added to ensure this behavior works as expected.

Enhancement to root node retrieval:

* Updated the `doGet` method in `MapX` to return the root node when the key is `"."`, enabling direct access to the root of the map.

Testing improvements:

* Added a test case in `TestGet` to verify that calling `Get(".")` returns the root data structure.