### PR TITLE
httpserver: moved httpserver to application stage and made it wait for shutdown;

### DIFF
--- a/pkg/cloud/aws/kinesis/shard_reader.go
+++ b/pkg/cloud/aws/kinesis/shard_reader.go
@@ -112,6 +112,10 @@ func (s *shardReader) Run(ctx context.Context, handler func(record []byte) error
 	shardIterator := s.getCheckpoint().GetShardIterator()
 	iterator, err := s.getShardIterator(ctx, sequenceNumber, shardIterator)
 	if err != nil {
+		if exec.IsRequestCanceled(err) {
+			return nil
+		}
+
 		return fmt.Errorf("failed to get shard iterator: %w", err)
 	}
 

--- a/pkg/funk/map.go
+++ b/pkg/funk/map.go
@@ -129,6 +129,7 @@ func Values[K comparable, V any, M ~map[K]V](m M) []V {
 	return values
 }
 
+// MapFilter removes entries from a map which don't satisfy a predicate. The order of the calls to the predicate is undefined.
 func MapFilter[K comparable, V any, M ~map[K]V](m M, f func(key K, value V) bool) map[K]V {
 	filteredMap := map[K]V{}
 
@@ -171,7 +172,7 @@ func MapKeysWith[K1 comparable, K2 comparable, V any, M1 ~map[K1]V](m M1, f func
 	return r
 }
 
-// MapValues applies a function to all values of a map.
+// MapValues applies a function to all values of a map. The order in which the function will be called for each value is undefined.
 func MapValues[K comparable, V1, V2 any, M1 ~map[K]V1](m M1, f func(value V1) V2) map[K]V2 {
 	r := make(map[K]V2, len(m))
 

--- a/pkg/kernel/common/constants.go
+++ b/pkg/kernel/common/constants.go
@@ -2,7 +2,8 @@ package common
 
 // internal use only to break cycles, use the constants from the kernel package
 const (
-	StageEssential   = 0
-	StageService     = 0x400
-	StageApplication = 0x800
+	StageEssential      = 0
+	StageProducerDaemon = 0x200
+	StageService        = 0x400
+	StageApplication    = 0x800
 )

--- a/pkg/kernel/module.go
+++ b/pkg/kernel/module.go
@@ -8,18 +8,21 @@ import (
 	"github.com/justtrackio/gosoline/pkg/log"
 )
 
+// The kernel is split into multiple stages.
+//  * Essential: Starts first and shuts down last. Includes metric writers and anything else that gets data from other modules
+//    and must not exist before the other modules do so.
+//  * ProducerDaemon: The producer daemon runs in its own stage. You can think of it as basically an additional service stage.
+//  * Service: Contains services provided to the application that should start first but still depend on the essential modules.
+//    This includes the modules provided by gosoline, for example a GeoIP database or the currency service.
+//  * Application: Your code should normally run in this stage. It will be started after other services are already
+//    running and shut down first so other stages still have some time to process the messages they did receive from
+//    your application. This stage includes the HTTP servers, consumers, and subscribers building your application.
+
 const (
-	// The kernel is split into three stages.
-	//  * Essential: Starts first and shuts down last. Includes metric writers and anything else that gets data from other
-	//    modules and must not exist before the other modules do so.
-	//  * Service: Contains services provided to the application that should start first but still depend on the essential
-	//    modules. This includes the modules provided by gosoline, for example the ApiServer.
-	//  * Application: Your code should normally run in this stage. It will be started after other services are already
-	//    running and shut down first so other stages still have some time to process the messages they did receive from
-	//    your application.
-	StageEssential   = common.StageEssential
-	StageService     = common.StageService
-	StageApplication = common.StageApplication
+	StageEssential      = common.StageEssential
+	StageProducerDaemon = common.StageProducerDaemon
+	StageService        = common.StageService
+	StageApplication    = common.StageApplication
 )
 
 type (

--- a/pkg/stream/producer_daemon.go
+++ b/pkg/stream/producer_daemon.go
@@ -225,7 +225,7 @@ func (d *producerDaemon) restart() {
 }
 
 func (d *producerDaemon) GetStage() int {
-	return 512
+	return kernel.StageProducerDaemon
 }
 
 func (d *producerDaemon) Run(kernelCtx context.Context) error {

--- a/test/stream/kafka/consumer/config.dist.yml
+++ b/test/stream/kafka/consumer/config.dist.yml
@@ -26,3 +26,4 @@ test:
   components:
     kafka:
       default:
+        expire_after: 5m

--- a/test/stream/kafka/producer/config.dist.yml
+++ b/test/stream/kafka/producer/config.dist.yml
@@ -16,3 +16,4 @@ test:
   components:
     kafka:
       default:
+        expire_after: 5m

--- a/test/stream/kafka/subscriber/config.dist.yml
+++ b/test/stream/kafka/subscriber/config.dist.yml
@@ -32,3 +32,4 @@ test:
   components:
     kafka:
       default:
+        expire_after: 5m

--- a/test/stream/retry_handler/config.dist.yml
+++ b/test/stream/retry_handler/config.dist.yml
@@ -23,3 +23,4 @@ test:
     localstack:
       default:
         services: sqs
+        expire_after: 5m

--- a/test/stream/retry_handler_sqs/config.dist.yml
+++ b/test/stream/retry_handler_sqs/config.dist.yml
@@ -27,6 +27,7 @@ test:
     localstack:
       default:
         services: sqs
+        expire_after: 5m
     streamInput:
       consumer:
         in_memory_override: false


### PR DESCRIPTION
In the past, the httpserver module would run in the service instead of the application stage. This would cause modules like the GeoIP database to be shut down at the same time as the server, potentially resulting requests to access the (now shut down) database and failing to get any data from it. We now move it to the correct application stage, resulting in the httpserver to be shut down before the rest. This commit also fixes a bug where we would not actually wait for all requests to be done before proceeding with the shutdown.