### PR TITLE
mdlsub: added a new persist_grace_time setting (default: 10s) to subscribers

### DIFF
--- a/pkg/mdlsub/settings.go
+++ b/pkg/mdlsub/settings.go
@@ -2,6 +2,7 @@ package mdlsub
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/justtrackio/gosoline/pkg/cfg"
 )
@@ -16,11 +17,12 @@ type Settings struct {
 }
 
 type SubscriberSettings struct {
-	Input       string          `cfg:"input" default:"sns"`
-	Output      string          `cfg:"output"`
-	RunnerCount int             `cfg:"runner_count" default:"10" validate:"min=1"`
-	SourceModel SubscriberModel `cfg:"source"`
-	TargetModel SubscriberModel `cfg:"target"`
+	Input            string          `cfg:"input" default:"sns"`
+	Output           string          `cfg:"output"`
+	PersistGraceTime time.Duration   `cfg:"persist_grace_time" default:"10s" validate:"min=0"`
+	RunnerCount      int             `cfg:"runner_count" default:"10" validate:"min=1"`
+	SourceModel      SubscriberModel `cfg:"source"`
+	TargetModel      SubscriberModel `cfg:"target"`
 }
 
 func unmarshalSettings(config cfg.Config) (*Settings, error) {

--- a/pkg/mdlsub/subscriber_factory.go
+++ b/pkg/mdlsub/subscriber_factory.go
@@ -16,7 +16,12 @@ func NewSubscriberFactory(transformerFactoryMap TransformerMapTypeVersionFactori
 	}
 }
 
-func SubscriberFactory(ctx context.Context, config cfg.Config, logger log.Logger, transformerFactories TransformerMapTypeVersionFactories) (map[string]kernel.ModuleFactory, error) {
+func SubscriberFactory(
+	ctx context.Context,
+	config cfg.Config,
+	logger log.Logger,
+	transformerFactories TransformerMapTypeVersionFactories,
+) (map[string]kernel.ModuleFactory, error) {
 	var err error
 	var core SubscriberCore
 	var settings *Settings
@@ -38,7 +43,7 @@ func SubscriberFactory(ctx context.Context, config cfg.Config, logger log.Logger
 			continue
 		}
 
-		callbackFactory := NewSubscriberCallbackFactory(core, subscriberSettings.SourceModel)
+		callbackFactory := NewSubscriberCallbackFactory(core, subscriberSettings.SourceModel, subscriberSettings.PersistGraceTime)
 		modules[subscriberFQN] = stream.NewUntypedConsumer(subscriberFQN, callbackFactory)
 	}
 


### PR DESCRIPTION
If your app should shutdown while transforming or persisting an entity in a subscriber, we now by default allow for up to 10s to write the entity. We also now handle a cancelled context while transforming the entity instead of logging an error.
