### PR TITLE
feat: Add AGENTS.md files;

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,144 @@
+# Agent Handbook
+
+Operate in this repository as the maintainer of the **gosoline** application framework—a Go-based toolkit for building cloud microservices with first-class AWS integration.
+
+## Quick facts
+- **Module path:** `github.com/justtrackio/gosoline`
+- **Go toolchain:** 1.24 (see `.tool-versions` for exact patch level)
+- **Primary frameworks:** Gin (HTTP), AWS SDK v2, testify, mockery
+- **Key tags:** most packages ship `fixtures` and `integration` build tags. Always include both when building, testing, or linting to pull in fixture wiring.
+
+## Repository layout
+- `pkg/`: Core framework packages (50+ packages covering application lifecycle, configuration, logging, AWS integrations, streaming, HTTP server, database, caching, etc.)
+- `docs/`: Docusaurus documentation site. Run `cd docs && yarn build` to verify.
+- `examples/`: Sample applications demonstrating gosoline features and best practices.
+- `test/`: Integration and E2E test suites (blob, cloud, db, db-repo, ddb, fixtures, guard, httpserver, mdlsub, stream, suite). Requires Docker.
+- `.github/workflows/`: CI pipelines—mockery check, build, golangci-lint, unit tests, race tests, integration tests.
+
+## Day-to-day workflow for changes
+1. Capture user requirements and convert them into a todo list (use the `manage_todo_list` tool). Keep a single active item at a time.
+2. Survey the relevant package (readme, docs, nested AGENTS.md) before editing code.
+3. Edit Go sources and immediately format using `gofumpt -w <files>`.
+4. Regenerate artifacts after interface changes:
+   - Mocks: `go generate -run='mockery' ./...`
+5. Validate locally:
+   - `gofumpt -w .`
+   - `go build -tags fixtures,integration ./...`
+   - `go test -tags fixtures,integration ./...`
+   - `golangci-lint run --build-tags integration,fixtures ./...`
+6. Update AGENTS.md files if your changes affect package structure, APIs, or workflows documented there. Check both the root `AGENTS.md` and any package-specific `AGENTS.md` (e.g., `pkg/<package>/AGENTS.md`).
+7. Summarize work with requirement coverage, commands executed, and pending follow-ups. Never stage or commit; CI and reviewers expect clean diffs only.
+
+## GitHub MCP server workflow
+- **Repository:** `justtrackio/gosoline`. Pass owner `justtrackio` and name `gosoline` to GitHub MCP tools.
+- **Search issues/PRs:** Use `github-pull-request_formSearchQuery` to convert natural language to GitHub search syntax, then execute with `github-pull-request_doSearch`. Filter by state, labels, or assignees as needed.
+- **Inspect an issue:** Fetch issue details with `github-pull-request_issue_fetch` by supplying `repo: {owner: "justtrackio", name: "gosoline"}` and the `issueNumber`.
+- **Active PR context:** Use `github-pull-request_activePullRequest` to get details about the currently checked-out PR, including title, description, changed files, review comments, and CI status.
+- **Suggest fixes:** Use `github-pull-request_suggest-fix` to analyze an issue and propose implementation approaches.
+- **Pull requests:** Do not create PRs yourself. Use `github-pull-request_openPullRequest` to inspect the currently visible PR if needed for review context.
+
+## Git contribution rules
+- **Branch creation:** Never create branches manually. Let maintainers handle branch creation.
+- **Commits:** Do not run `git commit` locally. Keep your workspace uncommitted so CI and reviewers can inspect the full diff without extra history.
+- **Pull requests:** Do not create PRs yourself. Ask a maintainer to open the PR and check the branch out locally.
+- **Merging:** Never merge PRs yourself. Leave merges to maintainers or automated pipelines.
+
+## Command reference
+| Task | Command |
+|------|---------|
+| Format | `gofumpt -w .` |
+| Build | `go build -tags fixtures,integration ./...` |
+| Unit tests | `go test ./...` |
+| Unit tests (race) | `go test -race ./...` |
+| Integration tests | `go test -tags integration,fixtures ./test/...` |
+| Lint | `golangci-lint run --build-tags integration,fixtures ./...` |
+| Mock generation | `go generate -run='mockery' ./...` |
+| Targeted test | `go test -tags fixtures,integration ./test/<package>/... -run <TestName>` |
+| Docs build | `cd docs && yarn install && yarn build` |
+
+## Domain map
+
+### Core packages (`pkg/`)
+| Package | Purpose |
+|---------|---------|
+| `application/` | Application entry point, lifecycle management |
+| `kernel/` | Module orchestration, startup/shutdown sequencing |
+| `cfg/` | Configuration management, AppId, macro interpolation |
+| `log/` | Structured logging infrastructure |
+| `httpserver/` | Gin-based HTTP server, middleware, handlers |
+| `stream/` | Message streaming, consumers, producers |
+| `mdl/` | Model definitions, ModelId |
+| `mdlsub/` | Model subscription patterns |
+
+### AWS integrations (`pkg/cloud/aws/`)
+| Package | AWS Service |
+|---------|-------------|
+| `sqs/` | Simple Queue Service |
+| `sns/` | Simple Notification Service |
+| `kinesis/` | Kinesis Data Streams |
+| `dynamodb/` | DynamoDB |
+| `s3/` | S3 object storage |
+| `cloudwatch/` | CloudWatch metrics/logs |
+| `secretsmanager/` | Secrets Manager |
+| `ses/` | Simple Email Service |
+
+### Data & persistence
+| Package | Purpose |
+|---------|---------|
+| `db/` | Database connections, migrations |
+| `db-repo/` | Repository pattern for SQL |
+| `ddb/` | DynamoDB repositories, naming |
+| `redis/` | Redis client, caching |
+| `kvstore/` | Key-value store abstraction |
+| `blob/` | Blob storage abstraction |
+| `fixtures/` | Test fixture loading |
+
+### Utilities
+| Package | Purpose |
+|---------|---------|
+| `exec/` | Retry, backoff, execution helpers |
+| `clock/` | Time abstraction for testing |
+| `uuid/` | UUID generation |
+| `funk/` | Functional utilities (map, filter, etc.) |
+| `mapx/` | Map utilities |
+| `cast/` | Type casting helpers |
+| `encoding/` | Encoding utilities |
+| `validation/` | Input validation |
+
+## Naming conventions and resource macros
+
+Gosoline uses a macro system for consistent resource naming across AWS services and data stores.
+
+### AppId macros (cfg package)
+Used in queue/topic/stream names via `cfg.AppId.ReplaceMacros(pattern)`:
+- `{project}` - app_project config value
+- `{env}` - environment
+- `{family}` - app_family
+- `{group}` - app_group
+- `{app}` - app_name
+
+### ModelId macros (mdl package)
+Used in DynamoDB table names via `mdl.ModelId.ReplaceMacros(pattern)`:
+- All AppId macros above, plus:
+- `{modelId}` - the model's string representation (`project.family.group.name`)
+
+### Service-specific macros
+- SQS/SNS: `{queueId}`, `{topicId}`
+- Kinesis: `{streamName}`
+- DynamoDB: `{modelId}`
+
+### Example config
+```yaml
+cloud.aws.sqs.clients.default.naming.pattern: "{project}-{env}-{family}-{group}-{app}-{queueId}"
+```
+
+## Conventions & testing patterns
+- File naming: `snake_case.go`
+- Exported names: `CamelCase`
+- JSON struct tags: `camelCase`
+- Config struct tags: `cfg:"key_name"`
+- Wrap errors: `fmt.Errorf("<context>: %w", err)`
+- Always propagate `context.Context`
+- Prefer dependency injection via gosoline configuration modules
+- Tests use `github.com/stretchr/testify`, Match `context.Context` arguments with `matcher.Context` from `pkg/test/matcher`
+- Keep build tags aligned across source and tests (`//go:build fixtures` / `integration`)

--- a/pkg/application/AGENTS.md
+++ b/pkg/application/AGENTS.md
@@ -1,0 +1,41 @@
+# Application Package Agent Guide
+
+## Scope
+- Bootstraps gosoline applications via `application.Run`.
+- Wires modules, runners, and metadata server exposure.
+- Bridges configuration (`cfg`) and lifecycle management (`kernel`).
+
+## Key files
+- `app.go` - core application struct and global Run entrypoint.
+- `options.go` - functional options for adding modules, health checks, and shared components.
+- `metadata_server.go` - HTTP server exposing build info and module metadata.
+- `runners.go` - helpers for wiring background runners/modules.
+
+## Common tasks
+- Add or adjust default modules: extend `appOptions` in `options.go` and ensure new dependencies are registered before `kernel.Run`.
+- Customize metadata output: update `metadata_server.go` and extend the struct returned by `buildMetadata`.
+- Provide new module factories: expose them via `WithModuleFactory` and document required config keys.
+
+## Testing
+- Run `go test ./pkg/application` before pushing changes.
+- Use `examples/application` to manually validate startup/shutdown flows.
+
+## Required config keys
+```yaml
+env: dev                    # Environment name
+app_project: myproject      # Project identifier
+app_family: myfamily        # Family grouping
+app_group: mygroup          # Group within family
+app_name: myapp             # Application name
+```
+
+## Related packages
+- `pkg/kernel` - module lifecycle, stages, middleware
+- `pkg/cfg` - configuration loading, AppId resolution
+- `pkg/log` - logger injection and channel management
+- `pkg/appctx` - cross-module state container
+
+## Tips
+- Keep module registration deterministic; avoid side effects in package `init`.
+- Prefer `appctx` for cross-module shared state instead of singletons.
+- Update root `AGENTS.md` when introducing new application-wide options that agents must know about.

--- a/pkg/cfg/AGENTS.md
+++ b/pkg/cfg/AGENTS.md
@@ -1,0 +1,40 @@
+# Configuration Package Agent Guide
+
+## Scope
+- Central configuration loader/merger used by every package.
+- Provides AppId/Realm handling + macro interpolation.
+- Exposes decoding helpers and merge strategies for YAML/JSON/env sources.
+
+## Key files
+- `config.go`, `read.go` - provider interfaces, load & merge process.
+- `application_identifiers.go` - `AppId`, realm macros, `ReplaceMacros` utilities.
+- `merge*.go`, `options.go` - precedence rules and customization points.
+- `postprocessor.go`, `sanitizer.go` - value normalization and validation hooks.
+
+## Common tasks
+- Add config sources: extend `Option` builders in `options.go` and hook a `Provider` implementation.
+- Update macro behavior: touch `application_identifiers.go`, update docs + relevant tests.
+- Enhance sanitization: implement `Sanitizer` and register it via `Option`.
+
+## Testing
+- `go test ./pkg/cfg` is mandatory after any change.
+- For macro work, ensure downstream packages (cfg, mdl, ddb, cloud/aws) still pass: `go test ./pkg/{cfg,mdl,cloud/aws,...}`.
+
+## Available macros in ReplaceMacros
+| Macro | Source | Description |
+|-------|--------|-------------|
+| `{project}` | `app_project` | Project identifier |
+| `{env}` | `env` | Environment name |
+| `{family}` | `app_family` | Family grouping |
+| `{group}` | `app_group` | Group within family |
+| `{app}` | `app_name` | Application name |
+
+## Related packages
+- `pkg/mdl` - ModelId with similar macro system for data models
+- `pkg/cloud/aws/*` - AWS services consume AppId for naming
+- `pkg/ddb` - DynamoDB naming uses ModelId which extends AppId concepts
+
+## Tips
+- Never call `Config.GetString` when you need raw template values; prefer `Get` + type conversion.
+- Document new config keys in package-level README or parent AGENT so other agents can discover them.
+- When adding interfaces, update `.mockery.yml` before running `go generate -run='mockery' ./...`.

--- a/pkg/cloud/aws/AGENTS.md
+++ b/pkg/cloud/aws/AGENTS.md
@@ -1,0 +1,46 @@
+# AWS Cloud Package Agent Guide
+
+## Scope
+- Houses all AWS integrations (SQS, SNS, Kinesis, DynamoDB, S3, ECS, etc.).
+- Wraps AWS SDK v2 clients with gosoline configuration, logging, retry, and naming helpers.
+- Provides credentials resolution for local dev, tests, and deployed runtimes.
+
+## Key areas
+- Client factories live beside each service (e.g., `sqs/`, `sns/`, `kinesis/`).
+- Shared helpers (middleware, retry, credentials) at package root: `awsv2*.go`, `credentials*.go`, `error.go`.
+- Naming relies on realm macros from `cfg.AppId`; service tests assert templates under each subpackage's `*_test.go`.
+
+## Common tasks
+- Adding a service: create `pkg/cloud/aws/<service>` with client settings struct, factory, naming helpers, and unit tests following SQS/SNS patterns.
+- Adjusting retries/backoff: edit `awsv2_retry.go` and keep unit tests in `awsv2_test.go` updated.
+- Credential flows: modify `credentials_default*.go` only after checking impacts on integration tests under `pkg/cloud/aws/*` and `examples/cloud`.
+
+## Testing
+- Service-specific: `go test ./pkg/cloud/aws/<service>`.
+- Shared helpers: `go test ./pkg/cloud/aws`.
+- For changes touching naming/macros, also run `go test ./pkg/ddb ./pkg/stream`.
+
+## Service subpackages
+| Package | Purpose | Config prefix |
+|---------|---------|---------------|
+| `athena/` | Athena query client | `cloud.aws.athena` |
+| `cloudwatch/` | Metrics/logs export | `cloud.aws.cloudwatch` |
+| `dynamodb/` | Low-level DDB client | `cloud.aws.dynamodb` |
+| `ec2/` | Instance metadata | `cloud.aws.ec2` |
+| `ecs/` | Container metadata | `cloud.aws.ecs` |
+| `kinesis/` | Stream client, naming | `cloud.aws.kinesis` |
+| `rds/` | RDS client | `cloud.aws.rds` |
+| `resourcegroupstaggingapi/` | Resource tagging API | `cloud.aws.resourcegroupstaggingapi` |
+| `s3/` | Object storage | `cloud.aws.s3` |
+| `secretsmanager/` | Secrets retrieval | `cloud.aws.secretsmanager` |
+| `servicediscovery/` | Cloud Map service discovery | `cloud.aws.servicediscovery` |
+| `ses/` | Email sending | `cloud.aws.ses` |
+| `sns/` | Topic client, naming | `cloud.aws.sns` |
+| `sqs/` | Queue client, naming | `cloud.aws.sqs` |
+| `ssm/` | Parameter store | `cloud.aws.ssm` |
+
+
+## Tips
+- Keep naming macros aligned with `cfg.AppId` and `mdl.ModelId`—never introduce new placeholder names without updating documentation.
+- Each service subpackage usually needs fixture-backed tests; mock AWS SDK clients with generated mocks from `.mockery.yml`.
+- Avoid hard-coding regions or account IDs; rely on config keys documented in root `AGENTS.md`.

--- a/pkg/db-repo/AGENTS.md
+++ b/pkg/db-repo/AGENTS.md
@@ -1,0 +1,26 @@
+# DB-Repo Package Agent Guide
+
+## Scope
+- Repository abstraction on top of `pkg/db` using gosoline models.
+- Handles CRUD, validation, change history, and notification hooks.
+- Powers many `examples/` and integration tests that rely on SQL persistence.
+
+## Key files
+- `model.go`, `metadata.go` - describe model shape and table metadata.
+- `repository.go`, `operation_repository_db.go` - core repository implementation.
+- `change_history_*` - audit log support and middleware wiring.
+- `notification_*` - publish DB changes to stream outputs.
+
+## Common tasks
+- Add repository features: extend `Repository` interface + implementation, then update mocks under `mocks/`.
+- Modify change history: adjust manager/middleware and ensure tests under `change_history*_test.go` cover regression.
+- Integrate new notification targets: modify `notification_publisher.go` and document required config keys (`db_repo.notification`).
+
+## Testing
+- `go test ./pkg/db-repo` is required; many tests rely on testify suites.
+- When touching notifications, also run `go test ./pkg/mdlsub` to ensure downstream compatibility.
+
+## Tips
+- Use `mdl.ModelId` for naming to stay aligned with DynamoDB counterparts.
+- Keep repository interfaces slim; cross-package consumers should rely on `pkg/db-repo/mocks` for isolation.
+- Whenever you change default indexes or metadata, update fixture writers and docs in `examples/`.

--- a/pkg/db/AGENTS.md
+++ b/pkg/db/AGENTS.md
@@ -1,0 +1,51 @@
+# DB Package Agent Guide
+
+## Scope
+- SQL connectivity layer: connection pooling, DSN generation, migrations, and fixtures.
+- Supports MySQL/MariaDB, Redshift, TiDB, CrateDB, and custom drivers via `driver_factory.go`.
+- Provides lifecycle management hooks for gosoline modules.
+
+## Key files
+- `connection.go`, `client.go` - central connection manager + lifecycle integration.
+- `driver_*.go` - dialect-specific configuration and registrations.
+- `migrations_*.go` - pluggable migration runners (goose, golang-migrate).
+- `fixture_*` + `data_*` - seeding/import/export helpers used by tests and CLI tools.
+
+## Common tasks
+- Add driver support: implement `Driver` in a new `driver_<name>.go`, register it in `driver_factory.go`, document config keys.
+- Extend migrations: update `migrations.go` and the helper specific to your engine.
+- Update metrics/logging: `metrics.go` wires health counters; keep names consistent with `metric` package.
+
+## Testing
+- `go test ./pkg/db` for unit coverage.
+- For driver additions, run targeted tests (e.g., `go test ./pkg/db -run TestMysql...`). Integration tests may need Docker DB instances.
+
+## Supported drivers
+| Driver | File | Notes |
+|--------|------|-------|
+| MySQL/MariaDB | `driver_mysql.go` | Default, most common |
+| Redshift | `driver_redshift.go` | AWS data warehouse |
+| CrateDB | `driver_cratedb.go` | Distributed SQL |
+| TiDB | `tidb/` | TiDB specific error checkers for retries |
+
+## Common config keys
+```yaml
+db.default.driver: mysql
+db.default.hostname: localhost
+db.default.port: 3306
+db.default.database: mydb
+db.default.username: root
+db.default.password: ""
+db.default.migrations.enabled: true
+db.default.migrations.path: migrations
+```
+
+## Related packages
+- `pkg/db-repo` - repository pattern built on this package
+- `pkg/fixtures` - fixture writers for test data seeding
+- `pkg/dbx` - sqlx-based query helpers
+
+## Tips
+- All config structs must use `cfg:"db.<client>.<key>"` naming to stay consistent with docs.
+- Always add fixture-writer support if the new driver will be used in integration tests.
+- When touching shared interfaces, regenerate mocks via `go generate -run='mockery' ./pkg/db`.

--- a/pkg/ddb/AGENTS.md
+++ b/pkg/ddb/AGENTS.md
@@ -1,0 +1,47 @@
+# DDB Package Agent Guide
+
+## Scope
+- DynamoDB integration layer: metadata modeling, repository abstraction, builders, and fixtures.
+- Aligns naming/macros with `cfg.AppId` and `mdl.ModelId` to ensure realm consistency.
+- Provides lifecycle helpers and purgers for test environments.
+
+## Key files
+- `metadata*.go` - model descriptors and attribute mapping.
+- `builder_*.go` - typed request builders for CRUD, query, scan, transact operations.
+- `repository*.go` - high-level repos built on builders/services.
+- `naming.go` - table naming rules (relies on `ModelId.ReplaceMacros`).
+
+## Common tasks
+- Extend model metadata: update `metadata_factory.go` and add tests covering new annotations.
+- Add new builder functionality: follow existing builder pattern and ensure API remains fluent.
+- Adjust throughput/capacity defaults: touch `settings.go` and document config keys.
+
+## Testing
+- Run `go test ./pkg/ddb` for all builders/repos.
+- For changes affecting naming/macros, also test `pkg/cloud/aws/kinesis` and `pkg/stream` to ensure shared expectations.
+
+## Naming with ModelId
+Table names are generated via `ModelId.ReplaceMacros(pattern)`. Default pattern:
+```yaml
+ddb.default.naming.pattern: "{project}-{env}-{family}-{group}-{modelId}"
+```
+
+Available macros:
+- `{project}`, `{env}`, `{family}`, `{group}`, `{app}` - from AppId
+- `{modelId}` - model's string representation
+
+## Common config keys
+```yaml
+cloud.aws.dynamodb.clients.default.endpoint: http://localhost:4566
+ddb.default.naming.pattern: "{project}-{env}-{family}-{group}-{modelId}"
+```
+
+## Related packages
+- `pkg/mdl` - ModelId definition and macro helpers
+- `pkg/cloud/aws/dynamodb` - low-level AWS client
+- `pkg/fixtures` - DDB fixture writers
+
+## Tips
+- Keep request builders composable—avoid hard-coding table names; always take `Metadata` or `ModelId` input.
+- Fixture writers (`fixture_writer_ddb*.go`) must stay in sync with metadata parsing.
+- Update `.mockery.yml` when adding new interfaces so DynamoDB service mocks stay current.

--- a/pkg/fixtures/AGENTS.md
+++ b/pkg/fixtures/AGENTS.md
@@ -1,0 +1,53 @@
+# Fixtures Package Agent Guide
+
+## Scope
+- Centralized fixture loading framework used by tests, integration suites, and examples.
+- Supports typed sequences, auto-numbering, UUIDs, and custom providers.
+- Coordinates with storage packages (`db`, `ddb`, `redis`, `blob`, etc.).
+
+## Key files
+- `loader.go`, `container.go` - orchestrate fixture set registration and execution.
+- `settings.go`, `fixture_set_options.go` - config surface for enabling/disabling fixtures per environment.
+- `provider/` - built-in providers for DB, DDB, Redis, etc.
+- Sequence helpers (`auto_numbered.go`, `uuid_sequence.go`, etc.) for deterministic IDs.
+
+## Common tasks
+- Add a provider: implement `Provider` interface in `provider/`, expose options, and document required config keys.
+- Customize fixture execution order: extend `FixtureSetOptions` and adjust `loader.go` accordingly.
+- Introduce new sequence strategy: add a helper type plus tests covering wrap-around/overflow.
+
+## Testing
+- `go test ./pkg/fixtures` after any change.
+- When adding a provider, also run the consuming package’s tests (e.g., `pkg/db`, `pkg/ddb`).
+
+## Build tag requirement
+All fixture code requires the `fixtures` build tag:
+```go
+//go:build fixtures
+
+package fixtures
+```
+
+Compile/test with: `go test -tags fixtures ./...`
+
+## Config keys
+```yaml
+fixtures.enabled: true
+fixtures.groups:
+  - default
+  - integration
+```
+
+## Built-in providers
+| Provider | Package | Purpose |
+|----------|---------|--------|
+| MySQL ORM | `pkg/db-repo` | GORM-based seeding |
+| MySQL SQLX | `pkg/db` | Raw SQL seeding |
+| DynamoDB | `pkg/ddb` | DDB item seeding |
+| Redis | `pkg/redis` | Key/value seeding |
+| Blob | `pkg/blob` | S3/file seeding |
+
+## Tips
+- Keep fixtures idempotent—providers should detect existing state when possible.
+- Respect `fixtures.disabled` config toggle so CI can skip expensive setup.
+- Document new fixture types/examples under `examples/fixtures` if they require external services.

--- a/pkg/httpserver/AGENTS.md
+++ b/pkg/httpserver/AGENTS.md
@@ -1,0 +1,53 @@
+# HTTP Server Package Agent Guide
+
+## Scope
+- Provides Gin-based HTTP server with gosoline middleware, auth, health, CRUD helpers, and profiling.
+- Supplies declarative handler definition + validation infrastructure used by examples and services.
+
+## Key files
+- `server.go`, `definition.go` - server lifecycle and handler registration structures.
+- `middleware_*.go` - logging, metrics, recovery, auth.
+- `handler.go`, `handler_static.go`, `response.go` - base handlers and response helpers.
+- `auth/`, `crud/`, `sql/` - optional submodules for auth flows and generic CRUD endpoints.
+
+## Common tasks
+- Add middleware: implement `Middleware` in `middleware_<name>.go` and register it via `ServerSettings`.
+- Introduce new handler helpers: extend `handler.go` and cover edge cases in `handler_test.go`.
+- Update health endpoints: modify `health_check.go` and ensure `examples/httpserver` still passes smoke tests.
+
+## Testing
+- `go test ./pkg/httpserver`.
+- Manual validation: `cd examples/httpserver/simple-handlers && go run .` then hit `/health`.
+
+## Handler patterns
+```go
+// Definer function for route registration
+type Definer func(ctx context.Context, config cfg.Config, logger log.Logger) (*Definitions, error)
+
+// Example handler registration
+func DefineRoutes(ctx context.Context, config cfg.Config, logger log.Logger) (*Definitions, error) {
+    d := &Definitions{}
+    d.GET("/health", HealthHandler())
+    d.POST("/api/v1/items", CreateItemHandler(logger))
+    return d, nil
+}
+```
+
+## Config keys
+```yaml
+httpserver.default.port: 8088
+httpserver.default.mode: release  # or debug
+httpserver.default.timeout.read: 60s
+httpserver.default.timeout.write: 60s
+httpserver.default.compress: true
+```
+
+## Related packages
+- `pkg/http` - HTTP client utilities
+- `pkg/validation` - request validation helpers
+- `pkg/tracing` - request tracing middleware
+
+## Tips
+- Keep handler signatures context-aware (always accept `context.Context`).
+- When adding protobuf/JSON helpers, ensure you regenerate `handler_test.proto` outputs.
+- Document new configuration knobs under `httpserver.server.*` in the global AGENT.

--- a/pkg/kernel/AGENTS.md
+++ b/pkg/kernel/AGENTS.md
@@ -1,0 +1,50 @@
+# Kernel Package Agent Guide
+
+## Scope
+- Core runtime orchestrator: stages, modules, middleware, and lifecycle hooks.
+- Used by `application` to start/stop modules in dependency order with health signaling.
+
+## Key files
+- `kernel.go`, `builder.go` - build and run the kernel with configured stages.
+- `module.go`, `module_options.go` - interfaces for modules and factories.
+- `stage.go`, `stages.go` - bootstraps ordered stage execution.
+- `middleware.go` - cross-cutting hooks invoked before/after modules run.
+
+## Common tasks
+- Add stage types: extend `StageConfig`, update builder logic, and document ordering guarantees.
+- Introduce middleware: implement the interface in `middleware.go`, wire into `kernel.go`.
+- Enhance health reporting: modify `health_check.go` to emit new statuses or metadata.
+
+## Testing
+- `go test ./pkg/kernel`—covers builder, middleware, and stage execution.
+- Run `go test ./pkg/application` when kernel APIs change to ensure compatibility.
+
+## Stage constants
+Modules run in ordered stages (lowest first):
+| Stage | Constant | Purpose |
+|-------|----------|--------|
+| Essential | `StageEssential` | Metrics, telemetry (starts first, stops last) |
+| ProducerDaemon | `StageProducerDaemon` | Background message producers |
+| Service | `StageService` | Shared services (GeoIP, currency, etc.) |
+| Application | `StageApplication` | Your modules (HTTP, consumers, subscribers) |
+
+## Module interface
+```go
+type Module interface {
+    Run(ctx context.Context) error
+}
+
+type ModuleFactory func(ctx context.Context, config cfg.Config, logger log.Logger) (Module, error)
+```
+
+Optional interfaces: `TypedModule` (essential/background), `StagedModule` (custom stage), `FullModule` (health checks).
+
+## Related packages
+- `pkg/application` - wires modules into the kernel
+- `pkg/stream` - provides consumer/producer module factories
+- `pkg/httpserver` - provides HTTP server module factory
+
+## Tips
+- Keep module interfaces backward compatible; changes ripple across most packages.
+- Prefer dependency injection via module factories rather than global registries.
+- Update docs/examples whenever you introduce new stage names or middleware hooks.

--- a/pkg/log/AGENTS.md
+++ b/pkg/log/AGENTS.md
@@ -1,0 +1,55 @@
+# Log Package Agent Guide
+
+## Scope
+- Structured logging facade with field enrichers, Sentry integration, sampling, and context propagation.
+- Consumed by almost every package via dependency injection.
+
+## Key files
+- `logger.go`, `options.go` - logger creation and configuration.
+- `handler_*.go`, `formatter.go` - sinks (stdout, file, Sentry) and formatting rules.
+- `context.go`, `stacktrace.go` - context helpers and panic capture.
+- `config_postprocessor_main_logger.go` - ties logger config into global app settings.
+
+## Common tasks
+- Add handler or formatter: create new handler file, register via `options.go`, add tests.
+- Extend sampling: adjust `logger_sampling.go` and ensure default config still keeps high-volume services safe.
+- Update ECS/Sentry metadata enrichment: edit `ecs_metadata.go` or `sentry.go` modules.
+
+## Testing
+- `go test ./pkg/log`.
+- For Sentry changes, run `go test ./pkg/log -run TestSentry` and, if possible, hit a dev DSN manually.
+
+## Log levels
+| Level | Priority | Use case |
+|-------|----------|----------|
+| `trace` | 0 | Verbose debugging |
+| `debug` | 1 | Development info |
+| `info` | 2 | Normal operations |
+| `warn` | 3 | Recoverable issues |
+| `error` | 4 | Failures requiring attention |
+| `none` | max | Disable logging |
+
+## Built-in handlers
+| Handler | File | Purpose |
+|---------|------|--------|
+| IOWriter | `handler_iowriter.go` | Stdout/file output |
+| Sentry | `handler_sentry.go` | Error reporting |
+
+## Config keys
+```yaml
+log.main.level: info
+log.main.handlers:
+  - type: iowriter
+    level: info
+    channels: ["*"]
+log.main.sentry.dsn: ""  # optional
+```
+
+## Related packages
+- `pkg/tracing` - distributed tracing integration
+- `pkg/metric` - metrics emission alongside logging
+
+## Tips
+- Avoid global loggers; expose factories via DI modules.
+- Document new config options under `log.main.*` and keep defaults safe for production.
+- When adding new handler dependencies, update root `go.mod` carefully to avoid bloat.

--- a/pkg/mdl/AGENTS.md
+++ b/pkg/mdl/AGENTS.md
@@ -1,0 +1,39 @@
+# Model Package Agent Guide
+
+## Scope
+- Shared model utilities: `ModelId`, factories, decorators used by DB, DDB, stream, and mdlsub packages.
+- Central place for macro interpolation logic tied to config AppId/Realm.
+
+## Key files
+- `model.go` - `ModelId`, macros, defaults, and helper methods.
+- `factory.go`, `named.go` - builder helpers for typed models.
+- `transform.go` - serializer/deserializer helpers for DTOs.
+
+## Common tasks
+- Adjust macro behavior or defaults: edit `model.go`, update tests, and check dependent packages (ddb, db-repo, stream).
+- Introduce helper factories: extend `factory.go` for new naming or metadata strategies.
+- Update transforms to support new encoding formats.
+
+## Testing
+- `go test ./pkg/mdl`.
+- When macros change, rerun `go test ./pkg/{cfg,ddb,cloud/aws}` to ensure naming remains consistent.
+
+## ReplaceMacros method
+Use `ModelId.ReplaceMacros(pattern)` to interpolate naming patterns:
+```go
+modelId := mdl.ModelId{Name: "users"}
+modelId.PadFromConfig(config)
+tableName := modelId.ReplaceMacros("{project}-{env}-{family}-{group}-{modelId}")
+// Result: "myproject-dev-myfamily-mygroup-myproject.myfamily.mygroup.users"
+```
+
+Built-in macros: `{project}`, `{env}`, `{family}`, `{group}`, `{app}`, `{modelId}`
+
+## Related packages
+- `pkg/cfg` - AppId with similar macro system
+- `pkg/ddb` - uses ModelId for table naming
+- `pkg/db-repo` - uses ModelId for SQL table metadata
+
+## Tips
+- Keep macro names aligned with `cfg.AppId` fields; avoid config-key style placeholders.
+- Document any new `ModelId` fields in root AGENT so downstream contributors know how to configure them.

--- a/pkg/mdlsub/AGENTS.md
+++ b/pkg/mdlsub/AGENTS.md
@@ -1,0 +1,46 @@
+# Model Subscription Package Agent Guide
+
+## Scope
+- Handles publishing/subscribing flows for data model changes across DB, DDB, KVStore, and stream outputs.
+- Provides config postprocessors, fixtures, and transformer helpers for mdl change pipelines.
+
+## Key files
+- `publisher*.go`, `output_*.go` - publish model changes to DB, DDB, KVStore, or stream layers.
+- `subscriber_*.go` - consumer side logic (callbacks, factories, settings).
+- `fixtures.go` - fixture wiring for integration suites.
+
+## Common tasks
+- Add a new output target: extend `output_<target>.go`, update settings, ensure tests cover retries/backoff.
+- Modify subscriber pipeline: update `subscriber_core.go` and keep `subscriber_factory.go` in sync.
+- Adjust config postprocessors so `application.yml` keys remain ergonomic.
+
+## Testing
+- `go test ./pkg/mdlsub`.
+- Integration coverage lives under `test/mdlsub`; run with `go test -tags integration,fixtures ./test/mdlsub/...` when touching IO-heavy code.
+
+## Publisher/subscriber flow
+```
+[DB/DDB change] → [Publisher] → [Stream output] → [Subscriber] → [Output target]
+```
+
+Output targets: `db`, `ddb`, `kvstore`
+
+## Config keys
+```yaml
+mdlsub.publishers.mymodel.output.type: sns
+mdlsub.publishers.mymodel.output.topic_id: model-changes
+
+mdlsub.subscribers.mymodel.input.type: sqs
+mdlsub.subscribers.mymodel.input.queue_id: model-changes
+mdlsub.subscribers.mymodel.output.type: ddb
+```
+
+## Related packages
+- `pkg/stream` - underlying transport layer
+- `pkg/ddb`, `pkg/db-repo`, `pkg/kvstore` - output targets
+- `pkg/mdl` - ModelId for naming
+
+## Tips
+- Rely on `mdl.ModelId` and `cfg.AppId` for naming; never duplicate logic locally.
+- Keep transformers stateless and idempotent to simplify retries.
+- Update fixture helpers when adding outputs so integration suites can preload state.

--- a/pkg/redis/AGENTS.md
+++ b/pkg/redis/AGENTS.md
@@ -1,0 +1,45 @@
+# Redis Package Agent Guide
+
+## Scope
+- Provides Redis client factory, lifecycle hooks, fixtures, and helper exec functions used by cache/stream modules.
+- Wraps go-redis with gosoline config, logging, and metrics.
+
+## Key files
+- `factory.go`, `client.go` - construct clients from config and expose helper interfaces.
+- `lifecycle.go`, `lifecycle_purger.go` - ensure clean startup/shutdown per module/test.
+- `fixture_writer_redis.go` - integrates fixtures package for deterministic test data.
+
+## Common tasks
+- Add client options: update `ClientSettings` in `factory.go`, propagate to `client.go`, and document config keys.
+- Modify lifecycle purging: adjust `lifecycle_purger.go` and ensure tests cover multi-db flushing.
+- Instrument metrics/logging: update `exec.go` wrappers so new commands emit telemetry.
+
+## Testing
+- `go test ./pkg/redis`.
+- For fixture or lifecycle changes, also run `go test ./pkg/stream ./pkg/fixtures` to catch regressions.
+
+## Config keys
+```yaml
+redis.default.address: localhost:6379
+redis.default.mode: standalone  # or cluster
+redis.default.database: 0
+redis.default.dialer.timeout: 5s
+redis.default.dialer.read_timeout: 3s
+redis.default.dialer.write_timeout: 3s
+```
+
+## Client modes
+| Mode | Use case |
+|------|----------|
+| `standalone` | Single Redis instance |
+| `cluster` | Redis Cluster |
+
+## Related packages
+- `pkg/kvstore` - key-value abstraction (can use Redis backend)
+- `pkg/stream` - Redis list input/output for messaging
+- `pkg/cache` - caching layer (can use Redis)
+
+## Tips
+- Keep default timeouts conservative; production workloads rely on these settings.
+- When adding new interfaces, update `.mockery.yml` and regenerate mocks before committing.
+- Document any assumptions about Redis version/features (cluster vs standalone) in this file.

--- a/pkg/stream/AGENTS.md
+++ b/pkg/stream/AGENTS.md
@@ -1,0 +1,50 @@
+# Stream Package Agent Guide
+
+## Scope
+- Unified streaming abstraction covering consumers, producers, encoders, retry handlers, and health reporting.
+- Supports multiple transports (SQS, SNS, Kinesis, Kafka, Redis, files, in-memory) via pluggable inputs/outputs.
+- Powers mdlsub, metrics exporters, and application stream modules.
+
+## Key files
+- `consumer*.go`, `producer*.go` - base logic and module factories for stream processing.
+- `input_*.go`, `output_*.go` - transport-specific adapters.
+- `encoding_*.go`, `message*.go` - serialization formats and message helpers.
+- `kinsumer_*` - autoscaling components for Kinesis-based consumers.
+
+## Common tasks
+- Add new transport: implement matching input/output files following existing patterns, expose settings structs, document config keys.
+- Extend encoding: add codec in `encoding_<format>.go`, wire into `EncodingConfig`.
+- Tune retry/backoff: update `retry_*.go` and ensure metrics + logging remain accurate.
+
+## Testing
+- `go test ./pkg/stream` (covers transports via mocks).
+- Transports with external deps may need integration tests under `test/stream` (run with `-tags integration,fixtures`).
+
+## Transport types
+| Input | Output | Config prefix |
+|-------|--------|---------------|
+| SQS | SQS | `stream.input/output.sqs` |
+| SNS | SNS | `stream.input/output.sns` |
+| Kinesis | Kinesis | `stream.input/output.kinesis` |
+| Kafka | Kafka | `stream.input/output.kafka` |
+| Redis | Redis | `stream.input/output.redis` |
+| File | File | `stream.input/output.file` |
+| InMemory | InMemory | (testing) |
+
+## Config keys
+```yaml
+stream.consumer.my-consumer.input: sqs
+stream.consumer.my-consumer.sqs.queue_id: my-queue
+stream.consumer.my-consumer.encoding: json
+stream.consumer.my-consumer.retry.enabled: true
+```
+
+## Related packages
+- `pkg/cloud/aws/sqs`, `sns`, `kinesis` - AWS transport clients
+- `pkg/kafka` - Kafka client integration
+- `pkg/mdlsub` - model subscription built on stream
+
+## Tips
+- Keep message attributes consistent; mdlsub and metric pipelines rely on canonical headers.
+- Use context cancellation carefully—consumers/producers run inside kernel modules.
+- Document new module factory names in `examples/stream` so users can discover them quickly.

--- a/pkg/test/AGENTS.md
+++ b/pkg/test/AGENTS.md
@@ -1,0 +1,63 @@
+# Test Utilities Package Agent Guide
+
+## Scope
+- Provides shared testing helpers: assertions, suites, env management, and matchers used across packages.
+- Abstracts Docker-based integration environments and context matchers.
+
+## Key directories
+- `assert/` - custom testify extensions and convenience helpers.
+- `env/` - spin up local stacks (e.g., Redis, DynamoDB, Localstack) for integration tests.
+- `matcher/` - gomock/testify matchers (context, time, slices).
+- `suite/` - base suites for integration/functional tests with setup/teardown hooks.
+
+## Common tasks
+- Add matcher: extend `matcher/` and update README/examples so developers know when to use it.
+- Enhance env providers: modify `env/` to support new services; document required Docker images.
+- Update base suites: extend `suite/` when tests need new lifecycle hooks (fixtures, tracing, etc.).
+
+## Testing
+- `go test ./pkg/test/...` must stay green; it is cheap to run and catches regressions fast.
+- When env changes require Docker, run targeted integration suites (e.g., `go test -tags integration,fixtures ./test/...`).
+
+## Common matchers
+```go
+import "github.com/justtrackio/gosoline/pkg/test/matcher"
+
+// Match any context
+mock.EXPECT().Method(matcher.Context).Return(nil)
+
+// Match specific time
+mock.EXPECT().Method(matcher.Time(expectedTime)).Return(nil)
+```
+
+## Suite pattern
+```go
+import "github.com/justtrackio/gosoline/pkg/test/suite"
+
+type MySuite struct {
+    suite.Suite
+}
+
+func (s *MySuite) SetupSuite() {
+    // Start containers, load fixtures
+}
+
+func (s *MySuite) TearDownSuite() {
+    // Stop containers
+}
+
+func TestMySuite(t *testing.T) {
+    suite.Run(t, new(MySuite))
+}
+```
+
+## Environment helpers
+| Helper | Package | Purpose |
+|--------|---------|--------|
+| `env/` | LocalStack, Redis, MySQL | Docker container management |
+| `assert/` | Custom assertions | Extended testify assertions |
+
+## Tips
+- Keep helper APIs backward compatible—every package imports `pkg/test`.
+- Avoid leaking goroutines from env helpers; always shut down containers in `TearDownSuite`.
+- Document new env variables or required binaries in this file so other agents can reproduce setups.


### PR DESCRIPTION
This pull request adds new agent guides (`AGENTS.md`) for the root directory and several key packages in the gosoline framework. These guides provide concise onboarding, workflows, conventions, and domain maps for maintainers and contributors, making it easier to understand package responsibilities, testing requirements, and configuration standards. The documentation is now more discoverable and actionable for day-to-day development and maintenance.