### PR TITLE
mdlsub: don't fail processing if you receive an invalid version;

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/elastic/go-elasticsearch/v7 v7.2.1-0.20190714143206-f1e755531ff4
 	github.com/elliotchance/redismock/v8 v8.11.0
 	github.com/emersion/go-smtp v0.21.3
+	github.com/ettle/strcase v0.2.0
 	github.com/fatih/color v1.13.0
 	github.com/getsentry/sentry-go v0.38.0
 	github.com/gin-contrib/cors v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -404,6 +404,8 @@ github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5 h1:Yzb9+7DPaBjB8zlTR87/ElzFsnQfuHnVUVqpZZIcV5Y=
 github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5/go.mod h1:a2zkGnVExMxdzMo3M0Hi/3sEU+cWnZpSni0O6/Yb/P0=
+github.com/ettle/strcase v0.2.0 h1:fGNiVF21fHXpX1niBgk0aROov1LagYsOwV/xqKDKR/Q=
+github.com/ettle/strcase v0.2.0/go.mod h1:DajmHElDSaX76ITe3/VHVyMin4LWSJN5Z909Wp+ED1A=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=

--- a/pkg/mdlsub/errors.go
+++ b/pkg/mdlsub/errors.go
@@ -1,0 +1,78 @@
+package mdlsub
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/justtrackio/gosoline/pkg/stream"
+)
+
+// UnknownModelError is returned when a model id is not found in the transformer list.
+type UnknownModelError struct {
+	ModelId string
+}
+
+func (e UnknownModelError) Error() string {
+	return fmt.Sprintf("unknown model: there is no transformer for modelId %s", e.ModelId)
+}
+
+func (e UnknownModelError) As(target any) bool {
+	if t, ok := target.(*UnknownModelError); ok {
+		*t = e
+
+		return true
+	}
+
+	return false
+}
+
+// IsIgnorableWithSettings implements stream.IgnorableGetModelError.
+func (e UnknownModelError) IsIgnorableWithSettings(settings stream.IgnoreOnGetModelErrorSettings) bool {
+	return settings.UnknownModel
+}
+
+func NewUnknownModelError(modelId string) UnknownModelError {
+	return UnknownModelError{
+		ModelId: modelId,
+	}
+}
+
+func IsUnknownModelError(err error) bool {
+	return errors.As(err, &UnknownModelError{})
+}
+
+// UnknownModelVersionError is returned when a version is not found for a model id in the transformer list.
+type UnknownModelVersionError struct {
+	ModelId string
+	Version int
+}
+
+func (e UnknownModelVersionError) Error() string {
+	return fmt.Sprintf("unknown model version: there is no transformer for modelId %s and version %d", e.ModelId, e.Version)
+}
+
+func (e UnknownModelVersionError) As(target any) bool {
+	if t, ok := target.(*UnknownModelVersionError); ok {
+		*t = e
+
+		return true
+	}
+
+	return false
+}
+
+// IsIgnorableWithSettings implements stream.IgnorableGetModelError.
+func (e UnknownModelVersionError) IsIgnorableWithSettings(settings stream.IgnoreOnGetModelErrorSettings) bool {
+	return settings.UnknownVersion
+}
+
+func NewUnknownModelVersionError(modelId string, version int) UnknownModelVersionError {
+	return UnknownModelVersionError{
+		ModelId: modelId,
+		Version: version,
+	}
+}
+
+func IsUnknownModelVersionError(err error) bool {
+	return errors.As(err, &UnknownModelVersionError{})
+}

--- a/pkg/mdlsub/output_ddb.go
+++ b/pkg/mdlsub/output_ddb.go
@@ -18,13 +18,20 @@ func init() {
 }
 
 func outputDdbFactory(ctx context.Context, config cfg.Config, logger log.Logger, settings *SubscriberSettings, transformers VersionedModelTransformers) (map[int]Output, error) {
-	var err error
 	outputs := make(map[int]Output)
 
 	for version, transformer := range transformers {
-		if outputs[version], err = NewOutputDdb(ctx, config, logger, transformer.GetModel(), settings); err != nil {
+		model, err := transformer.GetModel()
+		if err != nil {
+			return nil, fmt.Errorf("can not get model from transformer: %w", err)
+		}
+
+		var output Output
+		if output, err = NewOutputDdb(ctx, config, logger, model, settings); err != nil {
 			return nil, fmt.Errorf("can not create ddb output: %w", err)
 		}
+
+		outputs[version] = output
 	}
 
 	return outputs, nil

--- a/pkg/mdlsub/subscriber_callback_test.go
+++ b/pkg/mdlsub/subscriber_callback_test.go
@@ -1,0 +1,150 @@
+package mdlsub_test
+
+import (
+	"context"
+	"testing"
+
+	logMocks "github.com/justtrackio/gosoline/pkg/log/mocks"
+	"github.com/justtrackio/gosoline/pkg/mdl"
+	"github.com/justtrackio/gosoline/pkg/mdlsub"
+	"github.com/justtrackio/gosoline/pkg/mdlsub/mocks"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestSubscriberCallbackTestSuite(t *testing.T) {
+	suite.Run(t, new(SubscriberCallbackTestSuite))
+}
+
+type SubscriberCallbackTestSuite struct {
+	suite.Suite
+	core       *mocks.SubscriberCore
+	output     *mocks.Output
+	callback   *mdlsub.SubscriberCallback
+	modelId    mdl.ModelId
+	attributes map[string]string
+}
+
+func (s *SubscriberCallbackTestSuite) SetupTest() {
+	s.core = mocks.NewSubscriberCore(s.T())
+	s.output = mocks.NewOutput(s.T())
+
+	s.modelId = mdl.ModelId{
+		Project: "justtrack",
+		Family:  "gosoline",
+		Group:   "mdlsub",
+		Name:    "testModel",
+	}
+
+	sourceModel := mdlsub.SubscriberModel{
+		ModelId: s.modelId,
+	}
+
+	s.core.EXPECT().GetModelIds().Return([]string{"justtrack.gosoline.mdlsub.testModel"}).Once()
+
+	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(s.T()))
+	s.callback = mdlsub.NewSubscriberCallbackWithInterfaces(
+		logger,
+		s.core,
+		sourceModel,
+	)
+
+	// Default attributes for a valid message
+	s.attributes = map[string]string{
+		"modelId": "justtrack.gosoline.mdlsub.testModel",
+		"type":    "create",
+		"version": "1",
+	}
+}
+
+func (s *SubscriberCallbackTestSuite) TestConsume_Success() {
+	input := &TestInput{Id: 42}
+	expectedModel := TestModel{Id: 42}
+
+	transformer := mdlsub.EraseTransformerTypes[TestInput, TestModel](TestTransformer{})
+
+	spec := &mdlsub.ModelSpecification{
+		ModelId:  "justtrack.gosoline.mdlsub.testModel",
+		CrudType: "create",
+		Version:  1,
+	}
+
+	s.core.EXPECT().GetTransformer(spec).Return(transformer, nil).Once()
+	s.core.EXPECT().GetOutput(spec).Return(s.output, nil).Once()
+
+	s.output.EXPECT().Persist(mock.Anything, expectedModel, "create").Return(nil).Once()
+
+	ack, err := s.callback.Consume(s.T().Context(), input, s.attributes)
+
+	s.NoError(err)
+	s.True(ack)
+}
+
+func (s *SubscriberCallbackTestSuite) TestConsume_UnknownModelId() {
+	input := &TestInput{Id: 42}
+
+	s.attributes["modelId"] = "invalid.model.id"
+
+	spec := &mdlsub.ModelSpecification{
+		ModelId:  "invalid.model.id",
+		CrudType: "create",
+		Version:  1,
+	}
+
+	s.core.EXPECT().GetTransformer(spec).Return(nil, mdlsub.NewUnknownModelError("invalid.model.id")).Once()
+
+	ack, err := s.callback.Consume(s.T().Context(), input, s.attributes)
+
+	s.Error(err)
+	s.False(ack)
+	s.True(mdlsub.IsUnknownModelError(err))
+}
+
+func (s *SubscriberCallbackTestSuite) TestConsume_UnknownVersion() {
+	input := &TestInput{Id: 42}
+
+	s.attributes["version"] = "99"
+
+	spec := &mdlsub.ModelSpecification{
+		ModelId:  "justtrack.gosoline.mdlsub.testModel",
+		CrudType: "create",
+		Version:  99,
+	}
+
+	s.core.EXPECT().GetTransformer(spec).Return(nil, mdlsub.NewUnknownModelVersionError("justtrack.gosoline.mdlsub.testModel", 99)).Once()
+
+	ack, err := s.callback.Consume(s.T().Context(), input, s.attributes)
+
+	// Now returns an error for unknown version
+	s.Error(err)
+	s.False(ack)
+	s.True(mdlsub.IsUnknownModelVersionError(err))
+}
+
+func (s *SubscriberCallbackTestSuite) TestConsume_TransformReturnsNil() {
+	input := &TestInput{Id: 42}
+
+	// Create a transformer that returns nil
+	nilTransformer := mdlsub.EraseTransformerTypes[TestInput, TestModel](NilTestTransformer{})
+
+	spec := &mdlsub.ModelSpecification{
+		ModelId:  "justtrack.gosoline.mdlsub.testModel",
+		CrudType: "create",
+		Version:  1,
+	}
+
+	s.core.EXPECT().GetTransformer(spec).Return(nilTransformer, nil).Once()
+
+	ack, err := s.callback.Consume(s.T().Context(), input, s.attributes)
+
+	// Should acknowledge when transformer returns nil (skipping the item)
+	s.NoError(err)
+	s.True(ack)
+}
+
+// NilTestTransformer is a transformer that returns nil to test skipping behavior
+type NilTestTransformer struct{}
+
+func (t NilTestTransformer) Transform(ctx context.Context, inp TestInput) (out *TestModel, err error) {
+	return nil, nil
+}

--- a/pkg/mdlsub/subscriber_core.go
+++ b/pkg/mdlsub/subscriber_core.go
@@ -96,11 +96,11 @@ func (c *subscriberCore) GetTransformer(spec *ModelSpecification) (ModelTransfor
 	var ok bool
 
 	if _, ok = c.transformers[spec.ModelId]; !ok {
-		return nil, fmt.Errorf("there is no transformer for modelId %s", spec.ModelId)
+		return nil, NewUnknownModelError(spec.ModelId)
 	}
 
 	if _, ok = c.transformers[spec.ModelId][spec.Version]; !ok {
-		return nil, fmt.Errorf("there is no transformer for modelId %s and version %d", spec.ModelId, spec.Version)
+		return nil, NewUnknownModelVersionError(spec.ModelId, spec.Version)
 	}
 
 	return c.transformers[spec.ModelId][spec.Version], nil

--- a/pkg/mdlsub/transformer.go
+++ b/pkg/mdlsub/transformer.go
@@ -26,7 +26,7 @@ func (m ModelDb) GetId() any {
 // TypedTransformer and convert it to a ModelTransformer using NewGenericTransformer, EraseTransformerFactoryTypes, or EraseTransformerTypes.
 type ModelTransformer interface {
 	getInput() any
-	GetModel() any
+	GetModel() (any, error)
 	transform(ctx context.Context, inp any) (out Model, err error)
 	getSchemaSettings() (*stream.SchemaSettings, error)
 }
@@ -48,8 +48,8 @@ func (u untypedTransformer[I, M]) getInput() any {
 	return new(I)
 }
 
-func (u untypedTransformer[I, M]) GetModel() any {
-	return new(M)
+func (u untypedTransformer[I, M]) GetModel() (any, error) {
+	return new(M), nil
 }
 
 func (u untypedTransformer[I, M]) getSchemaSettings() (*stream.SchemaSettings, error) {

--- a/pkg/stream/consumer_batch_test.go
+++ b/pkg/stream/consumer_batch_test.go
@@ -124,9 +124,7 @@ func (s *BatchConsumerTestSuite) TestRun_ProcessOnStop() {
 		Once()
 
 	s.callback.EXPECT().GetModel(mock.AnythingOfType("map[string]string")).
-		Return(func(_ map[string]string) any {
-			return mdl.Box("")
-		}).
+		Return(mdl.Box(""), nil).
 		Times(3)
 
 	s.callback.EXPECT().Run(matcher.Context).
@@ -173,9 +171,7 @@ func (s *BatchConsumerTestSuite) TestRun_BatchSizeReached() {
 		Once()
 
 	s.callback.EXPECT().GetModel(mock.AnythingOfType("map[string]string")).
-		Return(func(_ map[string]string) any {
-			return mdl.Box("")
-		}).
+		Return(mdl.Box(""), nil).
 		Times(5)
 
 	s.callback.EXPECT().Run(matcher.Context).
@@ -284,7 +280,7 @@ func (s *BatchConsumerTestSuite) TestRun_AggregateMessage() {
 	s.callback.
 		EXPECT().
 		GetModel(mock.AnythingOfType("map[string]string")).
-		Return(mdl.Box("")).
+		Return(mdl.Box(""), nil).
 		Twice()
 
 	err = s.batchConsumer.Run(s.kernelCtx)

--- a/pkg/stream/consumer_settings.go
+++ b/pkg/stream/consumer_settings.go
@@ -15,15 +15,27 @@ const (
 )
 
 type ConsumerSettings struct {
-	Input                string                     `cfg:"input" default:"consumer" validate:"required"`
-	RunnerCount          int                        `cfg:"runner_count" default:"1" validate:"min=1"`
-	Encoding             EncodingType               `cfg:"encoding" default:"application/json"`
-	IdleTimeout          time.Duration              `cfg:"idle_timeout" default:"10s"`
-	AcknowledgeGraceTime time.Duration              `cfg:"acknowledge_grace_time" default:"10s"`
-	ConsumeGraceTime     time.Duration              `cfg:"consume_grace_time" default:"10s"`
-	Retry                ConsumerRetrySettings      `cfg:"retry"`
-	Healthcheck          health.HealthCheckSettings `cfg:"healthcheck"`
-	AggregateMessageMode string                     `cfg:"aggregate_message_mode" default:"atMostOnce" validate:"oneof=atLeastOnce atMostOnce"`
+	Input                 string                        `cfg:"input" default:"consumer" validate:"required"`
+	RunnerCount           int                           `cfg:"runner_count" default:"1" validate:"min=1"`
+	Encoding              EncodingType                  `cfg:"encoding" default:"application/json"`
+	IdleTimeout           time.Duration                 `cfg:"idle_timeout" default:"10s"`
+	AcknowledgeGraceTime  time.Duration                 `cfg:"acknowledge_grace_time" default:"10s"`
+	ConsumeGraceTime      time.Duration                 `cfg:"consume_grace_time" default:"10s"`
+	Retry                 ConsumerRetrySettings         `cfg:"retry"`
+	Healthcheck           health.HealthCheckSettings    `cfg:"healthcheck"`
+	AggregateMessageMode  string                        `cfg:"aggregate_message_mode" default:"atMostOnce" validate:"oneof=atLeastOnce atMostOnce"`
+	IgnoreOnGetModelError IgnoreOnGetModelErrorSettings `cfg:"ignore_on_get_model_error"`
+}
+
+// IgnoreOnGetModelErrorSettings configures which GetModel errors should result in the message being ignored
+// (acknowledged without processing) rather than being treated as an error.
+type IgnoreOnGetModelErrorSettings struct {
+	// UnknownModel indicates whether to ignore messages when the model is unknown.
+	// When true, messages with unknown model IDs will be acknowledged and skipped.
+	UnknownModel bool `cfg:"unknown_model" default:"false"`
+	// UnknownVersion indicates whether to ignore messages when the version is unknown.
+	// When true, messages with unknown versions for known models will be acknowledged and skipped.
+	UnknownVersion bool `cfg:"unknown_version" default:"false"`
 }
 
 type ConsumerRetrySettings struct {

--- a/pkg/stream/consumer_test.go
+++ b/pkg/stream/consumer_test.go
@@ -150,9 +150,7 @@ func (s *ConsumerTestSuite) TestGetModelNil() {
 		}).
 		Return(nil).
 		Once()
-	s.callback.EXPECT().GetModel(mock.AnythingOfType("map[string]string")).Return(func(_ map[string]string) any {
-		return nil
-	}).Once()
+	s.callback.EXPECT().GetModel(mock.AnythingOfType("map[string]string")).Return(nil, nil).Once()
 	s.callback.EXPECT().Run(matcher.Context).Return(nil).Once()
 
 	err := s.consumer.Run(s.kernelCtx)
@@ -194,9 +192,7 @@ func (s *ConsumerTestSuite) TestRun() {
 
 	s.callback.EXPECT().
 		GetModel(mock.AnythingOfType("map[string]string")).
-		Return(func(_ map[string]string) any {
-			return mdl.Box("")
-		}).
+		Return(mdl.Box(""), nil).
 		Times(3)
 
 	s.callback.EXPECT().Run(matcher.Context).Return(nil).Once()
@@ -278,9 +274,7 @@ func (s *ConsumerTestSuite) TestRun_CallbackRunPanic() {
 		Twice()
 	s.callback.EXPECT().
 		GetModel(mock.AnythingOfType("map[string]string")).
-		Return(func(_ map[string]string) any {
-			return mdl.Box("")
-		}).
+		Return(mdl.Box(""), nil).
 		Twice()
 
 	retryMsg := &stream.Message{
@@ -361,7 +355,7 @@ func (s *ConsumerTestSuite) TestRun_AggregateMessage() {
 	expectedModelAttributes1 := map[string]string{"attr1": "a", "encoding": "application/json"}
 	s.callback.EXPECT().
 		GetModel(expectedModelAttributes1).
-		Return(mdl.Box("")).
+		Return(mdl.Box(""), nil).
 		Once()
 
 	expectedAttributes2 := map[string]string{
@@ -384,7 +378,7 @@ func (s *ConsumerTestSuite) TestRun_AggregateMessage() {
 	expectedModelAttributes2 := map[string]string{"attr1": "b", "encoding": "application/json"}
 	s.callback.EXPECT().
 		GetModel(expectedModelAttributes2).
-		Return(mdl.Box("")).
+		Return(mdl.Box(""), nil).
 		Once()
 
 	err = s.consumer.Run(s.kernelCtx)
@@ -452,9 +446,7 @@ func (s *ConsumerTestSuite) TestRunWithRetry() {
 
 	s.callback.EXPECT().
 		GetModel(mock.AnythingOfType("map[string]string")).
-		Return(func(_ map[string]string) any {
-			return mdl.Box("")
-		}).
+		Return(mdl.Box(""), nil).
 		Twice()
 
 	s.callback.EXPECT().Run(matcher.Context).Return(nil)

--- a/pkg/stream/mocks/RunnableUntypedBatchConsumerCallback.go
+++ b/pkg/stream/mocks/RunnableUntypedBatchConsumerCallback.go
@@ -82,7 +82,7 @@ func (_c *RunnableUntypedBatchConsumerCallback_Consume_Call) RunAndReturn(run fu
 }
 
 // GetModel provides a mock function with given fields: attributes
-func (_m *RunnableUntypedBatchConsumerCallback) GetModel(attributes map[string]string) interface{} {
+func (_m *RunnableUntypedBatchConsumerCallback) GetModel(attributes map[string]string) (interface{}, error) {
 	ret := _m.Called(attributes)
 
 	if len(ret) == 0 {
@@ -90,6 +90,10 @@ func (_m *RunnableUntypedBatchConsumerCallback) GetModel(attributes map[string]s
 	}
 
 	var r0 interface{}
+	var r1 error
+	if rf, ok := ret.Get(0).(func(map[string]string) (interface{}, error)); ok {
+		return rf(attributes)
+	}
 	if rf, ok := ret.Get(0).(func(map[string]string) interface{}); ok {
 		r0 = rf(attributes)
 	} else {
@@ -98,7 +102,13 @@ func (_m *RunnableUntypedBatchConsumerCallback) GetModel(attributes map[string]s
 		}
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(map[string]string) error); ok {
+		r1 = rf(attributes)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // RunnableUntypedBatchConsumerCallback_GetModel_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetModel'
@@ -119,12 +129,12 @@ func (_c *RunnableUntypedBatchConsumerCallback_GetModel_Call) Run(run func(attri
 	return _c
 }
 
-func (_c *RunnableUntypedBatchConsumerCallback_GetModel_Call) Return(_a0 interface{}) *RunnableUntypedBatchConsumerCallback_GetModel_Call {
-	_c.Call.Return(_a0)
+func (_c *RunnableUntypedBatchConsumerCallback_GetModel_Call) Return(_a0 interface{}, _a1 error) *RunnableUntypedBatchConsumerCallback_GetModel_Call {
+	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *RunnableUntypedBatchConsumerCallback_GetModel_Call) RunAndReturn(run func(map[string]string) interface{}) *RunnableUntypedBatchConsumerCallback_GetModel_Call {
+func (_c *RunnableUntypedBatchConsumerCallback_GetModel_Call) RunAndReturn(run func(map[string]string) (interface{}, error)) *RunnableUntypedBatchConsumerCallback_GetModel_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/stream/mocks/RunnableUntypedConsumerCallback.go
+++ b/pkg/stream/mocks/RunnableUntypedConsumerCallback.go
@@ -80,7 +80,7 @@ func (_c *RunnableUntypedConsumerCallback_Consume_Call) RunAndReturn(run func(co
 }
 
 // GetModel provides a mock function with given fields: attributes
-func (_m *RunnableUntypedConsumerCallback) GetModel(attributes map[string]string) interface{} {
+func (_m *RunnableUntypedConsumerCallback) GetModel(attributes map[string]string) (interface{}, error) {
 	ret := _m.Called(attributes)
 
 	if len(ret) == 0 {
@@ -88,6 +88,10 @@ func (_m *RunnableUntypedConsumerCallback) GetModel(attributes map[string]string
 	}
 
 	var r0 interface{}
+	var r1 error
+	if rf, ok := ret.Get(0).(func(map[string]string) (interface{}, error)); ok {
+		return rf(attributes)
+	}
 	if rf, ok := ret.Get(0).(func(map[string]string) interface{}); ok {
 		r0 = rf(attributes)
 	} else {
@@ -96,7 +100,13 @@ func (_m *RunnableUntypedConsumerCallback) GetModel(attributes map[string]string
 		}
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(map[string]string) error); ok {
+		r1 = rf(attributes)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // RunnableUntypedConsumerCallback_GetModel_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetModel'
@@ -117,12 +127,12 @@ func (_c *RunnableUntypedConsumerCallback_GetModel_Call) Run(run func(attributes
 	return _c
 }
 
-func (_c *RunnableUntypedConsumerCallback_GetModel_Call) Return(_a0 interface{}) *RunnableUntypedConsumerCallback_GetModel_Call {
-	_c.Call.Return(_a0)
+func (_c *RunnableUntypedConsumerCallback_GetModel_Call) Return(_a0 interface{}, _a1 error) *RunnableUntypedConsumerCallback_GetModel_Call {
+	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *RunnableUntypedConsumerCallback_GetModel_Call) RunAndReturn(run func(map[string]string) interface{}) *RunnableUntypedConsumerCallback_GetModel_Call {
+func (_c *RunnableUntypedConsumerCallback_GetModel_Call) RunAndReturn(run func(map[string]string) (interface{}, error)) *RunnableUntypedConsumerCallback_GetModel_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/stream/mocks/UntypedBatchConsumerCallback.go
+++ b/pkg/stream/mocks/UntypedBatchConsumerCallback.go
@@ -82,7 +82,7 @@ func (_c *UntypedBatchConsumerCallback_Consume_Call) RunAndReturn(run func(conte
 }
 
 // GetModel provides a mock function with given fields: attributes
-func (_m *UntypedBatchConsumerCallback) GetModel(attributes map[string]string) interface{} {
+func (_m *UntypedBatchConsumerCallback) GetModel(attributes map[string]string) (interface{}, error) {
 	ret := _m.Called(attributes)
 
 	if len(ret) == 0 {
@@ -90,6 +90,10 @@ func (_m *UntypedBatchConsumerCallback) GetModel(attributes map[string]string) i
 	}
 
 	var r0 interface{}
+	var r1 error
+	if rf, ok := ret.Get(0).(func(map[string]string) (interface{}, error)); ok {
+		return rf(attributes)
+	}
 	if rf, ok := ret.Get(0).(func(map[string]string) interface{}); ok {
 		r0 = rf(attributes)
 	} else {
@@ -98,7 +102,13 @@ func (_m *UntypedBatchConsumerCallback) GetModel(attributes map[string]string) i
 		}
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(map[string]string) error); ok {
+		r1 = rf(attributes)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // UntypedBatchConsumerCallback_GetModel_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetModel'
@@ -119,12 +129,12 @@ func (_c *UntypedBatchConsumerCallback_GetModel_Call) Run(run func(attributes ma
 	return _c
 }
 
-func (_c *UntypedBatchConsumerCallback_GetModel_Call) Return(_a0 interface{}) *UntypedBatchConsumerCallback_GetModel_Call {
-	_c.Call.Return(_a0)
+func (_c *UntypedBatchConsumerCallback_GetModel_Call) Return(_a0 interface{}, _a1 error) *UntypedBatchConsumerCallback_GetModel_Call {
+	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *UntypedBatchConsumerCallback_GetModel_Call) RunAndReturn(run func(map[string]string) interface{}) *UntypedBatchConsumerCallback_GetModel_Call {
+func (_c *UntypedBatchConsumerCallback_GetModel_Call) RunAndReturn(run func(map[string]string) (interface{}, error)) *UntypedBatchConsumerCallback_GetModel_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/stream/mocks/UntypedConsumerCallback.go
+++ b/pkg/stream/mocks/UntypedConsumerCallback.go
@@ -80,7 +80,7 @@ func (_c *UntypedConsumerCallback_Consume_Call) RunAndReturn(run func(context.Co
 }
 
 // GetModel provides a mock function with given fields: attributes
-func (_m *UntypedConsumerCallback) GetModel(attributes map[string]string) interface{} {
+func (_m *UntypedConsumerCallback) GetModel(attributes map[string]string) (interface{}, error) {
 	ret := _m.Called(attributes)
 
 	if len(ret) == 0 {
@@ -88,6 +88,10 @@ func (_m *UntypedConsumerCallback) GetModel(attributes map[string]string) interf
 	}
 
 	var r0 interface{}
+	var r1 error
+	if rf, ok := ret.Get(0).(func(map[string]string) (interface{}, error)); ok {
+		return rf(attributes)
+	}
 	if rf, ok := ret.Get(0).(func(map[string]string) interface{}); ok {
 		r0 = rf(attributes)
 	} else {
@@ -96,7 +100,13 @@ func (_m *UntypedConsumerCallback) GetModel(attributes map[string]string) interf
 		}
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(map[string]string) error); ok {
+		r1 = rf(attributes)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // UntypedConsumerCallback_GetModel_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetModel'
@@ -117,12 +127,12 @@ func (_c *UntypedConsumerCallback_GetModel_Call) Run(run func(attributes map[str
 	return _c
 }
 
-func (_c *UntypedConsumerCallback_GetModel_Call) Return(_a0 interface{}) *UntypedConsumerCallback_GetModel_Call {
-	_c.Call.Return(_a0)
+func (_c *UntypedConsumerCallback_GetModel_Call) Return(_a0 interface{}, _a1 error) *UntypedConsumerCallback_GetModel_Call {
+	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *UntypedConsumerCallback_GetModel_Call) RunAndReturn(run func(map[string]string) interface{}) *UntypedConsumerCallback_GetModel_Call {
+func (_c *UntypedConsumerCallback_GetModel_Call) RunAndReturn(run func(map[string]string) (interface{}, error)) *UntypedConsumerCallback_GetModel_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/stream/typed_batch_consumer.go
+++ b/pkg/stream/typed_batch_consumer.go
@@ -55,8 +55,8 @@ func EraseBatchConsumerCallbackTypes[M any](consumerCallback BatchConsumerCallba
 	}
 }
 
-func (u untypedBatchConsumerCallback[M]) GetModel(_ map[string]string) any {
-	return new(M)
+func (u untypedBatchConsumerCallback[M]) GetModel(_ map[string]string) (any, error) {
+	return new(M), nil
 }
 
 func (u untypedBatchConsumerCallback[M]) Consume(ctx context.Context, models []any, attributes []map[string]string) ([]bool, error) {

--- a/pkg/stream/typed_consumer.go
+++ b/pkg/stream/typed_consumer.go
@@ -54,8 +54,8 @@ func EraseConsumerCallbackTypes[M any](consumerCallback ConsumerCallback[M]) Unt
 	}
 }
 
-func (u untypedConsumerCallback[M]) GetModel(_ map[string]string) any {
-	return new(M)
+func (u untypedConsumerCallback[M]) GetModel(_ map[string]string) (any, error) {
+	return new(M), nil
 }
 
 func (u untypedConsumerCallback[M]) Consume(ctx context.Context, model any, attributes map[string]string) (bool, error) {


### PR DESCRIPTION
At the moment, when adding a new version to one of the events going through mdlsub, the application will error and reject that message.
This provides a poor upgrade path. Ideally, you can add a new version in the source, start consuming it on the sink - and then remove the old one. This allows you to do the upgrade gracefully and non-breaking.

This PR adjusts the subscriber callback to warn and write a metric whenever there is an unknown version.