### PR TITLE
kafka: add EHOSTUNREACH (no route to host) and ENETUNREACH (network u…

### DIFF
--- a/pkg/kafka/errors/errors.go
+++ b/pkg/kafka/errors/errors.go
@@ -1,9 +1,12 @@
 package errors
 
 import (
+	"errors"
+
 	"github.com/justtrackio/gosoline/pkg/exec"
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo"
+	"golang.org/x/sys/unix"
 )
 
 func IsRetryableKafkaError(err error) bool {
@@ -15,6 +18,8 @@ func IsRetryableKafkaError(err error) bool {
 	case kerr.IsRetriable(err): // Check if this is a retryable Kafka protocol error
 		return true
 	case exec.IsDNSNotFoundError(err): // Check for "no such host" errors. This might be temporary in some environments if a broker restarts.
+		return true
+	case errors.Is(err, unix.EHOSTUNREACH) || errors.Is(err, unix.ENETUNREACH): // Check for "no route to host" and "network unreachable" errors.
 		return true
 	default:
 		return false

--- a/pkg/stream/input_kafka_test.go
+++ b/pkg/stream/input_kafka_test.go
@@ -94,6 +94,16 @@ func TestCheckKafkaRetryableError(t *testing.T) {
 			err:      &net.DNSError{Err: "no such host", IsNotFound: true},
 			expected: exec.ErrorTypeRetryable,
 		},
+		{
+			name:     "no route to host",
+			err:      unix.EHOSTUNREACH,
+			expected: exec.ErrorTypeRetryable,
+		},
+		{
+			name:     "network unreachable",
+			err:      unix.ENETUNREACH,
+			expected: exec.ErrorTypeRetryable,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
…nreachable) as retryable errors;