### PR TITLE
fix: guard containerManager.runners map with mutex to eliminate race condition

### DIFF
--- a/pkg/test/env/container_manager.go
+++ b/pkg/test/env/container_manager.go
@@ -35,6 +35,7 @@ type HealthCheckSettings struct {
 type containerManager struct {
 	logger            log.Logger
 	runnerFactory     func(typ string) (ContainerRunner, error)
+	runnersMu         sync.Mutex
 	runners           map[string]ContainerRunner
 	settings          *ContainerManagerSettings
 	shutdownCallbacks map[string]func() error
@@ -140,13 +141,17 @@ func (m *containerManager) runContainer(ctx context.Context, request ContainerRe
 		runnerType = m.settings.RunnerType
 	}
 
+	m.runnersMu.Lock()
 	if _, ok := m.runners[runnerType]; !ok {
 		if m.runners[runnerType], err = m.runnerFactory(runnerType); err != nil {
+			m.runnersMu.Unlock()
 			return nil, fmt.Errorf("can not create container runner for type %s: %w", runnerType, err)
 		}
 	}
+	runner := m.runners[runnerType]
+	m.runnersMu.Unlock()
 
-	if container, err = m.runners[runnerType].RunContainer(ctx, request); err != nil {
+	if container, err = runner.RunContainer(ctx, request); err != nil {
 		return nil, fmt.Errorf(
 			"can not run container %s (%s:%s): %w",
 			request.id(),
@@ -170,6 +175,9 @@ func (m *containerManager) Stop(ctx context.Context) error {
 			m.logger.Error(ctx, "shutdown callback failed for container %s: %w", name, err)
 		}
 	}
+
+	m.runnersMu.Lock()
+	defer m.runnersMu.Unlock()
 
 	for name, runner := range m.runners {
 		if err := runner.Stop(ctx); err != nil {


### PR DESCRIPTION
## Problem

`containerManager.runContainer` is called concurrently by multiple goroutines (spawned in `RunContainers` via `coffin.Gof`). It lazily initialises `m.runners` without any synchronisation:

```go
// container_manager.go — called from multiple goroutines simultaneously
if _, ok := m.runners[runnerType]; !ok {
    if m.runners[runnerType], err = m.runnerFactory(runnerType); err != nil {
        return nil, fmt.Errorf("can not create container runner for type %s: %w", runnerType, err)
    }
}
```

`m.runners` is a plain `map[string]ContainerRunner` with no mutex. In CI, when MySQL uses runner type `"external"` (via `UseExternalContainer: true`), goroutines for localstack/redis/mailpit all read `m.runners["local"]` while the MySQL goroutine simultaneously writes `m.runners["external"]` → `fatal error: concurrent map read and map write`.

The existing `lck` mutex in `RunContainers` only protects `skeleton.containers` and `shutdownCallbacks` — it does not protect `m.runners`.

## Fix

Add a dedicated `runnersMu sync.Mutex` to `containerManager`:

- In `runContainer`: acquire the lock for the check-and-set block, capture the runner in a local variable, release before calling `runner.RunContainer` (which is slow — starts containers).
- In `Stop`: acquire the lock with `defer` around the runners iteration.

The change is minimal — no restructuring, no new abstractions.

## Testing

```
go test -race ./pkg/test/env/...   # passes, no data races
go build -race -tags fixtures,integration ./pkg/test/env/...  # clean build
```