### PR TITLE
conc/ddb: handle cancel errors when releasing a lock

### DIFF
--- a/pkg/conc/ddb/ddb_lock.go
+++ b/pkg/conc/ddb/ddb_lock.go
@@ -78,25 +78,25 @@ func (l *ddbLock) Release() error {
 		return conc.ErrLockNotOwned
 	}
 
-	done := make(chan struct{})
-	defer close(done)
-
 	// we should always release the lock, even when our parent gets canceled.
 	// if we don't manage to do this until it expires anyway, there is no further point in trying.
-	ctx, cancel := exec.WithManualCancelContext(l.ctx)
-	go func() {
-		timer := l.clock.NewTimer(remainingLockTime)
-		defer timer.Stop()
+	// make sure we have enough time to release the lock:
+	delayedCtx, stop := exec.WithDelayedCancelContext(l.ctx, remainingLockTime)
+	defer stop()
 
-		select {
-		case <-done:
-			return
-		case <-timer.Chan():
-			cancel()
-		}
-	}()
+	// and that we don't spend more time than needed on it:
+	ctx, cancel := context.WithDeadline(delayedCtx, deadline)
+	defer cancel()
 
-	return l.manager.ReleaseLock(ctx, l.resource, l.token)
+	err := l.manager.ReleaseLock(ctx, l.resource, l.token)
+	if exec.IsRequestCanceled(err) {
+		// map the cancel to no error at all: we should only get this error if the lock expired,
+		// so we have "released" the lock in some other way as well, and we don't need to bother
+		// our caller with this.
+		return nil
+	}
+
+	return err
 }
 
 func (l *ddbLock) runWatcher() {

--- a/pkg/conc/ddb/ddb_lock_test.go
+++ b/pkg/conc/ddb/ddb_lock_test.go
@@ -30,7 +30,7 @@ func TestDdbLock(t *testing.T) {
 
 func (s *ddbLockTestSuite) SetupTest() {
 	s.lockManager = mocks.NewLockManager(s.T())
-	s.clock = clockPkg.NewFakeClock()
+	s.clock = clockPkg.NewFakeClockAt(time.Now())
 	s.logger = logMocks.NewLoggerMock(logMocks.WithTestingT(s.T()))
 	s.ctx = s.T().Context()
 	s.lock = ddb.NewDdbLockFromInterfaces(s.lockManager, s.clock, s.logger, s.ctx, "resource", "token", s.clock.Now().Add(time.Minute))
@@ -64,17 +64,43 @@ func (s *ddbLockTestSuite) TestReleaseLockFail() {
 	s.EqualError(err, "fail")
 }
 
-func (s *ddbLockTestSuite) TestReleaseLockTimeout() {
+func (s *ddbLockTestSuite) TestReleaseLockDelayedParentCancel() {
+	ctx, cancel := context.WithCancel(s.ctx)
+
+	s.lock = ddb.NewDdbLockFromInterfaces(s.lockManager, s.clock, s.logger, ctx, "resource", "token", s.clock.Now().Add(time.Minute))
+	cancel()
+
+	s.lockManager.EXPECT().ReleaseLock(matcher.Context, "resource", "token").
+		Run(func(ctx context.Context, resource string, token string) {
+			s.NoError(ctx.Err())
+		}).
+		Return(nil).
+		Once()
+
+	err := s.lock.Release()
+	s.NoError(err)
+}
+
+func (s *ddbLockTestSuite) TestReleaseLockCancellationIsIgnored() {
+	s.lock = ddb.NewDdbLockFromInterfaces(s.lockManager, s.clock, s.logger, s.ctx, "resource", "token", s.clock.Now().Add(time.Minute))
+
 	s.lockManager.EXPECT().
 		ReleaseLock(matcher.Context, "resource", "token").
-		Run(func(ctx context.Context, resource string, token string) {
-			s.clock.BlockUntilTimers(1)
-			s.clock.Advance(time.Minute)
-			<-ctx.Done()
-		}).
+		Return(context.Canceled).
+		Once()
+
+	err := s.lock.Release()
+	s.NoError(err)
+}
+
+func (s *ddbLockTestSuite) TestReleaseLockDeadlineExceededIsIgnored() {
+	s.lock = ddb.NewDdbLockFromInterfaces(s.lockManager, s.clock, s.logger, s.ctx, "resource", "token", s.clock.Now().Add(time.Minute))
+
+	s.lockManager.EXPECT().
+		ReleaseLock(matcher.Context, "resource", "token").
 		Return(context.DeadlineExceeded).
 		Once()
 
 	err := s.lock.Release()
-	s.EqualError(err, context.DeadlineExceeded.Error())
+	s.NoError(err)
 }

--- a/test/conc/ddb_lock_test.go
+++ b/test/conc/ddb_lock_test.go
@@ -152,8 +152,23 @@ func (s *DdbLockTestSuite) TestRenewAfterReleaseFails() {
 	s.Equal(conc.ErrLockNotOwned, err)
 }
 
+func (s *DdbLockTestSuite) TestReleaseAfterAcquireContextCanceled() {
+	// Case 6: releasing still works after the acquire context was canceled.
+	ctx, cancel := context.WithCancel(s.T().Context())
+	l, err := s.provider.Acquire(ctx, s.T().Name())
+	s.NoError(err)
+
+	cancel()
+	err = l.Release()
+	s.NoError(err)
+
+	l, err = s.provider.Acquire(s.T().Context(), s.T().Name())
+	s.NoError(err)
+	s.NoError(l.Release())
+}
+
 func (s *DdbLockTestSuite) TestAcquireDifferentResources() {
-	// Case 6: try to acquire two different resources
+	// Case 7: try to acquire two different resources
 	l1, err := s.provider.Acquire(s.T().Context(), s.T().Name())
 	s.NoError(err)
 	l2, err := s.provider.Acquire(s.T().Context(), s.T().Name()+"-other")


### PR DESCRIPTION
We extend a context until a lock expires, so if we for some reason (ddb slow) fail to release the lock in time, there is no point in propagating the cancel error as the lock has been released at that point anyway.