### PR TITLE
Fix delayed cancel context

### DIFF
--- a/pkg/conc/ddb/ddb_lock.go
+++ b/pkg/conc/ddb/ddb_lock.go
@@ -85,14 +85,13 @@ func (l *ddbLock) Release() error {
 	defer stop()
 
 	// and that we don't spend more time than needed on it:
-	ctx, cancel := context.WithDeadline(delayedCtx, deadline)
+	ctx, cancel := context.WithTimeout(delayedCtx, remainingLockTime)
 	defer cancel()
 
 	err := l.manager.ReleaseLock(ctx, l.resource, l.token)
-	if exec.IsRequestCanceled(err) {
-		// map the cancel to no error at all: we should only get this error if the lock expired,
-		// so we have "released" the lock in some other way as well, and we don't need to bother
-		// our caller with this.
+	if exec.IsRequestCanceled(err) && l.expiresIn() <= 0 {
+		// if the lock expired while the release request was in flight, treat the canceled
+		// release like a late release and keep callers from handling an already lost lock.
 		return nil
 	}
 

--- a/pkg/conc/ddb/ddb_lock_provider.go
+++ b/pkg/conc/ddb/ddb_lock_provider.go
@@ -96,11 +96,15 @@ func NewDdbLockProviderWithInterfaces(
 }
 
 func (m *ddbLockProvider) Acquire(ctx context.Context, resource string) (conc.DistributedLock, error) {
+	return m.acquire(ctx, ctx, resource)
+}
+
+func (m *ddbLockProvider) acquire(acquireCtx context.Context, lockCtx context.Context, resource string) (conc.DistributedLock, error) {
 	resource = fmt.Sprintf("%s-%s", m.domain, resource)
 	token := m.uuidSource.NewV4()
 
 	var lock *ddbLock
-	_, err := m.executor.Execute(ctx, func(ctx context.Context) (any, error) {
+	_, err := m.executor.Execute(acquireCtx, func(ctx context.Context) (any, error) {
 		now := m.clock.Now()
 		// ddb does return expired items if they have not yet been deleted
 		// to account for potential clock skew, we treat items that have been expired by at least five seconds as deleted
@@ -114,7 +118,6 @@ func (m *ddbLockProvider) Acquire(ctx context.Context, resource string) (conc.Di
 			Token:    token,
 			Ttl:      expires.Unix(),
 		})
-
 		if err != nil {
 			return nil, err
 		}
@@ -128,7 +131,9 @@ func (m *ddbLockProvider) Acquire(ctx context.Context, resource string) (conc.Di
 			"ddb_lock_resource": resource,
 		}).Debug(ctx, "acquired lock")
 
-		lock = NewDdbLockFromInterfaces(m, m.clock, m.logger, ctx, resource, token, expires)
+		// make sure we do not use the same context on the lock as when we acquire it - TryAcquireIn passes a context which gets canceled once we
+		// return, and we don't want to store that on our lock.
+		lock = NewDdbLockFromInterfaces(m, m.clock, m.logger, lockCtx, resource, token, expires)
 		go lock.runWatcher()
 
 		return nil, nil
@@ -138,10 +143,10 @@ func (m *ddbLockProvider) Acquire(ctx context.Context, resource string) (conc.Di
 }
 
 func (m *ddbLockProvider) TryAcquireIn(ctx context.Context, resource string, timeout time.Duration) (conc.DistributedLock, error) {
-	ctx, stop := context.WithTimeout(ctx, timeout)
+	acquireCtx, stop := context.WithTimeout(ctx, timeout)
 	defer stop()
 
-	lock, err := m.Acquire(ctx, resource)
+	lock, err := m.acquire(acquireCtx, ctx, resource)
 	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, conc.ErrLockOwned) {
 		// timeout or owned lock -> return no lock and no error as documented
 		return nil, nil
@@ -159,7 +164,6 @@ func (m *ddbLockProvider) RenewLock(ctx context.Context, lockTime time.Duration,
 			Set("ttl", expiry.Unix())
 
 		result, err := m.repo.UpdateItem(ctx, qb, &DdbLockItem{})
-
 		if err != nil {
 			return nil, fmt.Errorf("failed to renew lock: %w", err)
 		}

--- a/pkg/conc/ddb/ddb_lock_provider_test.go
+++ b/pkg/conc/ddb/ddb_lock_provider_test.go
@@ -73,7 +73,7 @@ func (s *ddbLockProviderTestSuite) SetupTest() {
 	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(s.T()))
 	s.ctx = s.T().Context()
 	s.repo = ddbMocks.NewRepository(s.T())
-	s.clock = clock.NewFakeClock()
+	s.clock = clock.NewFakeClockAt(time.Now().UTC())
 	s.uuidSource = uuidMocks.NewUuid(s.T())
 	s.uuidSource.EXPECT().NewV4().Return(s.token).Once()
 	s.executor = &testExecutor{
@@ -107,13 +107,14 @@ func (s *ddbLockProviderTestSuite) getRenewQueryBuilder() *ddbMocks.UpdateItemBu
 	return qb
 }
 
-func (s *ddbLockProviderTestSuite) getReleaseQueryBuilder(result *ddb.DeleteItemResult, err error) {
+func (s *ddbLockProviderTestSuite) getReleaseQueryBuilder(result *ddb.DeleteItemResult, err error) *ddbMocks.Repository_DeleteItem_Call {
 	qb := ddbMocks.NewDeleteItemBuilder(s.T())
 	qb.EXPECT().WithHash(s.resource).Return(qb).Once()
 	qb.EXPECT().WithCondition(ddb.AttributeExists("resource").And(ddb.Eq("token", s.token))).Return(qb).Once()
 
 	s.repo.EXPECT().DeleteItemBuilder().Return(qb).Once()
-	s.repo.EXPECT().DeleteItem(matcher.Context, qb, &concDdb.DdbLockItem{
+
+	return s.repo.EXPECT().DeleteItem(matcher.Context, qb, &concDdb.DdbLockItem{
 		Resource: s.resource,
 		Token:    s.token,
 	}).Return(result, err)
@@ -288,6 +289,30 @@ func (s *ddbLockProviderTestSuite) TestDdbLockProvider_AcquireInTimeout() {
 	l, err := s.provider.TryAcquireIn(s.ctx, s.resource[5:], time.Second)
 	s.Nil(l)
 	s.NoError(err)
+}
+
+func (s *ddbLockProviderTestSuite) TestDdbLockProvider_TryAcquireInReturnsLockThatReleasesWithCallerContext() {
+	acquireQb := s.getAcquireQueryBuilder()
+	s.repo.EXPECT().PutItem(matcher.Context, acquireQb, &concDdb.DdbLockItem{
+		Resource: s.resource,
+		Token:    s.token,
+		Ttl:      s.clock.Now().Add(time.Minute).Unix(),
+	}).Return(&ddb.PutItemResult{}, nil).Once()
+
+	s.getReleaseQueryBuilder(&ddb.DeleteItemResult{}, nil).Run(func(ctx context.Context, qb ddb.DeleteItemBuilder, item any) {
+		s.Require().NoError(ctx.Err())
+		deadline, ok := ctx.Deadline()
+		s.Require().True(ok)
+		minDeadline := s.clock.Now().Add(time.Minute).UTC().Truncate(time.Microsecond)
+		s.Require().WithinDuration(minDeadline, deadline.UTC(), time.Second*5)
+		s.Require().True(deadline.UTC().After(minDeadline))
+	}).Once()
+
+	lock, err := s.provider.TryAcquireIn(s.ctx, s.resource[5:], time.Second)
+	s.Require().NoError(err)
+	s.Require().NotNil(lock)
+
+	s.NoError(lock.Release())
 }
 
 func TestDdbLockProvider(t *testing.T) {

--- a/pkg/conc/ddb/ddb_lock_test.go
+++ b/pkg/conc/ddb/ddb_lock_test.go
@@ -81,7 +81,7 @@ func (s *ddbLockTestSuite) TestReleaseLockDelayedParentCancel() {
 	s.NoError(err)
 }
 
-func (s *ddbLockTestSuite) TestReleaseLockCancellationIsIgnored() {
+func (s *ddbLockTestSuite) TestReleaseLockCancellationIsNotIgnored() {
 	s.lock = ddb.NewDdbLockFromInterfaces(s.lockManager, s.clock, s.logger, s.ctx, "resource", "token", s.clock.Now().Add(time.Minute))
 
 	s.lockManager.EXPECT().
@@ -90,14 +90,32 @@ func (s *ddbLockTestSuite) TestReleaseLockCancellationIsIgnored() {
 		Once()
 
 	err := s.lock.Release()
-	s.NoError(err)
+	s.ErrorIs(err, context.Canceled)
 }
 
-func (s *ddbLockTestSuite) TestReleaseLockDeadlineExceededIsIgnored() {
+func (s *ddbLockTestSuite) TestReleaseLockCancellationIsIgnoredAfterExpiry() {
 	s.lock = ddb.NewDdbLockFromInterfaces(s.lockManager, s.clock, s.logger, s.ctx, "resource", "token", s.clock.Now().Add(time.Minute))
 
 	s.lockManager.EXPECT().
 		ReleaseLock(matcher.Context, "resource", "token").
+		Run(func(ctx context.Context, resource string, token string) {
+			s.clock.Advance(time.Minute)
+		}).
+		Return(context.Canceled).
+		Once()
+
+	err := s.lock.Release()
+	s.NoError(err)
+}
+
+func (s *ddbLockTestSuite) TestReleaseLockDeadlineExceededIsIgnoredAfterExpiry() {
+	s.lock = ddb.NewDdbLockFromInterfaces(s.lockManager, s.clock, s.logger, s.ctx, "resource", "token", s.clock.Now().Add(time.Minute))
+
+	s.lockManager.EXPECT().
+		ReleaseLock(matcher.Context, "resource", "token").
+		Run(func(ctx context.Context, resource string, token string) {
+			s.clock.Advance(time.Minute)
+		}).
 		Return(context.DeadlineExceeded).
 		Once()
 

--- a/pkg/exec/context.go
+++ b/pkg/exec/context.go
@@ -55,11 +55,6 @@ func newStoppableContext(parentCtx context.Context, deadline *time.Time, handler
 		stopped:   make(chan struct{}),
 		deadline:  deadline,
 	}
-	if parentDeadline, ok := parentCtx.Deadline(); ok {
-		if ctx.deadline == nil || ctx.deadline.After(parentDeadline) {
-			ctx.deadline = &parentDeadline
-		}
-	}
 
 	go func() {
 		defer ctx.stopWg.Done()
@@ -110,10 +105,17 @@ func (c *stoppableContext) stop() {
 // WithDelayedCancelContext creates a context which propagates the cancellation of the parent context after a fixed delay
 // to the returned context. Call the returned StopFunc function to release resources associated with the returned context once
 // you no longer need it. Calling stop never returns before all resources have been released, so after Stop returns,
-// the context will not experience a delayed cancel anymore (however, if the parent context was already canceled the moment
-// you called stop, the child context will immediately get canceled).
+// the context will not experience a delayed cancel anymore. However, if the parent context was already canceled the moment
+// you called stop, the child context will immediately get canceled.
+// The child context will extend the parent deadline by the specified delay if the parent context has a deadline.
 func WithDelayedCancelContext(parentCtx context.Context, delay time.Duration) (context.Context, StopFunc) {
-	return newStoppableContext(parentCtx, nil, func(ctx *stoppableContext) (bool, error) {
+	var deadline *time.Time
+	if parentDeadline, ok := parentCtx.Deadline(); ok {
+		d := parentDeadline.Add(delay)
+		deadline = &d
+	}
+
+	return newStoppableContext(parentCtx, deadline, func(ctx *stoppableContext) (bool, error) {
 		select {
 		case <-ctx.stopped:
 			return false, nil
@@ -139,6 +141,11 @@ func WithDelayedCancelContext(parentCtx context.Context, delay time.Duration) (c
 // you call the returned context.CancelFunc, WithStoppableDeadlineContext does not cancel the context if it is not yet canceled
 // once you stop it.
 func WithStoppableDeadlineContext(parentCtx context.Context, deadline time.Time) (context.Context, StopFunc) {
+	parentDeadline, ok := parentCtx.Deadline()
+	if ok && deadline.After(parentDeadline) {
+		deadline = parentDeadline
+	}
+
 	return newStoppableContext(parentCtx, &deadline, func(ctx *stoppableContext) (bool, error) {
 		c := clock.Provider
 		waitTime := -c.Since(deadline)

--- a/pkg/exec/context_test.go
+++ b/pkg/exec/context_test.go
@@ -87,6 +87,27 @@ func (s *contextTestSuite) TestWithDelayedCancelContext_StopAfterCancel() {
 	s.assertCanceled(ctx, context.Canceled)
 }
 
+func (s *contextTestSuite) TestWithDelayedCancelContext_DeadlineExtendsParentDeadline() {
+	parentDeadline := time.Now().Add(time.Minute)
+	parentCtx, cancel := context.WithDeadline(s.T().Context(), parentDeadline)
+	defer cancel()
+
+	ctx, stop := exec.WithDelayedCancelContext(parentCtx, time.Hour)
+	defer stop()
+
+	deadline, ok := ctx.Deadline()
+	s.True(ok)
+	s.WithinDuration(parentDeadline.Add(time.Hour), deadline, 0)
+}
+
+func (s *contextTestSuite) TestWithDelayedCancelContext_WithoutParentDeadlineHasNoDeadline() {
+	ctx, stop := exec.WithDelayedCancelContext(s.T().Context(), time.Hour)
+	defer stop()
+
+	_, ok := ctx.Deadline()
+	s.False(ok)
+}
+
 func (s *contextTestSuite) TestWithStoppableDeadlineContext() {
 	parentCtx := s.T().Context()
 	ctx, stop := exec.WithStoppableDeadlineContext(parentCtx, s.fakeClock.Now().Add(time.Minute))
@@ -135,6 +156,30 @@ func (s *contextTestSuite) TestWithStoppableDeadlineContext_Stop() {
 	// even give it some time to wrongly propagate a cancel - as this should not happen, this should not change it
 	time.Sleep(time.Millisecond)
 	s.assertNotCanceled(ctx)
+}
+
+func (s *contextTestSuite) TestWithStoppableDeadlineContext_ParentDeadlineEarlier() {
+	// Parent has a deadline earlier than the one we'll request
+	parentDeadline := time.Now().Add(time.Minute)
+	parentCtx, cancelParent := context.WithDeadline(s.T().Context(), parentDeadline)
+	defer cancelParent()
+
+	// Request a later deadline - it should be clamped to the parent's deadline
+	ctx, stop := exec.WithStoppableDeadlineContext(parentCtx, time.Now().Add(time.Hour))
+	defer stop()
+
+	// Initially the context is not canceled
+	s.assertNotCanceled(ctx)
+
+	// The reported deadline must match the parent's earlier deadline, not the requested later one
+	deadline, ok := ctx.Deadline()
+	s.True(ok)
+	s.WithinDuration(parentDeadline, deadline, 0)
+
+	// When the parent is canceled, the child should also be canceled
+	cancelParent()
+	<-ctx.Done()
+	s.assertCanceled(ctx, context.Canceled)
 }
 
 func (s *contextTestSuite) TestWithManualCancelContext() {


### PR DESCRIPTION
The `WithDelayedCancelContext` function delays the cancel of a context for some time, but it didn't extend the deadline of the parent. This could cause context cancels in child contexts of it based on the wrongly propagated deadline. This PR fixes this.

We are also fixing another issue in the ddb lock handling where we would 
- store an already canceled context in a lock and carry over a deadline we don't want, causing the `WithDelayedCancelContext` function to not work correctly
- mask too many errors if there was a context cancel error while the lock was not yet expired.