### PR TITLE
log: mask sensitive config values attached to Sentry events

### DIFF
--- a/pkg/log/handler_sentry_context.go
+++ b/pkg/log/handler_sentry_context.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"fmt"
+	"strings"
 )
 
 // ConfigProvider defines an interface for retrieving all configuration settings as a map.
@@ -12,11 +13,44 @@ type ConfigProvider interface {
 // SentryContextProvider is a function type for attaching extra context (like config or ECS metadata) to the Sentry handler.
 type SentryContextProvider func(config ConfigProvider, sentryHook *HandlerSentry) error
 
-// SentryContextConfigProvider attaches the entire configuration as context to Sentry events.
+var sentrySensitivePatterns = []string{
+	"password", "secret", "token", "key", "dsn", "credential",
+}
+
+func isSentrySensitiveKey(key string) bool {
+	lower := strings.ToLower(key)
+	for _, pattern := range sentrySensitivePatterns {
+		if strings.Contains(lower, pattern) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func maskSensitiveConfigValues(m map[string]any) map[string]any {
+	masked := make(map[string]any, len(m))
+	for k, v := range m {
+		if isSentrySensitiveKey(k) {
+			masked[k] = "***"
+
+			continue
+		}
+		if nested, ok := v.(map[string]any); ok {
+			masked[k] = maskSensitiveConfigValues(nested)
+
+			continue
+		}
+		masked[k] = v
+	}
+
+	return masked
+}
+
+// SentryContextConfigProvider attaches the configuration (with sensitive values masked) as context to Sentry events.
 func SentryContextConfigProvider(config ConfigProvider, handler *HandlerSentry) error {
 	configValues := config.AllSettings()
-	handler.WithContext("config", configValues)
-
+	handler.WithContext("config", maskSensitiveConfigValues(configValues))
 	return nil
 }
 
@@ -26,12 +60,9 @@ func SentryContextEcsMetadataProvider(_ ConfigProvider, handler *HandlerSentry) 
 	if err != nil {
 		return fmt.Errorf("can not read ecs metadata: %w", err)
 	}
-
 	if ecsMetadata == nil {
 		return nil
 	}
-
 	handler.WithContext("ecsMetadata", ecsMetadata)
-
 	return nil
 }

--- a/pkg/log/handler_sentry_context_test.go
+++ b/pkg/log/handler_sentry_context_test.go
@@ -1,0 +1,75 @@
+package log
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsSentrySensitiveKey_MatchesSensitivePatterns(t *testing.T) {
+	// All of these must be masked.
+	assert.True(t, isSentrySensitiveKey("password"))
+	assert.True(t, isSentrySensitiveKey("db_password"))
+	assert.True(t, isSentrySensitiveKey("API_SECRET"))
+	assert.True(t, isSentrySensitiveKey("auth_token"))
+	assert.True(t, isSentrySensitiveKey("api_key"))
+	assert.True(t, isSentrySensitiveKey("database_dsn"))
+	assert.True(t, isSentrySensitiveKey("user_credential"))
+	// Non-sensitive keys must not be masked.
+	assert.False(t, isSentrySensitiveKey("host"))
+	assert.False(t, isSentrySensitiveKey("port"))
+	assert.False(t, isSentrySensitiveKey("username"))
+	assert.False(t, isSentrySensitiveKey("region"))
+}
+
+func TestMaskSensitiveConfigValues_MasksSensitiveTopLevelKeys(t *testing.T) {
+	m := map[string]any{
+		"db_password":     "hunter2",
+		"api_secret":      "mysecret",
+		"auth_token":      "tok123",
+		"api_key":         "key123",
+		"database_dsn":    "host=localhost",
+		"user_credential": "cred",
+		"safe_value":      "plaintext",
+		"host":            "localhost",
+	}
+	got := maskSensitiveConfigValues(m)
+	assert.Equal(t, "***", got["db_password"])
+	assert.Equal(t, "***", got["api_secret"])
+	assert.Equal(t, "***", got["auth_token"])
+	assert.Equal(t, "***", got["api_key"])
+	assert.Equal(t, "***", got["database_dsn"])
+	assert.Equal(t, "***", got["user_credential"])
+	assert.Equal(t, "plaintext", got["safe_value"])
+	assert.Equal(t, "localhost", got["host"])
+}
+
+func TestMaskSensitiveConfigValues_MasksNestedMapRecursively(t *testing.T) {
+	m := map[string]any{
+		"database": map[string]any{
+			"password": "secret123",
+			"host":     "localhost",
+			"inner": map[string]any{
+				"token": "tok",
+				"port":  5432,
+			},
+		},
+	}
+	got := maskSensitiveConfigValues(m)
+	db := got["database"].(map[string]any)
+	assert.Equal(t, "***", db["password"])
+	assert.Equal(t, "localhost", db["host"])
+	inner := db["inner"].(map[string]any)
+	assert.Equal(t, "***", inner["token"])
+	assert.Equal(t, 5432, inner["port"])
+}
+
+func TestMaskSensitiveConfigValues_DoesNotMutateOriginal(t *testing.T) {
+	m := map[string]any{
+		"password": "hunter2",
+		"host":     "localhost",
+	}
+	_ = maskSensitiveConfigValues(m)
+	assert.Equal(t, "hunter2", m["password"])
+	assert.Equal(t, "localhost", m["host"])
+}


### PR DESCRIPTION
SentryContextConfigProvider now recursively masks values in the configuration map before attaching it to Sentry events. Any key whose name contains password, secret, token, key, dsn, or credential has its value replaced with ***.