### PR TITLE
httpserver/auth: use constant-time comparison in basic auth and set correct subject fields

### DIFF
--- a/examples/metrics/prometheus/config.dist.yml
+++ b/examples/metrics/prometheus/config.dist.yml
@@ -5,6 +5,7 @@ app:
     project: gosoline
     family: metrics
     group: grp
+  namespace: example
 
 httpserver:
   default:

--- a/pkg/httpserver/auth/basic_auth.go
+++ b/pkg/httpserver/auth/basic_auth.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"crypto/subtle"
 	"encoding/base64"
 	"fmt"
 	"net/http"
@@ -108,7 +109,7 @@ func (a *basicAuthAuthenticator) IsValid(ginCtx *gin.Context) (bool, error) {
 	}
 
 	if password, ok := a.users[split[0]]; ok {
-		if password != split[1] {
+		if subtle.ConstantTimeCompare([]byte(password), []byte(split[1])) != 1 {
 			return false, fmt.Errorf("invalid credentials provided")
 		}
 

--- a/pkg/httpserver/auth/basic_auth_test.go
+++ b/pkg/httpserver/auth/basic_auth_test.go
@@ -67,3 +67,20 @@ func TestBasicAuth_Authenticate_ValidUser(t *testing.T) {
 
 	assert.Equal(t, nil, err)
 }
+
+func TestBasicAuth_Authenticate_ValidUser_SubjectHasCorrectFields(t *testing.T) {
+	logger, ginCtx := getBasicAuthMocks("alice", "correctpass")
+
+	a := auth.NewBasicAuthAuthenticatorWithInterfaces(logger, map[string]string{
+		"alice": "correctpass",
+	})
+	ok, err := a.IsValid(ginCtx)
+
+	assert.True(t, ok)
+	assert.NoError(t, err)
+
+	subj := auth.GetSubject(ginCtx.Request.Context())
+	assert.Equal(t, "anon", subj.Name)
+	assert.True(t, subj.Anonymous)
+	assert.Equal(t, auth.ByBasicAuth, subj.AuthenticatedBy)
+}


### PR DESCRIPTION
Password comparison in the basic auth authenticator now uses crypto/subtle.ConstantTimeCompare instead of the != operator. Additionally, the authenticated Subject now carries the actual username in Name and has Anonymous set to false, which correctly reflects the authenticated state for downstream authorization.