### PR TITLE
application: mask sensitive values in metadata server config output

### DIFF
--- a/pkg/application/metadata_server.go
+++ b/pkg/application/metadata_server.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"runtime"
+	"strings"
 
 	"github.com/justtrackio/gosoline/pkg/appctx"
 	"github.com/justtrackio/gosoline/pkg/cfg"
@@ -16,6 +17,40 @@ import (
 	"github.com/justtrackio/gosoline/pkg/kernel"
 	"github.com/justtrackio/gosoline/pkg/log"
 )
+
+var sensitiveKeyPatterns = []string{
+	"password", "secret", "token", "key", "dsn", "credential",
+}
+
+func maskSecrets(m map[string]any) map[string]any {
+	masked := make(map[string]any, len(m))
+	for k, v := range m {
+		if isSensitiveKey(k) {
+			masked[k] = "***"
+
+			continue
+		}
+		if nested, ok := v.(map[string]any); ok {
+			masked[k] = maskSecrets(nested)
+
+			continue
+		}
+		masked[k] = v
+	}
+
+	return masked
+}
+
+func isSensitiveKey(key string) bool {
+	lower := strings.ToLower(key)
+	for _, pattern := range sensitiveKeyPatterns {
+		if strings.Contains(lower, pattern) {
+			return true
+		}
+	}
+
+	return false
+}
 
 func init() {
 	dx.RegisterRandomizablePortSetting("appctx.metadata.server.port")
@@ -107,7 +142,7 @@ func (s *MetadataServer) handleMetadata(metadata *appctx.Metadata) func(http.Res
 func (s *MetadataServer) handleConfig(writer http.ResponseWriter, request *http.Request) {
 	ctx := request.Context()
 	settings := s.config.AllSettings()
-	s.formattedResponse(ctx, writer, request, settings)
+	s.formattedResponse(ctx, writer, request, maskSecrets(settings))
 }
 
 func (s *MetadataServer) handleMemory(writer http.ResponseWriter, request *http.Request) {

--- a/pkg/application/metadata_server_masking_test.go
+++ b/pkg/application/metadata_server_masking_test.go
@@ -1,0 +1,68 @@
+package application
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMaskSecrets_SensitiveTopLevelKeys(t *testing.T) {
+	m := map[string]any{
+		"db_password":     "hunter2",
+		"api_secret":      "mysecret",
+		"auth_token":      "tok123",
+		"api_key":         "key123",
+		"database_dsn":    "host=localhost",
+		"user_credential": "cred",
+		"safe_value":      "plaintext",
+		"host":            "localhost",
+	}
+	got := maskSecrets(m)
+	assert.Equal(t, "***", got["db_password"])
+	assert.Equal(t, "***", got["api_secret"])
+	assert.Equal(t, "***", got["auth_token"])
+	assert.Equal(t, "***", got["api_key"])
+	assert.Equal(t, "***", got["database_dsn"])
+	assert.Equal(t, "***", got["user_credential"])
+	assert.Equal(t, "plaintext", got["safe_value"])
+	assert.Equal(t, "localhost", got["host"])
+}
+
+func TestMaskSecrets_NestedMapIsMaskedRecursively(t *testing.T) {
+	m := map[string]any{
+		"database": map[string]any{
+			"password": "secret123",
+			"host":     "localhost",
+			"inner": map[string]any{
+				"token": "tok",
+				"port":  5432,
+			},
+		},
+	}
+	got := maskSecrets(m)
+	db := got["database"].(map[string]any)
+	assert.Equal(t, "***", db["password"])
+	assert.Equal(t, "localhost", db["host"])
+	inner := db["inner"].(map[string]any)
+	assert.Equal(t, "***", inner["token"])
+	assert.Equal(t, 5432, inner["port"])
+}
+
+func TestMaskSecrets_DoesNotMutateOriginal(t *testing.T) {
+	m := map[string]any{
+		"password": "hunter2",
+		"host":     "localhost",
+	}
+	_ = maskSecrets(m)
+	assert.Equal(t, "hunter2", m["password"])
+	assert.Equal(t, "localhost", m["host"])
+}
+
+func TestIsSensitiveKey_CaseInsensitive(t *testing.T) {
+	assert.True(t, isSensitiveKey("PASSWORD"))
+	assert.True(t, isSensitiveKey("API_SECRET"))
+	assert.True(t, isSensitiveKey("Auth_Token"))
+	assert.False(t, isSensitiveKey("host"))
+	assert.False(t, isSensitiveKey("port"))
+	assert.False(t, isSensitiveKey("username"))
+}


### PR DESCRIPTION
The /config endpoint on the metadata server now replaces values for keys containing sensitive substrings (password, secret, token, key, dsn, credential) with *** before serializing the response. Nested config maps are traversed recursively.