### PR TITLE
httpserver/auth: remove token value from Google auth cache-miss log entry

### DIFF
--- a/pkg/httpserver/auth/config_google.go
+++ b/pkg/httpserver/auth/config_google.go
@@ -130,9 +130,7 @@ func (a *configGoogleAuthenticator) IsValid(ginCtx *gin.Context) (bool, error) {
 		return true, nil
 	}
 
-	a.logger.WithFields(log.Fields{
-		"id_token": idToken,
-	}).Info(reqCtx, "token not in cache, will perform request")
+	a.logger.Info(reqCtx, "token not in cache, will perform request")
 
 	tokenInfo, err = a.tokenProvider.GetTokenInfo(idToken)
 	if err != nil {


### PR DESCRIPTION
The informational log message emitted when a Google ID token is not in the cache no longer includes the token value as a structured field. The message itself is preserved.