### PR TITLE
httpserver: reject negative integers in uint path parameter reader

### DIFF
--- a/pkg/httpserver/param_reader.go
+++ b/pkg/httpserver/param_reader.go
@@ -14,7 +14,7 @@ func GetUintFromRequest(request *Request, name string) (*uint, bool) {
 	}
 
 	param, err := strconv.Atoi(paramString)
-	if err != nil {
+	if err != nil || param < 0 {
 		return mdl.Box(uint(0)), false
 	}
 

--- a/pkg/httpserver/param_reader_test.go
+++ b/pkg/httpserver/param_reader_test.go
@@ -1,0 +1,50 @@
+package httpserver_test
+
+import (
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/justtrackio/gosoline/pkg/httpserver"
+	"github.com/stretchr/testify/assert"
+)
+
+func makeParamRequest(paramName, paramValue string) *httpserver.Request {
+	return &httpserver.Request{
+		Params: gin.Params{{Key: paramName, Value: paramValue}},
+	}
+}
+
+func TestGetUintFromRequest_RejectsNegativeValue(t *testing.T) {
+	req := makeParamRequest("id", "-1")
+	val, ok := httpserver.GetUintFromRequest(req, "id")
+	assert.False(t, ok, "negative value must be rejected")
+	assert.Equal(t, uint(0), *val)
+}
+
+func TestGetUintFromRequest_AcceptsZero(t *testing.T) {
+	req := makeParamRequest("id", "0")
+	val, ok := httpserver.GetUintFromRequest(req, "id")
+	assert.True(t, ok)
+	assert.Equal(t, uint(0), *val)
+}
+
+func TestGetUintFromRequest_AcceptsPositive(t *testing.T) {
+	req := makeParamRequest("id", "42")
+	val, ok := httpserver.GetUintFromRequest(req, "id")
+	assert.True(t, ok)
+	assert.Equal(t, uint(42), *val)
+}
+
+func TestGetUintFromRequest_RejectsNonNumeric(t *testing.T) {
+	req := makeParamRequest("id", "abc")
+	val, ok := httpserver.GetUintFromRequest(req, "id")
+	assert.False(t, ok)
+	assert.Equal(t, uint(0), *val)
+}
+
+func TestGetUintFromRequest_RejectsMissing(t *testing.T) {
+	req := makeParamRequest("other", "1")
+	val, ok := httpserver.GetUintFromRequest(req, "id")
+	assert.False(t, ok)
+	assert.Equal(t, uint(0), *val)
+}


### PR DESCRIPTION
GetUintFromRequest now returns (0, false) when the parsed integer is negative, preventing the implicit wrap-around to a large unsigned value that occurs on 64-bit systems. Previously, a path parameter of -1 would be silently converted to 18446744073709551615.