### PR TITLE
db: change MySQL multi_statements default to false

### DIFF
--- a/pkg/db/driver_mysql_test.go
+++ b/pkg/db/driver_mysql_test.go
@@ -49,14 +49,28 @@ func (s *MysqlDriverTestSuite) TestDsn() {
 	s.NoError(err)
 
 	dsn := driver.GetDSN(s.settings)
-	s.Equal("tcp(localhost:3306)/?collation=utf8mb4_general_ci&multiStatements=true&parseTime=true&charset=utf8mb4&readTimeout=0s&writeTimeout=0s", dsn)
+	s.Equal("tcp(localhost:3306)/?collation=utf8mb4_general_ci&parseTime=true&charset=utf8mb4&readTimeout=0s&writeTimeout=0s", dsn)
 
 	s.settings.Timeouts.ReadTimeout = time.Millisecond * 50
 	s.settings.Timeouts.WriteTimeout = time.Millisecond * 50
 	dsn = driver.GetDSN(s.settings)
-	s.Equal("tcp(localhost:3306)/?collation=utf8mb4_general_ci&multiStatements=true&parseTime=true&charset=utf8mb4&readTimeout=50ms&writeTimeout=50ms", dsn)
+	s.Equal("tcp(localhost:3306)/?collation=utf8mb4_general_ci&parseTime=true&charset=utf8mb4&readTimeout=50ms&writeTimeout=50ms", dsn)
 
 	s.settings.Parameters["param1"] = "value1"
 	dsn = driver.GetDSN(s.settings)
-	s.Equal("tcp(localhost:3306)/?collation=utf8mb4_general_ci&multiStatements=true&parseTime=true&charset=utf8mb4&param1=value1&readTimeout=50ms&writeTimeout=50ms", dsn)
+	s.Equal("tcp(localhost:3306)/?collation=utf8mb4_general_ci&parseTime=true&charset=utf8mb4&param1=value1&readTimeout=50ms&writeTimeout=50ms", dsn)
+}
+
+func (s *MysqlDriverTestSuite) TestDsn_MigrationConnectionHasMultiStatements() {
+	// openMigrationDB copies settings and forces MultiStatements=true so that
+	// SQL migration files containing multiple statements execute correctly.
+	driver, err := db.NewMysqlDriver(s.logger)
+	s.NoError(err)
+
+	migrationSettings := *s.settings
+	migrationSettings.MultiStatements = true
+
+	dsn := driver.GetDSN(&migrationSettings)
+	s.Contains(dsn, "multiStatements=true",
+		"migration DSN must include multiStatements=true regardless of the runtime default")
 }

--- a/pkg/db/migrations.go
+++ b/pkg/db/migrations.go
@@ -29,7 +29,7 @@ var migrationProviders = map[string]MigrationProvider{
 	"goose":          runMigrationGoose,
 }
 
-func runMigrations(ctx context.Context, logger log.Logger, settings *Settings, db *sql.DB) error {
+func runMigrations(ctx context.Context, logger log.Logger, settings *Settings, _ *sql.DB) error {
 	logger = logger.WithChannel("db-migrations")
 
 	if !settings.Migrations.Enabled || settings.Migrations.Path == "" {
@@ -52,19 +52,47 @@ func runMigrations(ctx context.Context, logger log.Logger, settings *Settings, d
 		return fmt.Errorf("there is no migration provider of type %s available", settings.Migrations.Provider)
 	}
 
+	// Migrations may contain multi-statement SQL files; open a dedicated
+	// connection with MultiStatements enabled. Runtime connections keep the
+	// secure default (false) to prevent second-order SQL injection.
+	migrationDB, err := openMigrationDB(logger, settings)
+	if err != nil {
+		return fmt.Errorf("can not open migration connection: %w", err)
+	}
+	defer migrationDB.Close()
+
 	start := time.Now()
 
-	if err = resetMigrations(ctx, logger, settings, db); err != nil {
+	if err = resetMigrations(ctx, logger, settings, migrationDB); err != nil {
 		return fmt.Errorf("could not reset migrations: %w", err)
 	}
 
-	if err = provider(ctx, logger, settings, db); err != nil {
+	if err = provider(ctx, logger, settings, migrationDB); err != nil {
 		return fmt.Errorf("running migration provider %s failed: %w", settings.Migrations.Provider, err)
 	}
 
 	logger.Info(ctx, "migrated db in %s", time.Since(start))
 
 	return nil
+}
+
+func openMigrationDB(logger log.Logger, settings *Settings) (*sql.DB, error) {
+	drv, err := GetDriver(logger, settings.Driver)
+	if err != nil {
+		return nil, fmt.Errorf("can not get driver: %w", err)
+	}
+
+	migrationSettings := *settings
+	migrationSettings.MultiStatements = true
+
+	dsn := drv.GetDSN(&migrationSettings)
+
+	db, err := sql.Open(settings.Driver, dsn)
+	if err != nil {
+		return nil, fmt.Errorf("can not open connection: %w", err)
+	}
+
+	return db, nil
 }
 
 func resetMigrations(ctx context.Context, logger log.Logger, settings *Settings, db *sql.DB) error {

--- a/pkg/db/settings.go
+++ b/pkg/db/settings.go
@@ -16,7 +16,7 @@ type Settings struct {
 	MaxIdleConnections    int               `cfg:"max_idle_connections"    default:"2"` // 0 or negative number=no idle connections, sql driver default=2
 	MaxOpenConnections    int               `cfg:"max_open_connections"    default:"0"` // 0 or negative number=unlimited, sql driver default=0
 	Migrations            MigrationSettings `cfg:"migrations"`
-	MultiStatements       bool              `cfg:"multi_statements"        default:"true"`
+	MultiStatements       bool              `cfg:"multi_statements"        default:"false"`
 	Parameters            map[string]string `cfg:"parameters"`
 	ParseTime             bool              `cfg:"parse_time"              default:"true"`
 	Retry                 SettingsRetry     `cfg:"retry"`


### PR DESCRIPTION
The multi_statements driver option now defaults to false. Callers that require executing multiple statements in a single call can opt in explicitly via configuration. This matches the principle of least privilege for database connections.