### PR TITLE
cfg: mask sensitive values in DebugConfig log output

### DIFF
--- a/pkg/cfg/debug.go
+++ b/pkg/cfg/debug.go
@@ -11,6 +11,21 @@ import (
 	"github.com/justtrackio/gosoline/pkg/funk"
 )
 
+var debugSensitivePatterns = []string{
+	"password", "secret", "token", "key", "dsn", "credential",
+}
+
+func isSensitiveConfigKey(key string) bool {
+	lower := strings.ToLower(key)
+	for _, pattern := range debugSensitivePatterns {
+		if strings.Contains(lower, pattern) {
+			return true
+		}
+	}
+
+	return false
+}
+
 func DebugConfig(ctx context.Context, config Config, logger Logger) error {
 	settings := config.AllSettings()
 	flattened, err := flatten.Flatten(settings, "", flatten.DotStyle)
@@ -23,8 +38,14 @@ func DebugConfig(ctx context.Context, config Config, logger Logger) error {
 	sort.Strings(keys)
 
 	for i, key := range keys {
-		hashValues[i] = fmt.Sprintf("%v=%v", key, flattened[key])
-		logger.Info(ctx, "cfg %s", hashValues[i])
+		value := flattened[key]
+		// Use the real value for the fingerprint so config changes are always detectable.
+		hashValues[i] = fmt.Sprintf("%v=%v", key, value)
+		// Mask sensitive values in the log output.
+		if isSensitiveConfigKey(key) {
+			value = "***"
+		}
+		logger.Info(ctx, "cfg %v=%v", key, value)
 	}
 
 	hashString := strings.Join(hashValues, ";")

--- a/pkg/cfg/debug_test.go
+++ b/pkg/cfg/debug_test.go
@@ -1,0 +1,90 @@
+package cfg
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsSensitiveConfigKey_MatchesSensitivePatterns(t *testing.T) {
+	assert.True(t, isSensitiveConfigKey("password"))
+	assert.True(t, isSensitiveConfigKey("db_password"))
+	assert.True(t, isSensitiveConfigKey("API_SECRET"))
+	assert.True(t, isSensitiveConfigKey("auth_token"))
+	assert.True(t, isSensitiveConfigKey("api_key"))
+	assert.True(t, isSensitiveConfigKey("database_dsn"))
+	assert.True(t, isSensitiveConfigKey("user_credential"))
+	assert.True(t, isSensitiveConfigKey("AWS_ACCESS_KEY"))
+	// Non-sensitive keys must not be masked.
+	assert.False(t, isSensitiveConfigKey("host"))
+	assert.False(t, isSensitiveConfigKey("port"))
+	assert.False(t, isSensitiveConfigKey("username"))
+	assert.False(t, isSensitiveConfigKey("region"))
+}
+
+// captureLogger records every logged message.
+type captureLogger struct {
+	lines []string
+}
+
+func (l *captureLogger) Info(_ context.Context, format string, args ...any) {
+	l.lines = append(l.lines, fmt.Sprintf(format, args...))
+}
+
+func (l *captureLogger) Error(_ context.Context, format string, args ...any) {
+	l.lines = append(l.lines, fmt.Sprintf(format, args...))
+}
+
+func (l *captureLogger) hasLine(substr string) bool {
+	for _, line := range l.lines {
+		if strings.Contains(line, substr) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// TestDebugConfig_MasksSensitiveKeysInLog verifies that DebugConfig logs "***"
+// for sensitive config keys, preventing secret leakage in log output.
+func TestDebugConfig_MasksSensitiveKeysInLog(t *testing.T) {
+	config := New(map[string]any{
+		"db_password": "hunter2",
+		"host":        "localhost",
+	})
+
+	logger := &captureLogger{}
+	err := DebugConfig(context.Background(), config, logger)
+	require.NoError(t, err)
+
+	// Sensitive value must be masked in the log.
+	assert.False(t, logger.hasLine("hunter2"),
+		"real password must not appear in log output")
+	assert.True(t, logger.hasLine("***"),
+		"masked placeholder must appear in log output")
+	// Safe value must be logged as-is.
+	assert.True(t, logger.hasLine("localhost"),
+		"non-sensitive value must appear in log output")
+}
+
+// TestDebugConfig_FingerprintIsEmitted verifies that the fingerprint log line
+// is emitted (proving DebugConfig completed) even when sensitive keys are present.
+func TestDebugConfig_FingerprintIsEmitted(t *testing.T) {
+	config := New(map[string]any{
+		"api_secret": "topsecret",
+	})
+
+	logger := &captureLogger{}
+	err := DebugConfig(context.Background(), config, logger)
+	require.NoError(t, err)
+
+	assert.True(t, logger.hasLine("fingerprint"),
+		"fingerprint line must be emitted")
+	// The real secret must NOT appear in any log line.
+	assert.False(t, logger.hasLine("topsecret"),
+		"real secret must not appear anywhere in log output")
+}


### PR DESCRIPTION
DebugConfig now redacts the logged value for any config key whose name contains password, secret, token, key, dsn, credential, or access_key, replacing it with ***. The config fingerprint is still computed from the original values so that it accurately reflects all configuration changes.