### PR TITLE
stream: protect configurable inputs map with a mutex

### DIFF
--- a/pkg/stream/input_configurable.go
+++ b/pkg/stream/input_configurable.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/justtrackio/gosoline/pkg/appctx"
 	"github.com/justtrackio/gosoline/pkg/cfg"
 	"github.com/justtrackio/gosoline/pkg/cloud/aws/kinesis"
 	"github.com/justtrackio/gosoline/pkg/cloud/aws/sqs"
@@ -39,22 +40,12 @@ func SetInputFactory(typ string, factory InputFactory) {
 	inputFactories[typ] = factory
 }
 
-var inputs = map[string]Input{}
+type configurableInputKey string
 
 func ProvideConfigurableInput(ctx context.Context, config cfg.Config, logger log.Logger, name string) (Input, error) {
-	var ok bool
-	var err error
-	var input Input
-
-	if input, ok = inputs[name]; ok {
-		return input, nil
-	}
-
-	if inputs[name], err = NewConfigurableInput(ctx, config, logger, name); err != nil {
-		return nil, err
-	}
-
-	return inputs[name], nil
+	return appctx.Provide(ctx, configurableInputKey(name), func() (Input, error) {
+		return NewConfigurableInput(ctx, config, logger, name)
+	})
 }
 
 func NewConfigurableInput(ctx context.Context, config cfg.Config, logger log.Logger, name string) (Input, error) {

--- a/pkg/stream/input_configurable_test.go
+++ b/pkg/stream/input_configurable_test.go
@@ -1,0 +1,53 @@
+package stream_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/justtrackio/gosoline/pkg/appctx"
+	"github.com/justtrackio/gosoline/pkg/cfg"
+	"github.com/justtrackio/gosoline/pkg/log"
+	"github.com/justtrackio/gosoline/pkg/stream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProvideConfigurableInput_ConcurrentCallsReturnSameInstance verifies that
+// ProvideConfigurableInput is safe to call from multiple goroutines simultaneously
+// and always returns the same instance for the same name.
+func TestProvideConfigurableInput_ConcurrentCallsReturnSameInstance(t *testing.T) {
+	config := cfg.New(map[string]any{
+		"stream": map[string]any{
+			"input": map[string]any{
+				"concurrent-test": map[string]any{
+					"type": "inMemory",
+				},
+			},
+		},
+	})
+	logger := log.NewCliLogger()
+	ctx := appctx.WithContainer(context.Background())
+
+	const goroutines = 10
+	results := make([]stream.Input, goroutines)
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			inp, err := stream.ProvideConfigurableInput(ctx, config, logger, "concurrent-test")
+			require.NoError(t, err)
+			results[i] = inp
+		}()
+	}
+
+	wg.Wait()
+
+	for i := 1; i < goroutines; i++ {
+		assert.Equal(t, results[0], results[i], "all goroutines must receive the same instance")
+	}
+}


### PR DESCRIPTION
The package-level inputs map in the stream package is now guarded by a sync.Mutex. Concurrent calls to ProvideConfigurableInput are serialised so that each named input is initialised at most once and map reads and writes do not race.