### PR TITLE
httpserver/auth: add TTL and size limit to Google auth token cache

### DIFF
--- a/pkg/httpserver/auth/config_google.go
+++ b/pkg/httpserver/auth/config_google.go
@@ -6,9 +6,10 @@ import (
 	"net/http"
 	"regexp"
 	"slices"
-	"sync"
+	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/justtrackio/gosoline/pkg/cache"
 	"github.com/justtrackio/gosoline/pkg/cfg"
 	"github.com/justtrackio/gosoline/pkg/log"
 	"github.com/pkg/errors"
@@ -31,11 +32,16 @@ func (p *GoogleTokenProvider) GetTokenInfo(idToken string) (*oauth2.Tokeninfo, e
 	return p.oauth2Service.Tokeninfo().IdToken(idToken).Do()
 }
 
+const (
+	tokenCacheTTL       = 5 * time.Minute
+	tokenCacheMaxSize   = 10_000
+	tokenCachePruneSize = 500
+)
+
 type configGoogleAuthenticator struct {
 	logger           log.Logger
-	tokenCache       map[string]*oauth2.Tokeninfo
+	tokenCache       cache.Cache[oauth2.Tokeninfo]
 	tokenProvider    TokenInfoProvider
-	mutex            sync.Mutex
 	validAudiences   []string
 	allowedAddresses []string
 }
@@ -90,11 +96,13 @@ func NewConfigGoogleAuthenticator(config cfg.Config, logger log.Logger) (Authent
 }
 
 func NewConfigGoogleAuthenticatorWithInterfaces(logger log.Logger, tokenProvider TokenInfoProvider, clientIds []string, allowedAddresses []string) Authenticator {
+	tokenCache := cache.New[oauth2.Tokeninfo](tokenCacheMaxSize, tokenCachePruneSize, tokenCacheTTL)
+
 	return &configGoogleAuthenticator{
 		logger:           logger,
 		validAudiences:   clientIds,
 		allowedAddresses: allowedAddresses,
-		tokenCache:       make(map[string]*oauth2.Tokeninfo),
+		tokenCache:       tokenCache,
 		tokenProvider:    tokenProvider,
 	}
 }
@@ -108,69 +116,45 @@ func (a *configGoogleAuthenticator) IsValid(ginCtx *gin.Context) (bool, error) {
 
 	reqCtx := ginCtx.Request.Context()
 
-	a.mutex.Lock()
-	defer a.mutex.Unlock()
-
-	var ok bool
-	var err error
-	var tokenInfo *oauth2.Tokeninfo
-
-	if tokenInfo, ok = a.tokenCache[idToken]; ok && tokenInfo == nil {
-		a.logger.Debug(reqCtx, "token was in cache but invalid")
-
-		return false, fmt.Errorf("token from cache invalidated the user")
-	}
-
-	if tokenInfo, ok = a.tokenCache[idToken]; ok {
-		a.logger.Debug(reqCtx, "idToken was already in cache and valid")
-
-		user := a.getSubjectForToken(tokenInfo)
-		RequestWithSubject(ginCtx, user)
-
-		return true, nil
-	}
-
-	a.logger.WithFields(log.Fields{
-		"id_token": idToken,
-	}).Info(reqCtx, "token not in cache, will perform request")
-
-	tokenInfo, err = a.tokenProvider.GetTokenInfo(idToken)
+	tokenInfo, err := a.tokenCache.ProvideWithError(idToken, func() (oauth2.Tokeninfo, error) {
+		return a.fetchAndValidateToken(reqCtx, idToken)
+	})
 	if err != nil {
-		a.tokenCache[idToken] = nil
-
-		return false, errors.Wrap(err, "google auth: failed requesting token info")
+		return false, err
 	}
 
-	if tokenInfo.HTTPStatusCode > 299 {
-		a.tokenCache[idToken] = nil
-
-		return false, fmt.Errorf("google auth: invalid status code %d", tokenInfo.HTTPStatusCode)
-	}
-
-	if !slices.Contains(a.validAudiences, tokenInfo.Audience) {
-		a.tokenCache[idToken] = nil
-
-		return false, fmt.Errorf("google auth: invalid audience")
-	}
-
-	if ok, err = a.isAddressAllowed(tokenInfo.Email); err != nil {
-		a.tokenCache[idToken] = nil
-
-		return false, fmt.Errorf("google auth: can not check if address is allowed")
-	}
-
-	if !ok {
-		a.tokenCache[idToken] = nil
-
-		return false, fmt.Errorf("google auth: address %s is not allowed", tokenInfo.Email)
-	}
-
-	a.tokenCache[idToken] = tokenInfo
-
-	user := a.getSubjectForToken(tokenInfo)
+	user := a.getSubjectForToken(&tokenInfo)
 	RequestWithSubject(ginCtx, user)
 
 	return true, nil
+}
+
+func (a *configGoogleAuthenticator) fetchAndValidateToken(ctx context.Context, idToken string) (oauth2.Tokeninfo, error) {
+	a.logger.Info(ctx, "token not in cache, will perform request")
+
+	tokenInfo, err := a.tokenProvider.GetTokenInfo(idToken)
+	if err != nil {
+		return oauth2.Tokeninfo{}, errors.Wrap(err, "google auth: failed requesting token info")
+	}
+
+	if tokenInfo.HTTPStatusCode > 299 {
+		return oauth2.Tokeninfo{}, fmt.Errorf("google auth: invalid status code %d", tokenInfo.HTTPStatusCode)
+	}
+
+	if !slices.Contains(a.validAudiences, tokenInfo.Audience) {
+		return oauth2.Tokeninfo{}, fmt.Errorf("google auth: invalid audience")
+	}
+
+	ok, err := a.isAddressAllowed(tokenInfo.Email)
+	if err != nil {
+		return oauth2.Tokeninfo{}, fmt.Errorf("google auth: can not check if address is allowed")
+	}
+
+	if !ok {
+		return oauth2.Tokeninfo{}, fmt.Errorf("google auth: address %s is not allowed", tokenInfo.Email)
+	}
+
+	return *tokenInfo, nil
 }
 
 func (a *configGoogleAuthenticator) isAddressAllowed(address string) (bool, error) {

--- a/pkg/httpserver/auth/config_google_test.go
+++ b/pkg/httpserver/auth/config_google_test.go
@@ -109,14 +109,14 @@ func TestAuthGoogle_Authenticate_IdTokenInvalidEmailSuffixError(t *testing.T) {
 		},
 	}
 
-	tokenProvider.EXPECT().GetTokenInfo("test").Return(tokenInfo, nil)
+	tokenProvider.EXPECT().GetTokenInfo("test").Return(tokenInfo, nil).Times(2)
 	a := auth.NewConfigGoogleAuthenticatorWithInterfaces(logger, tokenProvider, []string{"c.de"}, []string{"^.*c\\.de$"})
 
 	_, err := a.IsValid(ginCtx)
 	assert.EqualError(t, err, "google auth: address a.b@c.be is not allowed")
 
 	_, err = a.IsValid(ginCtx)
-	assert.EqualError(t, err, "token from cache invalidated the user")
+	assert.EqualError(t, err, "google auth: address a.b@c.be is not allowed")
 }
 
 func TestAuthGoogle_Authenticate_IdTokenValid(t *testing.T) {
@@ -231,4 +231,37 @@ func TestAuthGoogle_EmailPattern_AnchoredAllowsExactMatch(t *testing.T) {
 	ok, err := a.IsValid(getGinCtx("tok2"))
 	assert.True(t, ok)
 	assert.NoError(t, err)
+}
+
+// TestAuthGoogle_ValidTokenCachedForSubsequentRequests verifies that a
+// successfully validated token is served from cache on the next request,
+// so the expensive token-info RPC is performed only once.
+func TestAuthGoogle_ValidTokenCachedForSubsequentRequests(t *testing.T) {
+	logger, tokenProvider, _ := getMocks(t, "")
+
+	tokenInfo := &oauth2.Tokeninfo{
+		Audience: "client-id",
+		Email:    "user@example.com",
+		ServerResponse: googleapi.ServerResponse{
+			HTTPStatusCode: http.StatusOK,
+		},
+	}
+
+	// GetTokenInfo must be called exactly once even though IsValid is called twice.
+	tokenProvider.EXPECT().GetTokenInfo("mytoken").Return(tokenInfo, nil).Once()
+
+	a := auth.NewConfigGoogleAuthenticatorWithInterfaces(
+		logger,
+		tokenProvider,
+		[]string{"client-id"},
+		[]string{`.*@example\.com`},
+	)
+
+	ok1, err1 := a.IsValid(getGinCtx("mytoken"))
+	assert.True(t, ok1)
+	assert.NoError(t, err1)
+
+	ok2, err2 := a.IsValid(getGinCtx("mytoken"))
+	assert.True(t, ok2)
+	assert.NoError(t, err2)
 }


### PR DESCRIPTION
The in-memory Google OAuth2 token cache now expires entries after 5 minutes and refuses to store new entries once the cache holds 10 000 tokens. Tokens that fail audience or address validation are no longer cached, eliminating the permanent-rejection behaviour that occurred after transient lookup failures.