### PR TITLE
httpserver/sql: restrict IS and IS NOT operators to NULL values

### DIFF
--- a/pkg/httpserver/sql/query_builder.go
+++ b/pkg/httpserver/sql/query_builder.go
@@ -310,6 +310,18 @@ func (qb baseQueryBuilder) buildFilterValues(match FilterMatch) (where string, a
 	return where, args, nil
 }
 
+// isNullValue reports whether v represents a SQL NULL — either a Go nil or the
+// case-insensitive string "null" (as sent by some HTTP clients and query params).
+func isNullValue(v any) bool {
+	if v == nil {
+		return true
+	}
+
+	s, ok := v.(string)
+
+	return ok && strings.EqualFold(s, "null")
+}
+
 func (qb baseQueryBuilder) buildFilterColumn(match FilterMatch, column db_repo.FieldMappingColumn) (where string, args []any, err error) {
 	if (match.Operator == OpEq || match.Operator == OpNeq) && len(match.Values) > 1 {
 		where, args := qb.buildSetFilterColumn(match, column)
@@ -325,10 +337,18 @@ func (qb baseQueryBuilder) buildFilterColumn(match FilterMatch, column db_repo.F
 	for _, v := range match.Values {
 		switch {
 		case strings.EqualFold(OpIs, match.Operator):
-			stmts = append(stmts, fmt.Sprintf("%s IS %s", column.Name(), v))
+			if !isNullValue(v) {
+				return "", nil, fmt.Errorf("IS operator only supports NULL, got %q", v)
+			}
+
+			stmts = append(stmts, fmt.Sprintf("%s IS NULL", column.Name()))
 
 		case strings.EqualFold(OpIsNot, match.Operator):
-			stmts = append(stmts, fmt.Sprintf("%s IS NOT %s", column.Name(), v))
+			if !isNullValue(v) {
+				return "", nil, fmt.Errorf("IS NOT operator only supports NULL, got %q", v)
+			}
+
+			stmts = append(stmts, fmt.Sprintf("%s IS NOT NULL", column.Name()))
 
 		case match.Operator == OpLike:
 			stmts = append(stmts, fmt.Sprintf("%s LIKE ?", column.Name()))
@@ -375,9 +395,7 @@ func (qb baseQueryBuilder) buildFilterColumn(match FilterMatch, column db_repo.F
 			match.Operator == OpLt ||
 			match.Operator == OpGt ||
 			match.Operator == OpLte ||
-			match.Operator == OpGte ||
-			strings.EqualFold(match.Operator, OpIs) ||
-			strings.EqualFold(match.Operator, OpIsNot):
+			match.Operator == OpGte:
 			stmts = append(stmts, fmt.Sprintf("%s %s ?", column.Name(), match.Operator))
 			args = append(args, v)
 

--- a/pkg/httpserver/sql/query_builder_test.go
+++ b/pkg/httpserver/sql/query_builder_test.go
@@ -210,7 +210,7 @@ func TestListQueryBuilder_Build_ComplexFilter(t *testing.T) {
 	expected := db_repo.NewQueryBuilder()
 	expected.Table("tablename")
 	expected.Where(
-		"(((foo IN (?,?))) AND ((fieldA != ?)) AND ((void IS null)) AND (((fieldB LIKE ?)) OR ((fieldB = ?))))",
+		"(((foo IN (?,?))) AND ((fieldA != ?)) AND ((void IS NULL)) AND (((fieldB LIKE ?)) OR ((fieldB = ?))))",
 		"blub",
 		"blubber",
 		1,
@@ -471,4 +471,260 @@ func TestListQueryBuilder_BuildSqlInjectionOperator(t *testing.T) {
 		`can not build filter: error building filter for column foo: invalid operator "IN (SELECT username FROM admins WHERE id = 42) AND 1 ="`,
 	)
 	assert.Equal(t, db_repo.NewQueryBuilder(), qb)
+}
+
+func TestListQueryBuilder_IsOperator_NullValueProducesIsNull(t *testing.T) {
+	metadata := db_repo.Metadata{
+		TableName:  "items",
+		PrimaryKey: "id",
+		Mappings: db_repo.FieldMappings{
+			"id":    db_repo.NewFieldMapping("id"),
+			"field": db_repo.NewFieldMapping("field"),
+		},
+	}
+	inp := &sql.Input{
+		Filter: sql.Filter{
+			Matches: []sql.FilterMatch{
+				{Dimension: "field", Operator: "IS", Values: []any{"NULL"}},
+			},
+			Bool: sql.BoolAnd,
+		},
+		Order:   []sql.Order{},
+		GroupBy: []string{},
+	}
+
+	lqb := sql.NewOrmQueryBuilder(metadata)
+	qb, err := lqb.Build(inp)
+
+	assert.NoError(t, err)
+	expected := db_repo.NewQueryBuilder()
+	expected.Table("items")
+	expected.Where("(((field IS NULL)))", []any{}...)
+	expected.GroupBy("id")
+	assert.Equal(t, expected, qb)
+}
+
+func TestListQueryBuilder_IsOperator_NonNullValueReturnsError(t *testing.T) {
+	metadata := db_repo.Metadata{
+		TableName:  "items",
+		PrimaryKey: "id",
+		Mappings: db_repo.FieldMappings{
+			"id":    db_repo.NewFieldMapping("id"),
+			"field": db_repo.NewFieldMapping("field"),
+		},
+	}
+	inp := &sql.Input{
+		Filter: sql.Filter{
+			Matches: []sql.FilterMatch{
+				{Dimension: "field", Operator: "IS", Values: []any{"somevalue"}},
+			},
+			Bool: sql.BoolAnd,
+		},
+		Order:   []sql.Order{},
+		GroupBy: []string{},
+	}
+
+	lqb := sql.NewOrmQueryBuilder(metadata)
+	_, err := lqb.Build(inp)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "IS operator only supports NULL")
+}
+
+func TestListQueryBuilder_IsNotOperator_NullValueProducesIsNotNull(t *testing.T) {
+	metadata := db_repo.Metadata{
+		TableName:  "items",
+		PrimaryKey: "id",
+		Mappings: db_repo.FieldMappings{
+			"id":    db_repo.NewFieldMapping("id"),
+			"field": db_repo.NewFieldMapping("field"),
+		},
+	}
+	inp := &sql.Input{
+		Filter: sql.Filter{
+			Matches: []sql.FilterMatch{
+				{Dimension: "field", Operator: "IS NOT", Values: []any{"null"}},
+			},
+			Bool: sql.BoolAnd,
+		},
+		Order:   []sql.Order{},
+		GroupBy: []string{},
+	}
+
+	lqb := sql.NewOrmQueryBuilder(metadata)
+	qb, err := lqb.Build(inp)
+
+	assert.NoError(t, err)
+	expected := db_repo.NewQueryBuilder()
+	expected.Table("items")
+	expected.Where("(((field IS NOT NULL)))", []any{}...)
+	expected.GroupBy("id")
+	assert.Equal(t, expected, qb)
+}
+
+func TestListQueryBuilder_IsNotOperator_NonNullValueReturnsError(t *testing.T) {
+	metadata := db_repo.Metadata{
+		TableName:  "items",
+		PrimaryKey: "id",
+		Mappings: db_repo.FieldMappings{
+			"id":    db_repo.NewFieldMapping("id"),
+			"field": db_repo.NewFieldMapping("field"),
+		},
+	}
+	inp := &sql.Input{
+		Filter: sql.Filter{
+			Matches: []sql.FilterMatch{
+				{Dimension: "field", Operator: "IS NOT", Values: []any{"1234"}},
+			},
+			Bool: sql.BoolAnd,
+		},
+		Order:   []sql.Order{},
+		GroupBy: []string{},
+	}
+
+	lqb := sql.NewOrmQueryBuilder(metadata)
+	_, err := lqb.Build(inp)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "IS NOT operator only supports NULL")
+}
+
+func TestListQueryBuilder_IsOperator_NullValueCaseInsensitive(t *testing.T) {
+	metadata := db_repo.Metadata{
+		TableName:  "items",
+		PrimaryKey: "id",
+		Mappings: db_repo.FieldMappings{
+			"id":    db_repo.NewFieldMapping("id"),
+			"field": db_repo.NewFieldMapping("field"),
+		},
+	}
+
+	for _, nullVariant := range []string{"null", "NULL", "Null", "nUlL", "NuLl"} {
+		nullVariant := nullVariant
+		t.Run(nullVariant, func(t *testing.T) {
+			inp := &sql.Input{
+				Filter: sql.Filter{
+					Matches: []sql.FilterMatch{
+						{Dimension: "field", Operator: "IS", Values: []any{nullVariant}},
+					},
+					Bool: sql.BoolAnd,
+				},
+				Order:   []sql.Order{},
+				GroupBy: []string{},
+			}
+
+			lqb := sql.NewOrmQueryBuilder(metadata)
+			qb, err := lqb.Build(inp)
+
+			assert.NoError(t, err, "IS operator must accept %q as NULL", nullVariant)
+			expected := db_repo.NewQueryBuilder()
+			expected.Table("items")
+			expected.Where("(((field IS NULL)))", []any{}...)
+			expected.GroupBy("id")
+			assert.Equal(t, expected, qb)
+		})
+	}
+}
+
+func TestListQueryBuilder_IsNotOperator_NullValueCaseInsensitive(t *testing.T) {
+	metadata := db_repo.Metadata{
+		TableName:  "items",
+		PrimaryKey: "id",
+		Mappings: db_repo.FieldMappings{
+			"id":    db_repo.NewFieldMapping("id"),
+			"field": db_repo.NewFieldMapping("field"),
+		},
+	}
+
+	for _, nullVariant := range []string{"null", "NULL", "Null", "nUlL", "NuLl"} {
+		nullVariant := nullVariant
+		t.Run(nullVariant, func(t *testing.T) {
+			inp := &sql.Input{
+				Filter: sql.Filter{
+					Matches: []sql.FilterMatch{
+						{Dimension: "field", Operator: "IS NOT", Values: []any{nullVariant}},
+					},
+					Bool: sql.BoolAnd,
+				},
+				Order:   []sql.Order{},
+				GroupBy: []string{},
+			}
+
+			lqb := sql.NewOrmQueryBuilder(metadata)
+			qb, err := lqb.Build(inp)
+
+			assert.NoError(t, err, "IS NOT operator must accept %q as NULL", nullVariant)
+			expected := db_repo.NewQueryBuilder()
+			expected.Table("items")
+			expected.Where("(((field IS NOT NULL)))", []any{}...)
+			expected.GroupBy("id")
+			assert.Equal(t, expected, qb)
+		})
+	}
+}
+
+func TestListQueryBuilder_IsOperator_NilValueProducesIsNull(t *testing.T) {
+	metadata := db_repo.Metadata{
+		TableName:  "items",
+		PrimaryKey: "id",
+		Mappings: db_repo.FieldMappings{
+			"id":    db_repo.NewFieldMapping("id"),
+			"field": db_repo.NewFieldMapping("field"),
+		},
+	}
+
+	inp := &sql.Input{
+		Filter: sql.Filter{
+			Matches: []sql.FilterMatch{
+				{Dimension: "field", Operator: "IS", Values: []any{nil}},
+			},
+			Bool: sql.BoolAnd,
+		},
+		Order:   []sql.Order{},
+		GroupBy: []string{},
+	}
+
+	lqb := sql.NewOrmQueryBuilder(metadata)
+	qb, err := lqb.Build(inp)
+
+	assert.NoError(t, err)
+
+	expected := db_repo.NewQueryBuilder()
+	expected.Table("items")
+	expected.Where("(((field IS NULL)))", []any{}...)
+	expected.GroupBy("id")
+	assert.Equal(t, expected, qb)
+}
+
+func TestListQueryBuilder_IsNotOperator_NilValueProducesIsNotNull(t *testing.T) {
+	metadata := db_repo.Metadata{
+		TableName:  "items",
+		PrimaryKey: "id",
+		Mappings: db_repo.FieldMappings{
+			"id":    db_repo.NewFieldMapping("id"),
+			"field": db_repo.NewFieldMapping("field"),
+		},
+	}
+
+	inp := &sql.Input{
+		Filter: sql.Filter{
+			Matches: []sql.FilterMatch{
+				{Dimension: "field", Operator: "IS NOT", Values: []any{nil}},
+			},
+			Bool: sql.BoolAnd,
+		},
+		Order:   []sql.Order{},
+		GroupBy: []string{},
+	}
+
+	lqb := sql.NewOrmQueryBuilder(metadata)
+	qb, err := lqb.Build(inp)
+
+	assert.NoError(t, err)
+
+	expected := db_repo.NewQueryBuilder()
+	expected.Table("items")
+	expected.Where("(((field IS NOT NULL)))", []any{}...)
+	expected.GroupBy("id")
+	assert.Equal(t, expected, qb)
 }


### PR DESCRIPTION
The IS and IS NOT filter operators in the SQL query builder now validate that the provided value is exactly NULL (case-insensitive). Any other value returns an error. This makes the intended IS NULL / IS NOT NULL semantics explicit and removes the implicit string interpolation.