### PR TITLE
metric: hold read lock when accessing metric defaults map

### DIFF
--- a/pkg/metric/daemon.go
+++ b/pkg/metric/daemon.go
@@ -127,9 +127,11 @@ func (d *Daemon) Run(ctx context.Context) error {
 	d.resetBatch(ctx)
 
 	// initialize the default metrics upon daemon module Run for raw writers
-	metricDefaultsLock.Lock()
-	d.rawFanout(ctx, funk.Values(metricDefaults))
-	metricDefaultsLock.Unlock()
+	metricDefaultsLock.RLock()
+	defaults := funk.Values(metricDefaults)
+	metricDefaultsLock.RUnlock()
+
+	d.rawFanout(ctx, defaults)
 
 	for {
 		select {
@@ -212,11 +214,17 @@ func (d *Daemon) resetBatch(ctx context.Context) {
 	d.batch = make(map[string]*BatchedMetricDatum)
 	d.dataPointCount = 0
 
+	metricDefaultsLock.RLock()
+	defs := make([]*Datum, 0, len(metricDefaults))
 	for _, def := range metricDefaults {
 		cpy := *def
 		cpy.Timestamp = time.Now()
+		defs = append(defs, &cpy)
+	}
+	metricDefaultsLock.RUnlock()
 
-		d.append(ctx, &cpy)
+	for _, cpy := range defs {
+		d.append(ctx, cpy)
 	}
 }
 

--- a/pkg/metric/defaults.go
+++ b/pkg/metric/defaults.go
@@ -3,7 +3,7 @@ package metric
 import "sync"
 
 var (
-	metricDefaultsLock = sync.Mutex{}
+	metricDefaultsLock sync.RWMutex
 	metricDefaults     = map[string]*Datum{}
 )
 
@@ -18,8 +18,10 @@ func addMetricDefaults(data ...*Datum) {
 }
 
 func amendFromDefault(datum *Datum) {
+	metricDefaultsLock.RLock()
 	defId := datum.Id()
 	def, ok := metricDefaults[defId]
+	metricDefaultsLock.RUnlock()
 
 	if !ok {
 		return

--- a/pkg/metric/defaults_test.go
+++ b/pkg/metric/defaults_test.go
@@ -1,0 +1,88 @@
+package metric
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestMetricDefaults_ConcurrentReadWrite exercises addMetricDefaults (write lock)
+// and amendFromDefault (read lock) concurrently. The race detector catches any data
+// race, and a deadlock would cause the test to time out.
+func TestMetricDefaults_ConcurrentReadWrite(t *testing.T) {
+	datum := &Datum{
+		MetricName: "test-concurrent-defaults",
+		Priority:   PriorityHigh,
+		Unit:       UnitCount,
+		Kind:       KindGauge.Build(),
+	}
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < 20; i++ {
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			addMetricDefaults(datum)
+		}()
+
+		go func() {
+			defer wg.Done()
+			cpy := *datum
+			amendFromDefault(&cpy)
+		}()
+	}
+
+	wg.Wait()
+
+	// Verify the default was actually registered.
+	metricDefaultsLock.RLock()
+	_, ok := metricDefaults[datum.Id()]
+	metricDefaultsLock.RUnlock()
+
+	assert.True(t, ok, "metric default must be registered after concurrent writes")
+}
+
+// TestAmendFromDefault_PopulatesEmptyFields verifies that amendFromDefault fills
+// in missing Priority, Unit, and Kind from the registered default.
+func TestAmendFromDefault_PopulatesEmptyFields(t *testing.T) {
+	def := &Datum{
+		MetricName: "test-amend-defaults",
+		Priority:   PriorityHigh,
+		Unit:       UnitCount,
+		Kind:       KindGauge.Build(),
+	}
+	addMetricDefaults(def)
+
+	target := &Datum{MetricName: "test-amend-defaults"}
+	amendFromDefault(target)
+
+	assert.Equal(t, PriorityHigh, target.Priority)
+	assert.Equal(t, UnitCount, target.Unit)
+	assert.Equal(t, KindGauge.Build(), target.Kind)
+}
+
+// TestAmendFromDefault_DoesNotOverwriteExistingFields verifies that non-zero
+// fields on the incoming datum are preserved and not replaced by defaults.
+func TestAmendFromDefault_DoesNotOverwriteExistingFields(t *testing.T) {
+	def := &Datum{
+		MetricName: "test-amend-no-overwrite",
+		Priority:   PriorityHigh,
+		Unit:       UnitCount,
+		Kind:       KindGauge.Build(),
+	}
+	addMetricDefaults(def)
+
+	target := &Datum{
+		MetricName: "test-amend-no-overwrite",
+		Priority:   PriorityLow,
+		Unit:       UnitMilliseconds,
+	}
+	amendFromDefault(target)
+
+	// Fields already set must not be overwritten.
+	assert.Equal(t, PriorityLow, target.Priority)
+	assert.Equal(t, UnitMilliseconds, target.Unit)
+}


### PR DESCRIPTION
Converts metricDefaultsLock from sync.Mutex to sync.RWMutex. amendFromDefault and the defaults iteration in resetBatch now acquire a read lock before accessing the map, while addMetricDefaults continues to use the exclusive write lock. Multiple readers can now proceed concurrently.