### PR TITLE
httpserver: return generic message for 5xx responses

### DIFF
--- a/pkg/httpserver/crud/patch_test.go
+++ b/pkg/httpserver/crud/patch_test.go
@@ -151,8 +151,7 @@ func (s *patchTestSuite) TestPatch_UnmarshalPatchedModel() {
 	response := httpserver.HttpTest("PATCH", "/:id", "/1", `{"name":123}`, s.patchHandler)
 
 	s.Equal(http.StatusInternalServerError, response.Code)
-	s.Contains(response.Body.String(), `failed to unmarshal patched model`)
-	s.Contains(response.Body.String(), `cannot unmarshal number`)
+	s.JSONEq(`{"err":"internal server error"}`, response.Body.String())
 }
 
 func (s *patchTestSuite) TestPatch_InvalidBody() {

--- a/pkg/httpserver/error.go
+++ b/pkg/httpserver/error.go
@@ -8,10 +8,15 @@ import (
 type ErrorHandler func(statusCode int, err error) *Response
 
 func errorHandlerJson(statusCode int, err error) *Response {
+	body := gin.H{"err": err.Error()}
+	if statusCode >= 500 {
+		body = gin.H{"err": "internal server error"}
+	}
+
 	return &Response{
 		StatusCode:  statusCode,
 		ContentType: mdl.Box(ContentTypeJson),
-		Body:        gin.H{"err": err.Error()},
+		Body:        body,
 	}
 }
 

--- a/pkg/httpserver/error_test.go
+++ b/pkg/httpserver/error_test.go
@@ -1,0 +1,65 @@
+package httpserver_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/justtrackio/gosoline/pkg/httpserver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// marshalBody marshals resp.Body to JSON and returns it as a string so we can
+// compare without depending on the concrete map type returned by gin.H.
+func marshalBody(t *testing.T, resp *httpserver.Response) string {
+	t.Helper()
+	b, err := json.Marshal(resp.Body)
+	require.NoError(t, err)
+
+	return string(b)
+}
+
+func TestErrorHandlerJson_5xxReturnsGenericMessage(t *testing.T) {
+	handler := httpserver.GetErrorHandler()
+	resp := handler(http.StatusInternalServerError, fmt.Errorf("super secret internal detail"))
+
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	assert.JSONEq(t, `{"err":"internal server error"}`, marshalBody(t, resp),
+		"500 must not expose the real error message")
+}
+
+func TestErrorHandlerJson_503ReturnsGenericMessage(t *testing.T) {
+	handler := httpserver.GetErrorHandler()
+	resp := handler(http.StatusServiceUnavailable, fmt.Errorf("db connection pool exhausted"))
+
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	assert.JSONEq(t, `{"err":"internal server error"}`, marshalBody(t, resp),
+		"503 must not expose the real error message")
+}
+
+func TestErrorHandlerJson_4xxExposesActualError(t *testing.T) {
+	handler := httpserver.GetErrorHandler()
+	resp := handler(http.StatusBadRequest, fmt.Errorf("validation failed: missing field"))
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.JSONEq(t, `{"err":"validation failed: missing field"}`, marshalBody(t, resp),
+		"4xx must expose the actual error message")
+}
+
+func TestErrorHandlerJson_404ExposesActualError(t *testing.T) {
+	handler := httpserver.GetErrorHandler()
+	resp := handler(http.StatusNotFound, fmt.Errorf("resource not found"))
+
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.JSONEq(t, `{"err":"resource not found"}`, marshalBody(t, resp))
+}
+
+func TestErrorHandlerJson_499ClientCancelExposesActualError(t *testing.T) {
+	// 499 is used for client-cancelled requests; it is < 500 so the real message is shown.
+	handler := httpserver.GetErrorHandler()
+	resp := handler(499, fmt.Errorf("context canceled"))
+
+	assert.JSONEq(t, `{"err":"context canceled"}`, marshalBody(t, resp))
+}

--- a/pkg/httpserver/health_check.go
+++ b/pkg/httpserver/health_check.go
@@ -104,16 +104,12 @@ func buildHealthCheckHandler(logger log.Logger, healthChecker kernel.HealthCheck
 
 		if result.Err() != nil {
 			ctx := c.Request.Context()
-			logger.Error(ctx, "encountered an error during the health check: %", result.Err())
+			logger.Error(ctx, "encountered an error during the health check: %w", result.Err())
 		}
 
 		resp := gin.H{}
 		for _, module := range result.GetUnhealthy() {
-			if module.Err != nil {
-				resp[module.Name] = module.Err.Error()
-			} else {
-				resp[module.Name] = "unhealthy"
-			}
+			resp[module.Name] = "unhealthy"
 		}
 
 		c.JSON(http.StatusInternalServerError, resp)


### PR DESCRIPTION
The default JSON error handler now returns the static string "internal server error" for 5xx status codes instead of the raw error message, which may contain internal implementation details. The health-check endpoint similarly returns "unhealthy" for all failed module checks.