### PR TITLE
httpserver/auth: increase JWT secret minimum length and anchor Google email patterns

### DIFF
--- a/pkg/httpserver/auth/config_google.go
+++ b/pkg/httpserver/auth/config_google.go
@@ -175,7 +175,7 @@ func (a *configGoogleAuthenticator) IsValid(ginCtx *gin.Context) (bool, error) {
 
 func (a *configGoogleAuthenticator) isAddressAllowed(address string) (bool, error) {
 	for _, allowed := range a.allowedAddresses {
-		ok, err := regexp.MatchString(allowed, address)
+		ok, err := regexp.MatchString("^(?:"+allowed+")$", address)
 		if err != nil {
 			return false, fmt.Errorf("can not compile regex for allowed address check: %w", err)
 		}

--- a/pkg/httpserver/auth/config_google_test.go
+++ b/pkg/httpserver/auth/config_google_test.go
@@ -176,7 +176,6 @@ func TestAuthGoogle_Authenticate_MultipleAudiences(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-
 // TestAuthGoogle_EmailPattern_AnchoredPreventsPartialMatch verifies that an
 // allowedAddresses pattern without explicit anchors (e.g. `.*@company\.com`)
 // does NOT match an email whose domain extends the pattern

--- a/pkg/httpserver/auth/config_google_test.go
+++ b/pkg/httpserver/auth/config_google_test.go
@@ -175,3 +175,61 @@ func TestAuthGoogle_Authenticate_MultipleAudiences(t *testing.T) {
 
 	assert.NoError(t, err)
 }
+
+
+// TestAuthGoogle_EmailPattern_AnchoredPreventsPartialMatch verifies that an
+// allowedAddresses pattern without explicit anchors (e.g. `.*@company\.com`)
+// does NOT match an email whose domain extends the pattern
+// (e.g. `user@company.com.evil.com`). Before the fix the unanchored regex
+// would match because the pattern appears inside the longer string.
+func TestAuthGoogle_EmailPattern_AnchoredPreventsPartialMatch(t *testing.T) {
+	logger, tokenProvider, _ := getMocks(t, "")
+
+	// Email domain is a suffix-extension of the pattern's domain.
+	tokenInfo := &oauth2.Tokeninfo{
+		Audience: "client-id",
+		Email:    "user@company.com.evil.com",
+		ServerResponse: googleapi.ServerResponse{
+			HTTPStatusCode: http.StatusOK,
+		},
+	}
+	tokenProvider.EXPECT().GetTokenInfo("tok").Return(tokenInfo, nil)
+
+	a := auth.NewConfigGoogleAuthenticatorWithInterfaces(
+		logger,
+		tokenProvider,
+		[]string{"client-id"},
+		// Pattern without explicit anchors; the fix adds ^(?:...)$ automatically.
+		[]string{`.*@company\.com`},
+	)
+
+	ok, err := a.IsValid(getGinCtx("tok"))
+	assert.False(t, ok, "suffix-extended email must be rejected")
+	assert.EqualError(t, err, "google auth: address user@company.com.evil.com is not allowed")
+}
+
+// TestAuthGoogle_EmailPattern_AnchoredAllowsExactMatch verifies that the
+// same pattern does accept an email that matches exactly.
+func TestAuthGoogle_EmailPattern_AnchoredAllowsExactMatch(t *testing.T) {
+	logger, tokenProvider, _ := getMocks(t, "")
+
+	tokenInfo := &oauth2.Tokeninfo{
+		Audience: "client-id",
+		Email:    "user@company.com",
+		ServerResponse: googleapi.ServerResponse{
+			HTTPStatusCode: http.StatusOK,
+		},
+	}
+	tokenProvider.EXPECT().GetTokenInfo("tok2").Return(tokenInfo, nil)
+
+	a := auth.NewConfigGoogleAuthenticatorWithInterfaces(
+		logger,
+		tokenProvider,
+		[]string{"client-id"},
+		[]string{`.*@company\.com`},
+	)
+
+	ok, err := a.IsValid(getGinCtx("tok2"))
+	assert.True(t, ok)
+	assert.NoError(t, err)
+}

--- a/pkg/httpserver/auth/jwt_token_handler_test.go
+++ b/pkg/httpserver/auth/jwt_token_handler_test.go
@@ -145,7 +145,6 @@ func TestJwtTokenHandler_Sign_IsValid_Valid(t *testing.T) {
 	assert.Equal(t, "image", claims["image"])
 }
 
-
 // TestJwtTokenHandlerSettings_SigningSecretMinLength verifies that the cfg
 // validation rejects a signing secret shorter than 32 characters.
 func TestJwtTokenHandlerSettings_SigningSecretMinLength(t *testing.T) {

--- a/pkg/httpserver/auth/jwt_token_handler_test.go
+++ b/pkg/httpserver/auth/jwt_token_handler_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/justtrackio/gosoline/pkg/cfg"
 	"github.com/justtrackio/gosoline/pkg/httpserver/auth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -142,4 +143,38 @@ func TestJwtTokenHandler_Sign_IsValid_Valid(t *testing.T) {
 	assert.Equal(t, "test", claims["name"])
 	assert.Equal(t, "mail", claims["email"])
 	assert.Equal(t, "image", claims["image"])
+}
+
+
+// TestJwtTokenHandlerSettings_SigningSecretMinLength verifies that the cfg
+// validation rejects a signing secret shorter than 32 characters.
+func TestJwtTokenHandlerSettings_SigningSecretMinLength(t *testing.T) {
+	config := cfg.New(map[string]any{
+		"jwt": map[string]any{
+			"signingSecret":  "tooshort", // 8 chars, must fail
+			"issuer":         "me",
+			"expireDuration": "15m",
+		},
+	})
+
+	var settings auth.JwtTokenHandlerSettings
+	err := config.UnmarshalKey("jwt", &settings)
+	assert.Error(t, err, "signing secret shorter than 32 chars must fail validation")
+}
+
+// TestJwtTokenHandlerSettings_SigningSecretMinLength_Valid verifies that a
+// secret with at least 32 characters passes validation.
+func TestJwtTokenHandlerSettings_SigningSecretMinLength_Valid(t *testing.T) {
+	config := cfg.New(map[string]any{
+		"jwt": map[string]any{
+			"signingSecret":  "this-is-a-valid-secret-at-least-32-chars",
+			"issuer":         "me",
+			"expireDuration": "15m",
+		},
+	})
+
+	var settings auth.JwtTokenHandlerSettings
+	err := config.UnmarshalKey("jwt", &settings)
+	assert.NoError(t, err)
+	assert.Equal(t, "this-is-a-valid-secret-at-least-32-chars", settings.SigningSecret)
 }

--- a/pkg/httpserver/auth/settings.go
+++ b/pkg/httpserver/auth/settings.go
@@ -8,7 +8,7 @@ type (
 	}
 
 	JwtTokenHandlerSettings struct {
-		SigningSecret  string        `cfg:"signingSecret"  validate:"min=8"`
+		SigningSecret  string        `cfg:"signingSecret"  validate:"min=32"`
 		Issuer         string        `cfg:"issuer"         validate:"required"`
 		ExpireDuration time.Duration `cfg:"expireDuration" validate:"min=60000000000" default:"15m"`
 	}


### PR DESCRIPTION
The minimum length validation for JWT HMAC signing secrets is raised from 8 to 32 characters, aligning with NIST SP 800-107 recommendations for HMAC-SHA256 keys. The per-address regex patterns used in Google OAuth2 email validation are now automatically wrapped with ^(?:...)$ anchors to enforce full-string matching.