### PR TITLE
mdlsub: fix output db causes panic on update;

### DIFF
--- a/pkg/mdlsub/output_db.go
+++ b/pkg/mdlsub/output_db.go
@@ -3,6 +3,7 @@ package mdlsub
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	"github.com/jinzhu/gorm"
 	"github.com/justtrackio/gosoline/pkg/cfg"
@@ -49,16 +50,34 @@ func NewOutputDb(ctx context.Context, config cfg.Config, logger log.Logger) (*Ou
 }
 
 func (p *OutputDb) Persist(_ context.Context, model Model, op string) error {
-	var err error
+	addressableModel, err := ensureAddressableModel(model)
+	if err != nil {
+		return err
+	}
 
 	switch op {
 	case db_repo.Create, db_repo.Update:
-		err = p.orm.Save(model).Error
+		err = p.orm.Save(addressableModel).Error
 	case db_repo.Delete:
-		err = p.orm.Delete(model).Error
+		err = p.orm.Delete(addressableModel).Error
 	default:
 		err = fmt.Errorf("unknown operation %s in OutputDb", op)
 	}
 
 	return err
+}
+
+func ensureAddressableModel(model Model) (any, error) {
+	value := reflect.ValueOf(model)
+	if !value.IsValid() {
+		return nil, fmt.Errorf("model must not be nil")
+	}
+	if value.Kind() == reflect.Ptr {
+		return nil, fmt.Errorf("model must not be a pointer")
+	}
+
+	pointer := reflect.New(value.Type())
+	pointer.Elem().Set(value)
+
+	return pointer.Interface(), nil
 }

--- a/pkg/mdlsub/output_db_test.go
+++ b/pkg/mdlsub/output_db_test.go
@@ -1,0 +1,70 @@
+package mdlsub
+
+import (
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/justtrackio/gosoline/pkg/db-repo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type outputDbTestModel struct {
+	Id   uint `gorm:"primary_key"`
+	Name string
+}
+
+func (m outputDbTestModel) GetId() any {
+	return m.Id
+}
+
+func (m outputDbTestModel) TableName() string {
+	return "output_db_test_models"
+}
+
+func TestOutputDbPersistUpdateWithNoRowsAffectedDoesNotPanic(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+
+	orm, err := db_repo.NewOrmWithInterfaces(db, db_repo.OrmSettings{
+		Driver: "mysql",
+	})
+	require.NoError(t, err)
+
+	output := &OutputDb{
+		orm: orm,
+	}
+	model := outputDbTestModel{
+		Id:   1,
+		Name: "test",
+	}
+
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE `output_db_test_models` SET `name` = \\? WHERE `output_db_test_models`\\.`id` = \\?").
+		WithArgs("test", 1).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+	mock.ExpectQuery("SELECT \\* FROM `output_db_test_models` WHERE `output_db_test_models`\\.`id` = \\? ORDER BY `output_db_test_models`\\.`id` ASC LIMIT 1").
+		WithArgs(1).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name"}).AddRow(1, "test"))
+	mock.ExpectClose()
+
+	assert.NotPanics(t, func() {
+		err = output.Persist(t.Context(), model, db_repo.Update)
+	})
+	assert.NoError(t, err)
+	assert.NoError(t, db.Close())
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestOutputDbPersistWithPointerModelReturnsError(t *testing.T) {
+	output := &OutputDb{}
+	err := output.Persist(t.Context(), &outputDbTestModel{Id: 1, Name: "test"}, db_repo.Update)
+	assert.EqualError(t, err, "model must not be a pointer")
+}
+
+func TestOutputDbPersistWithNilModelReturnsError(t *testing.T) {
+	output := &OutputDb{}
+	err := output.Persist(t.Context(), nil, db_repo.Update)
+	assert.EqualError(t, err, "model must not be nil")
+}


### PR DESCRIPTION
pkg/mdlsub/transformer.go currently defines TypedTransformer.Transform as returning *M, then untypedTransformer.transform dereferences it before persistence. 

OutputDb.Persist then calls gorm.Save with a non-pointer model which causes gorm to panic on an update in the case where no rows are affected.

So, this change ensure that the model we pass to gorm.Save is addressable.

