### PR TITLE
httpserver: added new HttpRejectedRequests metric showing the number of requests rejected because the server was overloaded;

### DIFF
--- a/pkg/db/lifecycle.go
+++ b/pkg/db/lifecycle.go
@@ -55,12 +55,12 @@ func (m *lifecycleManager) GetId() string {
 	return fmt.Sprintf("db/%s", m.settings.Uri.Database)
 }
 
-func (l *lifecycleManager) Register(ctx context.Context) (key string, metadata any, err error) {
+func (m *lifecycleManager) Register(_ context.Context) (key string, metadata any, err error) {
 	metadata = Metadata{
-		Name:     l.name,
-		Host:     l.settings.Uri.Host,
-		Port:     l.settings.Uri.Port,
-		Database: l.settings.Uri.Database,
+		Name:     m.name,
+		Host:     m.settings.Uri.Host,
+		Port:     m.settings.Uri.Port,
+		Database: m.settings.Uri.Database,
 	}
 
 	return MetadataKey, metadata, nil

--- a/pkg/httpserver/connection_limit_listener_test.go
+++ b/pkg/httpserver/connection_limit_listener_test.go
@@ -9,167 +9,130 @@ import (
 	"github.com/justtrackio/gosoline/pkg/httpserver"
 	httpserverMocks "github.com/justtrackio/gosoline/pkg/httpserver/mocks"
 	logMocks "github.com/justtrackio/gosoline/pkg/log/mocks"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 )
 
-func TestConnectionLimit_DisabledReturnsOriginalListener(t *testing.T) {
-	listener := httpserverMocks.NewNetListener(t)
-	manager := httpserverMocks.NewConnectionPressureManager(t)
-	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
+type ConnectionLimitListenerTestSuite struct {
+	suite.Suite
 
-	limited := httpserver.NewConnectionLimitListener(
-		t.Context(),
-		logger,
-		listener,
-		httpserver.ConcurrencySettings{},
-		manager,
-	)
-
-	assert.Same(t, listener, limited)
+	listener      *httpserverMocks.NetListener
+	manager       *httpserverMocks.ConnectionPressureManager
+	logger        logMocks.LoggerMock
+	idleAvailable chan struct{}
 }
 
-func TestConnectionLimit_AcceptWaitsUntilConnectionSlotIsReleased(t *testing.T) {
-	listener := httpserverMocks.NewNetListener(t)
-	idleAvailable := make(chan struct{})
-	manager := httpserverMocks.NewConnectionPressureManager(t)
-	manager.EXPECT().CloseOldestIdleConnection().Return(false, nil).Maybe()
-	manager.EXPECT().IdleConnectionAvailable().Return(idleAvailable).Maybe()
-	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
+func TestRunConnectionLimitListenerTestSuite(t *testing.T) {
+	suite.Run(t, new(ConnectionLimitListenerTestSuite))
+}
 
-	limited := httpserver.NewConnectionLimitListener(
-		t.Context(),
-		logger,
-		listener,
-		httpserver.ConcurrencySettings{MaxConnections: 1},
-		manager,
-	)
+func (s *ConnectionLimitListenerTestSuite) SetupTest() {
+	s.listener = httpserverMocks.NewNetListener(s.T())
+	s.manager = httpserverMocks.NewConnectionPressureManager(s.T())
+	s.logger = logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(s.T()))
+	s.idleAvailable = make(chan struct{})
+}
 
-	connA := httpserverMocks.NewNetConn(t)
-	connA.EXPECT().Close().Return(nil).Once()
-	listener.EXPECT().Accept().Return(connA, nil).Once()
+func (s *ConnectionLimitListenerTestSuite) TestDisabledReturnsOriginalListener() {
+	limited := s.newLimited(0)
+
+	s.Same(s.listener, limited)
+}
+
+func (s *ConnectionLimitListenerTestSuite) TestAcceptWaitsUntilConnectionSlotIsReleased() {
+	s.manager.EXPECT().CloseOldestIdleConnection().Return(false, nil).Maybe()
+	s.manager.EXPECT().IdleConnectionAvailable().Return(s.idleAvailable).Maybe()
+
+	limited := s.newLimited(1)
+
+	s.mockAcceptedConn()
 	limitedConnA, err := limited.Accept()
-	require.NoError(t, err)
-	require.NotNil(t, limitedConnA)
+	s.NoError(err)
+	s.NotNil(limitedConnA)
 
 	acceptedSecond := atomic.Bool{}
-	listener.EXPECT().Accept().Return(httpserverMocks.NewNetConn(t), nil).Once()
+	s.listener.EXPECT().Accept().Return(httpserverMocks.NewNetConn(s.T()), nil).Once()
 	go func() {
 		connB, acceptErr := limited.Accept()
-		require.NoError(t, acceptErr)
-		require.NotNil(t, connB)
+		s.NoError(acceptErr)
+		s.NotNil(connB)
 		acceptedSecond.Store(true)
 	}()
 
-	assert.Never(t, acceptedSecond.Load, 20*time.Millisecond, time.Millisecond)
+	s.Never(acceptedSecond.Load, 20*time.Millisecond, time.Millisecond)
 
-	require.NoError(t, limitedConnA.Close())
-	assert.Eventually(t, acceptedSecond.Load, time.Second, time.Millisecond)
+	s.NoError(limitedConnA.Close())
+	s.Eventually(acceptedSecond.Load, time.Second, time.Millisecond)
 }
 
-func TestConnectionLimit_ClosesIdleConnectionBeforeWaiting(t *testing.T) {
-	listener := httpserverMocks.NewNetListener(t)
-	idleAvailable := make(chan struct{})
+func (s *ConnectionLimitListenerTestSuite) TestClosesIdleConnectionBeforeWaiting() {
 	closedIdle := atomic.Bool{}
-	manager := httpserverMocks.NewConnectionPressureManager(t)
-	manager.EXPECT().CloseOldestIdleConnection().Run(func() {
+	s.manager.EXPECT().CloseOldestIdleConnection().Run(func() {
 		closedIdle.Store(true)
 	}).Return(true, nil).Once()
-	manager.EXPECT().CloseOldestIdleConnection().Return(false, nil).Maybe()
-	manager.EXPECT().IdleConnectionAvailable().Return(idleAvailable).Maybe()
-	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
+	s.manager.EXPECT().CloseOldestIdleConnection().Return(false, nil).Maybe()
+	s.manager.EXPECT().IdleConnectionAvailable().Return(s.idleAvailable).Maybe()
 
-	limited := httpserver.NewConnectionLimitListener(
-		t.Context(),
-		logger,
-		listener,
-		httpserver.ConcurrencySettings{MaxConnections: 1},
-		manager,
-	)
+	limited := s.newLimited(1)
 
-	connA := httpserverMocks.NewNetConn(t)
-	connA.EXPECT().Close().Return(nil).Once()
-	listener.EXPECT().Accept().Return(connA, nil).Once()
+	s.mockAcceptedConn()
 	limitedConnA, err := limited.Accept()
-	require.NoError(t, err)
-	require.NotNil(t, limitedConnA)
+	s.NoError(err)
+	s.NotNil(limitedConnA)
 
-	listener.EXPECT().Accept().Return(httpserverMocks.NewNetConn(t), nil).Once()
+	s.listener.EXPECT().Accept().Return(httpserverMocks.NewNetConn(s.T()), nil).Once()
 	acceptedSecond := atomic.Bool{}
 	go func() {
 		connB, acceptErr := limited.Accept()
-		require.NoError(t, acceptErr)
-		require.NotNil(t, connB)
+		s.NoError(acceptErr)
+		s.NotNil(connB)
 		acceptedSecond.Store(true)
 	}()
 
-	assert.Eventually(t, closedIdle.Load, time.Second, time.Millisecond)
-	assert.Never(t, acceptedSecond.Load, 20*time.Millisecond, time.Millisecond)
+	s.Eventually(closedIdle.Load, time.Second, time.Millisecond)
+	s.Never(acceptedSecond.Load, 20*time.Millisecond, time.Millisecond)
 
-	require.NoError(t, limitedConnA.Close())
-	assert.Eventually(t, acceptedSecond.Load, time.Second, time.Millisecond)
+	s.NoError(limitedConnA.Close())
+	s.Eventually(acceptedSecond.Load, time.Second, time.Millisecond)
 }
 
-func TestConnectionLimit_WakesUpWhenIdleConnectionBecomesAvailable(t *testing.T) {
-	listener := httpserverMocks.NewNetListener(t)
-	idleAvailable := make(chan struct{})
-	manager := httpserverMocks.NewConnectionPressureManager(t)
-	manager.EXPECT().CloseOldestIdleConnection().Return(false, nil).Maybe()
-	manager.EXPECT().IdleConnectionAvailable().Return(idleAvailable).Maybe()
-	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
+func (s *ConnectionLimitListenerTestSuite) TestWakesUpWhenIdleConnectionBecomesAvailable() {
+	s.manager.EXPECT().CloseOldestIdleConnection().Return(false, nil).Maybe()
+	s.manager.EXPECT().IdleConnectionAvailable().Return(s.idleAvailable).Maybe()
 
-	limited := httpserver.NewConnectionLimitListener(
-		t.Context(),
-		logger,
-		listener,
-		httpserver.ConcurrencySettings{MaxConnections: 1},
-		manager,
-	)
+	limited := s.newLimited(1)
 
-	connA := httpserverMocks.NewNetConn(t)
-	connA.EXPECT().Close().Return(nil).Once()
-	listener.EXPECT().Accept().Return(connA, nil).Once()
+	s.mockAcceptedConn()
 	limitedConnA, err := limited.Accept()
-	require.NoError(t, err)
-	require.NotNil(t, limitedConnA)
+	s.NoError(err)
+	s.NotNil(limitedConnA)
 
-	listener.EXPECT().Accept().Return(httpserverMocks.NewNetConn(t), nil).Once()
+	s.listener.EXPECT().Accept().Return(httpserverMocks.NewNetConn(s.T()), nil).Once()
 	acceptedSecond := atomic.Bool{}
 	go func() {
 		connB, acceptErr := limited.Accept()
-		require.NoError(t, acceptErr)
-		require.NotNil(t, connB)
+		s.NoError(acceptErr)
+		s.NotNil(connB)
 		acceptedSecond.Store(true)
 	}()
 
-	assert.Never(t, acceptedSecond.Load, 20*time.Millisecond, time.Millisecond)
+	s.Never(acceptedSecond.Load, 20*time.Millisecond, time.Millisecond)
 
-	require.NoError(t, limitedConnA.Close())
-	close(idleAvailable)
-	assert.Eventually(t, acceptedSecond.Load, time.Second, time.Millisecond)
+	s.NoError(limitedConnA.Close())
+	close(s.idleAvailable)
+	s.Eventually(acceptedSecond.Load, time.Second, time.Millisecond)
 }
 
-func TestConnectionLimit_CloseUnblocksWaitingAccept(t *testing.T) {
-	listener := httpserverMocks.NewNetListener(t)
-	idleAvailable := make(chan struct{})
-	manager := httpserverMocks.NewConnectionPressureManager(t)
-	manager.EXPECT().CloseOldestIdleConnection().Return(false, nil).Maybe()
-	manager.EXPECT().IdleConnectionAvailable().Return(idleAvailable).Maybe()
-	listener.EXPECT().Close().Return(nil).Once()
-	logger := logMocks.NewLoggerMock(logMocks.WithMockAll, logMocks.WithTestingT(t))
+func (s *ConnectionLimitListenerTestSuite) TestCloseUnblocksWaitingAccept() {
+	s.manager.EXPECT().CloseOldestIdleConnection().Return(false, nil).Maybe()
+	s.manager.EXPECT().IdleConnectionAvailable().Return(s.idleAvailable).Maybe()
+	s.listener.EXPECT().Close().Return(nil).Once()
 
-	limited := httpserver.NewConnectionLimitListener(
-		t.Context(),
-		logger,
-		listener,
-		httpserver.ConcurrencySettings{MaxConnections: 1},
-		manager,
-	)
+	limited := s.newLimited(1)
 
-	listener.EXPECT().Accept().Return(httpserverMocks.NewNetConn(t), nil).Once()
+	s.listener.EXPECT().Accept().Return(httpserverMocks.NewNetConn(s.T()), nil).Once()
 	connA, err := limited.Accept()
-	require.NoError(t, err)
-	require.NotNil(t, connA)
+	s.NoError(err)
+	s.NotNil(connA)
 
 	acceptedSecond := make(chan error, 1)
 	acceptReturned := atomic.Bool{}
@@ -179,9 +142,25 @@ func TestConnectionLimit_CloseUnblocksWaitingAccept(t *testing.T) {
 		acceptedSecond <- acceptErr
 	}()
 
-	assert.Never(t, acceptReturned.Load, 20*time.Millisecond, time.Millisecond)
+	s.Never(acceptReturned.Load, 20*time.Millisecond, time.Millisecond)
 
-	require.NoError(t, limited.Close())
-	require.Eventually(t, acceptReturned.Load, time.Second, time.Millisecond)
-	assert.ErrorIs(t, <-acceptedSecond, net.ErrClosed)
+	s.NoError(limited.Close())
+	s.Eventually(acceptReturned.Load, time.Second, time.Millisecond)
+	s.ErrorIs(<-acceptedSecond, net.ErrClosed)
+}
+
+func (s *ConnectionLimitListenerTestSuite) newLimited(maxConnections int) net.Listener {
+	return httpserver.NewConnectionLimitListener(
+		s.T().Context(),
+		s.logger,
+		s.listener,
+		httpserver.ConcurrencySettings{MaxConnections: maxConnections},
+		s.manager,
+	)
+}
+
+func (s *ConnectionLimitListenerTestSuite) mockAcceptedConn() {
+	connA := httpserverMocks.NewNetConn(s.T())
+	connA.EXPECT().Close().Return(nil).Once()
+	s.listener.EXPECT().Accept().Return(connA, nil).Once()
 }

--- a/pkg/httpserver/connection_pressure_manager_test.go
+++ b/pkg/httpserver/connection_pressure_manager_test.go
@@ -10,95 +10,101 @@ import (
 	"github.com/justtrackio/gosoline/pkg/httpserver"
 	httpserverMocks "github.com/justtrackio/gosoline/pkg/httpserver/mocks"
 	"github.com/justtrackio/gosoline/pkg/test/matcher"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 )
 
-func TestConnectionPressureManager_TracksConnectionOpenedAndClosed(t *testing.T) {
-	recorder := httpserverMocks.NewServerMetricRecorder(t)
-	manager := httpserver.NewConnectionPressureManagerWithInterfaces(t.Context(), clock.NewFakeClock(), recorder)
-	conn := httpserverMocks.NewNetConn(t)
-	recorder.EXPECT().TrackConnectionOpened(matcher.Context).Return().Once()
-	recorder.EXPECT().TrackConnectionClosed(matcher.Context).Return().Once()
-
-	manager.ConnState(conn, http.StateNew)
-	manager.ConnState(conn, http.StateActive)
-	manager.ConnState(conn, http.StateIdle)
-	manager.ConnState(conn, http.StateClosed)
+func TestRunConnectionPressureManagerTestSuite(t *testing.T) {
+	suite.Run(t, new(ConnectionPressureManagerTestSuite))
 }
 
-func TestConnectionPressureManager_NotifiesWhenConnectionBecomesIdle(t *testing.T) {
-	recorder := httpserverMocks.NewServerMetricRecorder(t)
-	manager := httpserver.NewConnectionPressureManagerWithInterfaces(t.Context(), clock.NewFakeClock(), recorder)
-	conn := httpserverMocks.NewNetConn(t)
+type ConnectionPressureManagerTestSuite struct {
+	suite.Suite
+
+	recorder *httpserverMocks.ServerMetricRecorder
+	manager  httpserver.ConnectionPressureManager
+}
+
+func (s *ConnectionPressureManagerTestSuite) SetupTest() {
+	s.recorder = httpserverMocks.NewServerMetricRecorder(s.T())
+	s.manager = httpserver.NewConnectionPressureManagerWithInterfaces(s.T().Context(), clock.NewFakeClock(), s.recorder)
+}
+
+func (s *ConnectionPressureManagerTestSuite) TestTracksConnectionOpenedAndClosed() {
+	conn := httpserverMocks.NewNetConn(s.T())
+	s.recorder.EXPECT().TrackConnectionOpened(matcher.Context).Return().Once()
+	s.recorder.EXPECT().TrackConnectionClosed(matcher.Context).Return().Once()
+
+	s.manager.ConnState(conn, http.StateNew)
+	s.manager.ConnState(conn, http.StateActive)
+	s.manager.ConnState(conn, http.StateIdle)
+	s.manager.ConnState(conn, http.StateClosed)
+}
+
+func (s *ConnectionPressureManagerTestSuite) TestNotifiesWhenConnectionBecomesIdle() {
+	conn := httpserverMocks.NewNetConn(s.T())
 	ready := make(chan struct{})
 	notified := atomic.Bool{}
-	recorder.EXPECT().TrackConnectionOpened(matcher.Context).Return().Once()
+	s.recorder.EXPECT().TrackConnectionOpened(matcher.Context).Return().Once()
+
 	go func() {
 		close(ready)
-		<-manager.IdleConnectionAvailable()
+		<-s.manager.IdleConnectionAvailable()
 		notified.Store(true)
 	}()
 	<-ready
 
-	manager.ConnState(conn, http.StateNew)
-	manager.ConnState(conn, http.StateIdle)
+	s.manager.ConnState(conn, http.StateNew)
+	s.manager.ConnState(conn, http.StateIdle)
 
-	assert.Eventually(t, notified.Load, time.Second, time.Millisecond)
+	s.Eventually(notified.Load, time.Second, time.Millisecond)
 }
 
-func TestConnectionPressureManager_ClosesOldestIdleConnection(t *testing.T) {
-	recorder := httpserverMocks.NewServerMetricRecorder(t)
-	manager := httpserver.NewConnectionPressureManagerWithInterfaces(t.Context(), clock.NewFakeClock(), recorder)
-	connA := httpserverMocks.NewNetConn(t)
-	connB := httpserverMocks.NewNetConn(t)
+func (s *ConnectionPressureManagerTestSuite) TestClosesOldestIdleConnection() {
+	connA := httpserverMocks.NewNetConn(s.T())
+	connB := httpserverMocks.NewNetConn(s.T())
 	connAClosed := atomic.Bool{}
 	connA.EXPECT().Close().Run(func() {
 		connAClosed.Store(true)
 	}).Return(nil).Once()
-	recorder.EXPECT().TrackConnectionOpened(matcher.Context).Return().Twice()
-	recorder.EXPECT().TrackConnectionClosed(matcher.Context).Return().Once()
+	s.recorder.EXPECT().TrackConnectionOpened(matcher.Context).Return().Twice()
+	s.recorder.EXPECT().TrackConnectionClosed(matcher.Context).Return().Once()
 
-	manager.ConnState(connA, http.StateNew)
-	manager.ConnState(connA, http.StateIdle)
-	manager.ConnState(connB, http.StateNew)
-	manager.ConnState(connB, http.StateIdle)
+	s.manager.ConnState(connA, http.StateNew)
+	s.manager.ConnState(connA, http.StateIdle)
+	s.manager.ConnState(connB, http.StateNew)
+	s.manager.ConnState(connA, http.StateIdle)
 
-	closed, err := manager.CloseOldestIdleConnection()
+	closed, err := s.manager.CloseOldestIdleConnection()
 
-	require.NoError(t, err)
-	assert.True(t, closed)
-	assert.True(t, connAClosed.Load())
+	s.NoError(err)
+	s.True(closed)
+	s.True(connAClosed.Load())
 }
 
-func TestConnectionPressureManager_DoesNotCloseActiveConnection(t *testing.T) {
-	recorder := httpserverMocks.NewServerMetricRecorder(t)
-	manager := httpserver.NewConnectionPressureManagerWithInterfaces(t.Context(), clock.NewFakeClock(), recorder)
-	conn := httpserverMocks.NewNetConn(t)
-	recorder.EXPECT().TrackConnectionOpened(matcher.Context).Return().Once()
+func (s *ConnectionPressureManagerTestSuite) TestDoesNotCloseActiveConnection() {
+	conn := httpserverMocks.NewNetConn(s.T())
+	s.recorder.EXPECT().TrackConnectionOpened(matcher.Context).Return().Once()
 
-	manager.ConnState(conn, http.StateNew)
+	s.manager.ConnState(conn, http.StateNew)
 
-	closed, err := manager.CloseOldestIdleConnection()
+	closed, err := s.manager.CloseOldestIdleConnection()
 
-	require.NoError(t, err)
-	assert.False(t, closed)
+	s.NoError(err)
+	s.False(closed)
 }
 
-func TestConnectionPressureManager_TracksClosedOnceWhenIdleConnectionWasAlreadyEvicted(t *testing.T) {
-	recorder := httpserverMocks.NewServerMetricRecorder(t)
-	manager := httpserver.NewConnectionPressureManagerWithInterfaces(t.Context(), clock.NewFakeClock(), recorder)
-	conn := httpserverMocks.NewNetConn(t)
+func (s *ConnectionPressureManagerTestSuite) TestTracksClosedOnceWhenIdleConnectionWasAlreadyEvicted() {
+	conn := httpserverMocks.NewNetConn(s.T())
 	conn.EXPECT().Close().Return(nil).Once()
-	recorder.EXPECT().TrackConnectionOpened(matcher.Context).Return().Once()
-	recorder.EXPECT().TrackConnectionClosed(matcher.Context).Return().Once()
+	s.recorder.EXPECT().TrackConnectionOpened(matcher.Context).Return().Once()
+	s.recorder.EXPECT().TrackConnectionClosed(matcher.Context).Return().Once()
 
-	manager.ConnState(conn, http.StateNew)
-	manager.ConnState(conn, http.StateIdle)
+	s.manager.ConnState(conn, http.StateNew)
+	s.manager.ConnState(conn, http.StateIdle)
 
-	closed, err := manager.CloseOldestIdleConnection()
-	require.NoError(t, err)
-	require.True(t, closed)
+	closed, err := s.manager.CloseOldestIdleConnection()
+	s.NoError(err)
+	s.True(closed)
 
-	manager.ConnState(conn, http.StateClosed)
+	s.manager.ConnState(conn, http.StateClosed)
 }

--- a/pkg/httpserver/metric_recorder.go
+++ b/pkg/httpserver/metric_recorder.go
@@ -84,20 +84,20 @@ func (r *serverMetricRecorder) Run(ctx context.Context) error {
 
 func (r *serverMetricRecorder) writeCurrent(ctx context.Context) {
 	r.writer.Write(ctx, metric.Data{
-		r.buildDatum(MetricHttpConcurrentRequests, r.activeRequests.Load()),
-		r.buildDatum(MetricHttpOpenConnections, r.openConnections.Load()),
+		r.buildGaugeDatum(MetricHttpConcurrentRequests, r.activeRequests.Load()),
+		r.buildGaugeDatum(MetricHttpOpenConnections, r.openConnections.Load()),
 	})
 }
 
 func (r *serverMetricRecorder) writeConcurrentRequests(ctx context.Context, value int64) {
-	r.writer.WriteOne(ctx, r.buildDatum(MetricHttpConcurrentRequests, value))
+	r.writer.WriteOne(ctx, r.buildGaugeDatum(MetricHttpConcurrentRequests, value))
 }
 
 func (r *serverMetricRecorder) writeOpenConnections(ctx context.Context, value int64) {
-	r.writer.WriteOne(ctx, r.buildDatum(MetricHttpOpenConnections, value))
+	r.writer.WriteOne(ctx, r.buildGaugeDatum(MetricHttpOpenConnections, value))
 }
 
-func (r *serverMetricRecorder) buildDatum(metricName string, value int64) *metric.Datum {
+func (r *serverMetricRecorder) buildGaugeDatum(metricName string, value int64) *metric.Datum {
 	return &metric.Datum{
 		Priority:   metric.PriorityHigh,
 		MetricName: metricName,
@@ -112,7 +112,7 @@ func (r *serverMetricRecorder) buildDatum(metricName string, value int64) *metri
 
 func getMetricRecorderDefaults(name string) metric.Data {
 	return metric.Data{
-		&metric.Datum{
+		{
 			Priority:   metric.PriorityHigh,
 			MetricName: MetricHttpConcurrentRequests,
 			Dimensions: metric.Dimensions{
@@ -122,7 +122,7 @@ func getMetricRecorderDefaults(name string) metric.Data {
 			Kind:  metric.KindGauge.Build(),
 			Value: 0,
 		},
-		&metric.Datum{
+		{
 			Priority:   metric.PriorityHigh,
 			MetricName: MetricHttpOpenConnections,
 			Dimensions: metric.Dimensions{

--- a/pkg/httpserver/middleware_concurrency.go
+++ b/pkg/httpserver/middleware_concurrency.go
@@ -1,6 +1,8 @@
 package httpserver
 
 import (
+	"context"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -27,6 +29,7 @@ func ConcurrentRequestLimitMiddleware(settings ConcurrencySettings) gin.HandlerF
 
 			c.Next()
 		default:
+			c.Request = markRequestRejected(c.Request)
 			writeRetryAfterHeader(c, settings.RetryAfter)
 			c.AbortWithStatusJSON(settings.OverloadStatusCode, gin.H{
 				"error": "server overloaded",
@@ -49,4 +52,16 @@ func writeRetryAfterHeader(c *gin.Context, retryAfter time.Duration) {
 	}
 
 	c.Header("Retry-After", strconv.FormatInt(seconds, 10))
+}
+
+type rejectedRequestKey struct{}
+
+func markRequestRejected(request *http.Request) *http.Request {
+	return request.WithContext(context.WithValue(request.Context(), rejectedRequestKey{}, true))
+}
+
+func wasRequestRejected(request *http.Request) bool {
+	isRejected, ok := request.Context().Value(rejectedRequestKey{}).(bool)
+
+	return ok && isRejected
 }

--- a/pkg/httpserver/middleware_metric.go
+++ b/pkg/httpserver/middleware_metric.go
@@ -2,6 +2,7 @@ package httpserver
 
 import (
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -14,6 +15,7 @@ const (
 	MetricHttpRequestCount         = "HttpRequestCount"
 	MetricHttpRequestCountPerRoute = "HttpRequestCountPerRoute"
 	MetricHttpRequestResponseTime  = "HttpRequestResponseTime"
+	MetricHttpRequestsRejected     = "HttpRequestsRejected"
 	MetricHttpStatus               = "HttpStatus"
 )
 
@@ -86,6 +88,32 @@ func metricMiddleware(name string, ginCtx *gin.Context, writer metric.Writer, me
 			"ServerName": name,
 		},
 	}))
+
+	if wasRequestRejected(ginCtx.Request) {
+		writer.Write(ginCtx.Request.Context(), metric.Data{
+			{
+				Priority:   metric.PriorityHigh,
+				MetricName: MetricHttpRequestsRejected,
+				Unit:       metric.UnitCount,
+				Dimensions: map[string]string{
+					"Method":     method,
+					"Path":       path,
+					"ServerName": name,
+				},
+				Value: 1.0,
+			},
+			{
+				Priority:   metric.PriorityHigh,
+				MetricName: MetricHttpRequestsRejected,
+				Unit:       metric.UnitCount,
+				Dimensions: map[string]string{
+					"ServerName": name,
+				},
+				Value: 1.0,
+				Kind:  metric.KindTotal,
+			},
+		})
+	}
 }
 
 // createMetricsWithDimensions is creating a metric.Data set
@@ -107,25 +135,53 @@ func createMetricsWithDimensions(metrics metric.Data, dimensionsByMetricSuffix m
 }
 
 func getMetricMiddlewareDefaults(name string, definitions ...Definition) metric.Data {
-	return append(funk.Map(definitions, func(definition Definition) *metric.Datum {
-		return &metric.Datum{
-			Priority:   metric.PriorityHigh,
-			MetricName: MetricHttpRequestCountPerRoute,
-			Dimensions: metric.Dimensions{
-				"Method":     definition.httpMethod,
-				"Path":       definition.getAbsolutePath(),
-				"ServerName": name,
+	return slices.Concat(
+		funk.Map(definitions, func(definition Definition) *metric.Datum {
+			return &metric.Datum{
+				Priority:   metric.PriorityHigh,
+				MetricName: MetricHttpRequestCountPerRoute,
+				Dimensions: metric.Dimensions{
+					"Method":     definition.httpMethod,
+					"Path":       definition.getAbsolutePath(),
+					"ServerName": name,
+				},
+				Unit:  metric.UnitCount,
+				Value: 0.0,
+			}
+		}),
+		funk.Map(definitions, func(definition Definition) *metric.Datum {
+			return &metric.Datum{
+				Priority:   metric.PriorityHigh,
+				MetricName: MetricHttpRequestsRejected,
+				Dimensions: metric.Dimensions{
+					"Method":     definition.httpMethod,
+					"Path":       definition.getAbsolutePath(),
+					"ServerName": name,
+				},
+				Unit:  metric.UnitCount,
+				Value: 0.0,
+			}
+		}),
+		metric.Data{
+			{
+				Priority:   metric.PriorityHigh,
+				MetricName: MetricHttpRequestsRejected,
+				Dimensions: metric.Dimensions{
+					"ServerName": name,
+				},
+				Unit:  metric.UnitCount,
+				Value: 0.0,
+				Kind:  metric.KindTotal,
 			},
-			Unit:  metric.UnitCount,
-			Value: 0.0,
-		}
-	}), &metric.Datum{
-		Priority:   metric.PriorityHigh,
-		MetricName: MetricHttpRequestCount,
-		Dimensions: metric.Dimensions{
-			"ServerName": name,
+			{
+				Priority:   metric.PriorityHigh,
+				MetricName: MetricHttpRequestCount,
+				Dimensions: metric.Dimensions{
+					"ServerName": name,
+				},
+				Unit:  metric.UnitCount,
+				Value: 0.0,
+			},
 		},
-		Unit:  metric.UnitCount,
-		Value: 0.0,
-	})
+	)
 }

--- a/pkg/reslife/lifecycle_manager.go
+++ b/pkg/reslife/lifecycle_manager.go
@@ -281,11 +281,9 @@ func (m *LifeCycleManager) prepareCycle(settings SettingsCycle) (enabled bool, e
 }
 
 func (m *LifeCycleManager) shouldSkip(ctx context.Context, id string, visited funk.Set[string], excludes []*regexp.Regexp) bool {
-	if visited.Contains(id) {
+	if !visited.Add(id) {
 		return true
 	}
-
-	visited.Add(id)
 
 	for _, exclude := range excludes {
 		if exclude.MatchString(id) {

--- a/pkg/test/env/environment.go
+++ b/pkg/test/env/environment.go
@@ -240,13 +240,21 @@ func (e *Environment) LoadFixtureSet(factory fixtures.FixtureSetsFactory, postPr
 	return e.LoadFixtureSets([]fixtures.FixtureSetsFactory{factory}, postProcessorFactories...)
 }
 
-func (e *Environment) LifeCyleCreate() error {
+func (e *Environment) runLifeCycle() error {
 	if err := e.resManager.Create(e.ctx); err != nil {
 		return fmt.Errorf("can not handle the create lifecycle: %w", err)
 	}
 
 	if err := e.resManager.Init(e.ctx); err != nil {
 		return fmt.Errorf("can not handle the init lifecycle: %w", err)
+	}
+
+	if err := e.resManager.Register(e.ctx); err != nil {
+		return fmt.Errorf("can not handle the register lifecycle: %w", err)
+	}
+
+	if err := e.resManager.Purge(e.ctx); err != nil {
+		return fmt.Errorf("can not handle the purge lifecycle: %w", err)
 	}
 
 	return nil
@@ -280,7 +288,7 @@ func (e *Environment) LoadFixtureSets(factories []fixtures.FixtureSetsFactory, p
 		}
 	}
 
-	if err := e.LifeCyleCreate(); err != nil {
+	if err := e.runLifeCycle(); err != nil {
 		return fmt.Errorf("can not handle the lifecycle: %w", err)
 	}
 

--- a/pkg/test/suite/suite_configuration.go
+++ b/pkg/test/suite/suite_configuration.go
@@ -1,6 +1,7 @@
 package suite
 
 import (
+	"context"
 	"slices"
 
 	"github.com/justtrackio/gosoline/pkg/application"
@@ -17,6 +18,7 @@ type SuiteConfiguration struct {
 	fixtureSetFactories              []fixtures.FixtureSetsFactory
 	fixtureSetPostProcessorFactories []fixtures.PostProcessorFactory
 
+	appCtx       context.Context
 	appOptions   []application.Option
 	appModules   map[string]kernel.ModuleFactory
 	appFactories []kernel.ModuleMultiFactory

--- a/pkg/test/suite/testcase_application.go
+++ b/pkg/test/suite/testcase_application.go
@@ -101,7 +101,12 @@ func RunTestCaseApplication(t *testing.T, _ TestingSuite, suiteConf *SuiteConfig
 
 	// We need to create a new context here to isolate the individual apps from each other.
 	// Else they would share the same container and module instances which can lead to issues.
-	appCtx := appctx.WithContainer(t.Context())
+	// However, if a custom appCtx is provided (e.g., for base test cases where SetupTest registers
+	// lifecycle managers in the environment context), we use that instead.
+	appCtx := suiteConf.appCtx
+	if appCtx == nil {
+		appCtx = appctx.WithContainer(t.Context())
+	}
 	app, err := application.NewWithInterfaces(appCtx, config, logger, appOptions...)
 	if err != nil {
 		assert.FailNow(t, "failed to create application under test", err.Error())

--- a/pkg/test/suite/testcase_base.go
+++ b/pkg/test/suite/testcase_base.go
@@ -1,11 +1,14 @@
 package suite
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"testing"
-	"time"
 
+	"github.com/justtrackio/gosoline/pkg/cfg"
+	"github.com/justtrackio/gosoline/pkg/kernel"
+	"github.com/justtrackio/gosoline/pkg/log"
 	"github.com/justtrackio/gosoline/pkg/test/env"
 )
 
@@ -37,20 +40,19 @@ func isTestCaseBase(_ TestingSuite, method reflect.Method) error {
 func buildTestCaseBase(_ TestingSuite, method reflect.Method) (TestCaseRunner, error) {
 	return func(t *testing.T, suite TestingSuite, suiteConf *SuiteConfiguration, environment *env.Environment) {
 		suite.SetT(t)
-		if err := environment.LifeCyleCreate(); err != nil {
-			t.Fatalf("failed to run the create lifecycle: %v", err)
 
-			return
+		suiteConf.appModules["testcase"] = func(ctx context.Context, config cfg.Config, logger log.Logger) (kernel.Module, error) {
+			return kernel.NewModuleFunc(func(ctx context.Context) error {
+				return nil
+			}), nil
 		}
 
-		start := time.Now()
-		if err := environment.LoadFixtureSets(suiteConf.fixtureSetFactories, suiteConf.fixtureSetPostProcessorFactories...); err != nil {
-			t.Fatalf("failed to load fixtures from factories: %v", err)
+		// Use the environment's context so that lifecycle managers registered during SetupTest
+		// (e.g., SNS topics, SQS queues, DDB tables) are visible to the application's lifecycle.
+		suiteConf.appCtx = environment.Context()
 
-			return
-		}
-		environment.Logger().WithChannel("fixtures").Debug(environment.Context(), "loaded fixtures in %s", time.Since(start))
-
-		method.Func.Call([]reflect.Value{reflect.ValueOf(suite)})
+		RunTestCaseApplication(t, suite, suiteConf, environment, func(app AppUnderTest) {
+			method.Func.Call([]reflect.Value{reflect.ValueOf(suite)})
+		})
 	}, nil
 }


### PR DESCRIPTION
This should help distinguishing them from other 5xx errors as they trigger the 5XX metric as all other 5xx response codes.