### PR TITLE
fix(kafka): use consistent prometheus label names for broker metrics

### DIFF
--- a/pkg/kafka/consumer/consumer.go
+++ b/pkg/kafka/consumer/consumer.go
@@ -282,7 +282,7 @@ func (c *consumer) processPartitions(ctx context.Context, fetches kgo.Fetches) {
 }
 
 func (c *consumer) writeMetrics(ctx context.Context, pollDurationMs float64, recordCount int) {
-	dims := metric.Dimensions{kafka.DimensionConsumer: c.name, kafka.DimensionTopic: c.fullTopicName}
+	dims := metric.Dimensions{kafka.DimensionClientType: kafka.DimensionConsumer, kafka.DimensionClient: c.name, kafka.DimensionTopic: c.fullTopicName}
 
 	c.metricWriter.Write(ctx, metric.Data{
 		metric.NewMetricDatum(metricNamePollCount, dims, 1.0, metric.UnitCount, metric.PriorityHigh),
@@ -292,7 +292,7 @@ func (c *consumer) writeMetrics(ctx context.Context, pollDurationMs float64, rec
 }
 
 func getConsumerDefaultMetrics(name, topicName string) metric.Data {
-	dims := metric.Dimensions{kafka.DimensionConsumer: name, kafka.DimensionTopic: topicName}
+	dims := metric.Dimensions{kafka.DimensionClientType: kafka.DimensionConsumer, kafka.DimensionClient: name, kafka.DimensionTopic: topicName}
 
 	return metric.Data{
 		{Priority: metric.PriorityHigh, MetricName: metricNameRecordsConsumed, Dimensions: dims, Unit: metric.UnitCount, Kind: metric.KindDefault},

--- a/pkg/kafka/consumer/partition_manager.go
+++ b/pkg/kafka/consumer/partition_manager.go
@@ -99,7 +99,8 @@ func (p *PartitionManager) OnPartitionsLostOrRevoked(ctx context.Context, _ *kgo
 	defer wg.Wait()
 
 	for topic, partitions := range lost {
-		p.metricWriter.WriteOne(ctx, metric.NewMetricDatum(metricNameRebalanceCount, metric.Dimensions{kafka.DimensionConsumer: p.name, kafka.DimensionTopic: topic}, 1.0, metric.UnitCount, metric.PriorityHigh))
+		dims := metric.Dimensions{kafka.DimensionClientType: kafka.DimensionConsumer, kafka.DimensionClient: p.name, kafka.DimensionTopic: topic}
+		p.metricWriter.WriteOne(ctx, metric.NewMetricDatum(metricNameRebalanceCount, dims, 1.0, metric.UnitCount, metric.PriorityHigh))
 
 		for _, partition := range partitions {
 			assignment := assignment{topic, partition}

--- a/pkg/kafka/metrics.go
+++ b/pkg/kafka/metrics.go
@@ -8,21 +8,24 @@ import (
 
 // Dimension key constants for all Kafka metrics.
 const (
-	DimensionConsumer  = "Consumer"
-	DimensionProducer  = "Producer"
-	DimensionTopic     = "Topic"
-	DimensionPartition = "Partition"
-	DimensionBroker    = "Broker"
+	DimensionConsumer   = "Consumer"
+	DimensionProducer   = "Producer"
+	DimensionClientType = "ClientType"
+	DimensionClient     = "Client"
+	DimensionTopic      = "Topic"
+	DimensionPartition  = "Partition"
+	DimensionBroker     = "Broker"
 )
 
 // MetricPair writes a metric at two granularities: topic-level (KindTotal) and
-// topic+partition level, both including the named dimension (e.g. Consumer or Producer).
-func MetricPair(dimKey, name, metricName, topic string, partition int32, value float64, unit metric.StandardUnit) metric.Data {
+// topic+partition level. Uses fixed DimensionClientType and DimensionClient labels
+// to ensure consistent Prometheus label sets regardless of caller.
+func MetricPair(clientType, clientName, metricName, topic string, partition int32, value float64, unit metric.StandardUnit) metric.Data {
 	return metric.Data{
 		{
 			Priority:   metric.PriorityHigh,
 			MetricName: metricName,
-			Dimensions: metric.Dimensions{dimKey: name, DimensionTopic: topic},
+			Dimensions: metric.Dimensions{DimensionClientType: clientType, DimensionClient: clientName, DimensionTopic: topic},
 			Value:      value,
 			Unit:       unit,
 			Kind:       metric.KindTotal,
@@ -30,7 +33,7 @@ func MetricPair(dimKey, name, metricName, topic string, partition int32, value f
 		{
 			Priority:   metric.PriorityHigh,
 			MetricName: metricName,
-			Dimensions: metric.Dimensions{dimKey: name, DimensionTopic: topic, DimensionPartition: fmt.Sprintf("%d", partition)},
+			Dimensions: metric.Dimensions{DimensionClientType: clientType, DimensionClient: clientName, DimensionTopic: topic, DimensionPartition: fmt.Sprintf("%d", partition)},
 			Value:      value,
 			Unit:       unit,
 		},

--- a/pkg/kafka/metrics_hook.go
+++ b/pkg/kafka/metrics_hook.go
@@ -27,8 +27,8 @@ const (
 // connectivity, throttling, and produce/consume batch operations.
 type MetricsHook struct {
 	metricWriter metric.Writer
-	dimKey       string
-	name         string
+	clientType   string
+	clientName   string
 }
 
 // Compile-time interface assertions.
@@ -39,12 +39,16 @@ var (
 	_ kgo.HookFetchBatchRead      = (*MetricsHook)(nil)
 )
 
-func NewMetricsHook(metricWriter metric.Writer, dimKey, name string) *MetricsHook {
-	return &MetricsHook{metricWriter: metricWriter, dimKey: dimKey, name: name}
+func NewMetricsHook(metricWriter metric.Writer, clientType, clientName string) *MetricsHook {
+	return &MetricsHook{metricWriter: metricWriter, clientType: clientType, clientName: clientName}
 }
 
 func (h *MetricsHook) OnBrokerConnect(meta kgo.BrokerMetadata, _ time.Duration, _ net.Conn, err error) {
-	dims := metric.Dimensions{h.dimKey: h.name, DimensionBroker: fmt.Sprintf("%s:%d", meta.Host, meta.Port)}
+	dims := metric.Dimensions{
+		DimensionClientType: h.clientType,
+		DimensionClient:     h.clientName,
+		DimensionBroker:     fmt.Sprintf("%s:%d", meta.Host, meta.Port),
+	}
 
 	metricName := MetricNameBrokerConnects
 	if err != nil {
@@ -55,7 +59,11 @@ func (h *MetricsHook) OnBrokerConnect(meta kgo.BrokerMetadata, _ time.Duration, 
 }
 
 func (h *MetricsHook) OnBrokerThrottle(meta kgo.BrokerMetadata, throttleInterval time.Duration, _ bool) {
-	dims := metric.Dimensions{h.dimKey: h.name, DimensionBroker: fmt.Sprintf("%s:%d", meta.Host, meta.Port)}
+	dims := metric.Dimensions{
+		DimensionClientType: h.clientType,
+		DimensionClient:     h.clientName,
+		DimensionBroker:     fmt.Sprintf("%s:%d", meta.Host, meta.Port),
+	}
 
 	h.metricWriter.Write(context.Background(), metric.Data{
 		metric.NewMetricDatum(MetricNameBrokerThrottleCount, dims, 1.0, metric.UnitCount, metric.PriorityHigh),
@@ -65,18 +73,18 @@ func (h *MetricsHook) OnBrokerThrottle(meta kgo.BrokerMetadata, throttleInterval
 
 func (h *MetricsHook) OnProduceBatchWritten(_ kgo.BrokerMetadata, topic string, partition int32, metrics kgo.ProduceBatchMetrics) {
 	var data metric.Data
-	data = append(data, MetricPair(h.dimKey, h.name, MetricNameProduceBatchRecords, topic, partition, float64(metrics.NumRecords), metric.UnitCount)...)
-	data = append(data, MetricPair(h.dimKey, h.name, MetricNameProduceBatchBytes, topic, partition, float64(metrics.UncompressedBytes), metric.UnitCount)...)
-	data = append(data, MetricPair(h.dimKey, h.name, MetricNameProduceBatchBytesCmp, topic, partition, float64(metrics.CompressedBytes), metric.UnitCount)...)
+	data = append(data, MetricPair(h.clientType, h.clientName, MetricNameProduceBatchRecords, topic, partition, float64(metrics.NumRecords), metric.UnitCount)...)
+	data = append(data, MetricPair(h.clientType, h.clientName, MetricNameProduceBatchBytes, topic, partition, float64(metrics.UncompressedBytes), metric.UnitCount)...)
+	data = append(data, MetricPair(h.clientType, h.clientName, MetricNameProduceBatchBytesCmp, topic, partition, float64(metrics.CompressedBytes), metric.UnitCount)...)
 
 	h.metricWriter.Write(context.Background(), data)
 }
 
 func (h *MetricsHook) OnFetchBatchRead(_ kgo.BrokerMetadata, topic string, partition int32, metrics kgo.FetchBatchMetrics) {
 	var data metric.Data
-	data = append(data, MetricPair(h.dimKey, h.name, MetricNameFetchBatchRecords, topic, partition, float64(metrics.NumRecords), metric.UnitCount)...)
-	data = append(data, MetricPair(h.dimKey, h.name, MetricNameFetchBatchBytes, topic, partition, float64(metrics.UncompressedBytes), metric.UnitCount)...)
-	data = append(data, MetricPair(h.dimKey, h.name, MetricNameFetchBatchBytesCmp, topic, partition, float64(metrics.CompressedBytes), metric.UnitCount)...)
+	data = append(data, MetricPair(h.clientType, h.clientName, MetricNameFetchBatchRecords, topic, partition, float64(metrics.NumRecords), metric.UnitCount)...)
+	data = append(data, MetricPair(h.clientType, h.clientName, MetricNameFetchBatchBytes, topic, partition, float64(metrics.UncompressedBytes), metric.UnitCount)...)
+	data = append(data, MetricPair(h.clientType, h.clientName, MetricNameFetchBatchBytesCmp, topic, partition, float64(metrics.CompressedBytes), metric.UnitCount)...)
 
 	h.metricWriter.Write(context.Background(), data)
 }

--- a/pkg/kafka/producer/producer.go
+++ b/pkg/kafka/producer/producer.go
@@ -75,7 +75,7 @@ func (p *producer) ProduceSync(ctx context.Context, records ...*kgo.Record) erro
 	results := p.writer.ProduceSync(ctx, records...)
 	durationMs := float64(p.clock.Since(start).Milliseconds())
 
-	dims := metric.Dimensions{kafka.DimensionProducer: p.name, kafka.DimensionTopic: p.topicName}
+	dims := metric.Dimensions{kafka.DimensionClientType: kafka.DimensionProducer, kafka.DimensionClient: p.name, kafka.DimensionTopic: p.topicName}
 
 	data := metric.Data{
 		metric.NewMetricDatum(metricNameProduceBatchSize, dims, float64(len(records)), metric.UnitCountAverage, metric.PriorityHigh),
@@ -110,7 +110,7 @@ func (p *producer) ProduceSync(ctx context.Context, records ...*kgo.Record) erro
 }
 
 func getProducerDefaultMetrics(name, topicName string) metric.Data {
-	dims := metric.Dimensions{kafka.DimensionProducer: name, kafka.DimensionTopic: topicName}
+	dims := metric.Dimensions{kafka.DimensionClientType: kafka.DimensionProducer, kafka.DimensionClient: name, kafka.DimensionTopic: topicName}
 
 	return metric.Data{
 		{Priority: metric.PriorityHigh, MetricName: metricNameRecordsSent, Dimensions: dims, Unit: metric.UnitCount, Kind: metric.KindDefault},


### PR DESCRIPTION
## Problem

The `MetricsHook` in `pkg/kafka/metrics_hook.go` used a variable dimension key name (`Producer` or `Consumer`) as a Prometheus label name. When both a producer and consumer exist in the same application, broker-level metrics (`BrokerConnects`, `BrokerConnectsFailed`, `BrokerThrottleCount`, `BrokerThrottleTime`) are registered with conflicting label names, causing:

```
register metric BrokerConnects: a previously registered descriptor with the same
fully-qualified name ... has different label names
```

## Solution

Replaced all variable dimension key usage (`DimensionConsumer`/`DimensionProducer` as map keys) with two fixed dimensions:

- `ClientType` — value is `"Consumer"` or `"Producer"`
- `Client` — value is the client name

This ensures identical label sets across all registrations of the same metric name.

Example — before:
```
Producer: {Producer: "myProducer", Broker: "host:9092"}
Consumer: {Consumer: "myConsumer", Broker: "host:9092"}  // CONFLICT: different label names
```

After:
```
Producer: {ClientType: "Producer", Client: "myProducer", Broker: "host:9092"}
Consumer: {ClientType: "Consumer", Client: "myConsumer", Broker: "host:9092"}  // OK: same labels
```

Applied consistently across all kafka metrics in:
- `pkg/kafka/metrics.go` — new constants + `MetricPair`
- `pkg/kafka/metrics_hook.go` — broker connect/throttle metrics
- `pkg/kafka/producer/producer.go` — produce metrics + defaults
- `pkg/kafka/consumer/consumer.go` — consumer metrics + defaults
- `pkg/kafka/consumer/partition_manager.go` — rebalance metric

## Breaking Changes

Prometheus label names change from `Producer`/`Consumer` to `ClientType`/`Client`. Dashboards and alerts referencing the old labels will need updating.

## What was tested

- `go build -tags fixtures,integration ./...`
- `go test -tags fixtures,integration ./pkg/kafka/...`
- `golangci-lint run --build-tags integration,fixtures ./pkg/kafka/...`