### PR TITLE
test/suite: isolate per-run configuration

### DIFF
--- a/pkg/test/suite/suite_configuration.go
+++ b/pkg/test/suite/suite_configuration.go
@@ -2,6 +2,7 @@ package suite
 
 import (
 	"context"
+	"maps"
 	"slices"
 
 	"github.com/justtrackio/gosoline/pkg/application"
@@ -25,6 +26,24 @@ type SuiteConfiguration struct {
 
 	testCaseWhitelist   []string
 	testCaseRepeatCount int
+}
+
+func (s *SuiteConfiguration) clone() *SuiteConfiguration {
+	clone := &SuiteConfiguration{
+		envOptions:                       append([]env.Option(nil), s.envOptions...),
+		envSetup:                         append([]func() error(nil), s.envSetup...),
+		envIsShared:                      s.envIsShared,
+		fixtureSetFactories:              append([]fixtures.FixtureSetsFactory(nil), s.fixtureSetFactories...),
+		fixtureSetPostProcessorFactories: append([]fixtures.PostProcessorFactory(nil), s.fixtureSetPostProcessorFactories...),
+		appCtx:                           s.appCtx,
+		appOptions:                       append([]application.Option(nil), s.appOptions...),
+		appModules:                       maps.Clone(s.appModules),
+		appFactories:                     append([]kernel.ModuleMultiFactory(nil), s.appFactories...),
+		testCaseWhitelist:                append([]string(nil), s.testCaseWhitelist...),
+		testCaseRepeatCount:              s.testCaseRepeatCount,
+	}
+
+	return clone
 }
 
 func newSuiteConfiguration(options []Option) *SuiteConfiguration {

--- a/pkg/test/suite/suite_options.go
+++ b/pkg/test/suite/suite_options.go
@@ -1,6 +1,7 @@
 package suite
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -17,6 +18,12 @@ import (
 )
 
 type Option func(s *SuiteConfiguration)
+
+func withAppCtx(ctx context.Context) Option {
+	return func(s *SuiteConfiguration) {
+		s.appCtx = ctx
+	}
+}
 
 func WithClockProvider(clk clock.Clock) Option {
 	return func(s *SuiteConfiguration) {

--- a/pkg/test/suite/testcase_application.go
+++ b/pkg/test/suite/testcase_application.go
@@ -59,14 +59,17 @@ func buildTestCaseApplication(_ TestingSuite, method reflect.Method) (TestCaseRu
 }
 
 func RunTestCaseApplication(t *testing.T, _ TestingSuite, suiteConf *SuiteConfiguration, environment *env.Environment, testcase func(aut AppUnderTest), extraOptions ...Option) {
+	suiteConf = suiteConf.clone()
+
 	var appOptions []application.Option
+	appModules := make(map[string]kernel.ModuleFactory, len(suiteConf.appModules))
 
 	for _, opt := range extraOptions {
 		opt(suiteConf)
 	}
 
 	for k, factory := range suiteConf.appModules {
-		suiteConf.appModules[k] = newEssentialModuleFactory(factory)
+		appModules[k] = newEssentialModuleFactory(factory)
 	}
 
 	appOptions = append(appOptions, suiteConf.appOptions...)
@@ -88,7 +91,7 @@ func RunTestCaseApplication(t *testing.T, _ TestingSuite, suiteConf *SuiteConfig
 		appOptions = append(appOptions, application.WithFixtureSetFactory("default", factory))
 	}
 
-	for name, module := range suiteConf.appModules {
+	for name, module := range appModules {
 		appOptions = append(appOptions, application.WithModuleFactory(name, module))
 	}
 

--- a/pkg/test/suite/testcase_base.go
+++ b/pkg/test/suite/testcase_base.go
@@ -41,18 +41,19 @@ func buildTestCaseBase(_ TestingSuite, method reflect.Method) (TestCaseRunner, e
 	return func(t *testing.T, suite TestingSuite, suiteConf *SuiteConfiguration, environment *env.Environment) {
 		suite.SetT(t)
 
-		suiteConf.appModules["testcase"] = func(ctx context.Context, config cfg.Config, logger log.Logger) (kernel.Module, error) {
+		testcaseModule := func(ctx context.Context, config cfg.Config, logger log.Logger) (kernel.Module, error) {
 			return kernel.NewModuleFunc(func(ctx context.Context) error {
 				return nil
 			}), nil
 		}
 
-		// Use the environment's context so that lifecycle managers registered during SetupTest
-		// (e.g., SNS topics, SQS queues, DDB tables) are visible to the application's lifecycle.
-		suiteConf.appCtx = environment.Context()
-
 		RunTestCaseApplication(t, suite, suiteConf, environment, func(app AppUnderTest) {
 			method.Func.Call([]reflect.Value{reflect.ValueOf(suite)})
-		})
+		},
+			WithModule("testcase", testcaseModule),
+			// Use the environment's context so lifecycle managers registered during SetupTest
+			// are visible to this application's lifecycle without leaking to later tests.
+			withAppCtx(environment.Context()),
+		)
 	}, nil
 }

--- a/pkg/test/suite/testcase_httpserver.go
+++ b/pkg/test/suite/testcase_httpserver.go
@@ -106,7 +106,7 @@ func runTestCaseHttpserver(suite TestingSuite, testCase func(suite TestingSuite,
 
 		apiDefinitions := apiDefinitionAware.SetupApiDefinitions()
 
-		suiteConf.appModules["api"] = func(ctx context.Context, config cfg.Config, logger log.Logger) (kernel.Module, error) {
+		apiModule := func(ctx context.Context, config cfg.Config, logger log.Logger) (kernel.Module, error) {
 			module, err := httpserver.New("default", apiDefinitions)(ctx, config, logger)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create test http server: %w", err)
@@ -116,14 +116,6 @@ func runTestCaseHttpserver(suite TestingSuite, testCase func(suite TestingSuite,
 
 			return server, nil
 		}
-
-		suiteConf.addAppOption(application.WithConfigMap(map[string]any{
-			"httpserver": map[string]any{
-				"default": map[string]any{
-					"port": 0,
-				},
-			},
-		}))
 
 		RunTestCaseApplication(t, suite, suiteConf, environment, func(app AppUnderTest) {
 			port, err := server.GetPort()
@@ -137,6 +129,17 @@ func runTestCaseHttpserver(suite TestingSuite, testCase func(suite TestingSuite,
 			client := resty.New().SetBaseURL(url)
 
 			testCase(suite, app, client)
-		})
+		},
+			WithModule("api", apiModule),
+			func(s *SuiteConfiguration) {
+				s.addAppOption(application.WithConfigMap(map[string]any{
+					"httpserver": map[string]any{
+						"default": map[string]any{
+							"port": 0,
+						},
+					},
+				}))
+			},
+		)
 	}, nil
 }

--- a/pkg/test/suite/testcase_subscriber.go
+++ b/pkg/test/suite/testcase_subscriber.go
@@ -91,14 +91,6 @@ func buildTestCaseSubscriber(_ TestingSuite, method reflect.Method) (TestCaseRun
 	return func(t *testing.T, suite TestingSuite, suiteConf *SuiteConfiguration, environment *env.Environment) {
 		suite.SetT(t)
 
-		suiteConf.addAppOption(application.WithConfigMap(map[string]any{
-			"httpserver": map[string]any{
-				"default": map[string]any{
-					"port": 0,
-				},
-			},
-		}))
-
 		RunTestCaseApplication(t, suite, suiteConf, environment, func(app AppUnderTest) {
 			ret := method.Func.Call([]reflect.Value{reflect.ValueOf(suite)})
 			err := ret[1].Interface()
@@ -149,6 +141,14 @@ func buildTestCaseSubscriber(_ TestingSuite, method reflect.Method) (TestCaseRun
 			default:
 				assert.FailNow(t, "invalid subscriber output type", "the test case for the subscription of %s has an invalid output type: %s", tc.GetName(), outputType)
 			}
+		}, func(s *SuiteConfiguration) {
+			s.addAppOption(application.WithConfigMap(map[string]any{
+				"httpserver": map[string]any{
+					"default": map[string]any{
+						"port": 0,
+					},
+				},
+			}))
 		})
 	}, nil
 }


### PR DESCRIPTION
## Summary
- clone SuiteConfiguration for each application run so per-test options cannot leak
- scope base-test app context to the base application run while preserving lifecycle registrations
- avoid mutating httpserver/subscriber/base runner modules and app options globally
- add regression coverage for suite state isolation

Closes #1411

## Tests
- go test -tags fixtures,integration ./pkg/test/suite