### PR TITLE
fix(kafka): align consumer default metric labels with runtime writes

### DIFF
--- a/pkg/kafka/consumer/consumer.go
+++ b/pkg/kafka/consumer/consumer.go
@@ -293,16 +293,17 @@ func (c *consumer) writeMetrics(ctx context.Context, pollDurationMs float64, rec
 
 func getConsumerDefaultMetrics(name, topicName string) metric.Data {
 	dims := metric.Dimensions{kafka.DimensionClientType: kafka.DimensionConsumer, kafka.DimensionClient: name, kafka.DimensionTopic: topicName}
+	partitionDims := metric.Dimensions{kafka.DimensionClientType: kafka.DimensionConsumer, kafka.DimensionClient: name, kafka.DimensionTopic: topicName, kafka.DimensionPartition: metric.DimensionDefault}
 
 	return metric.Data{
 		{Priority: metric.PriorityHigh, MetricName: metricNameRecordsConsumed, Dimensions: dims, Unit: metric.UnitCount, Kind: metric.KindDefault},
-		{Priority: metric.PriorityHigh, MetricName: metricNameRecordsConsumedFailed, Dimensions: dims, Unit: metric.UnitCount, Kind: metric.KindDefault},
+		{Priority: metric.PriorityHigh, MetricName: metricNameRecordsConsumedFailed, Dimensions: partitionDims, Unit: metric.UnitCount, Kind: metric.KindDefault},
 		{Priority: metric.PriorityHigh, MetricName: metricNamePollCount, Dimensions: dims, Unit: metric.UnitCount, Kind: metric.KindDefault},
 		{Priority: metric.PriorityHigh, MetricName: metricNamePollDuration, Dimensions: dims, Unit: metric.UnitMillisecondsAverage, Kind: metric.KindDefault},
-		{Priority: metric.PriorityHigh, MetricName: metricNameProcessDuration, Dimensions: dims, Unit: metric.UnitMillisecondsAverage, Kind: metric.KindDefault},
-		{Priority: metric.PriorityHigh, MetricName: metricNameWaitDuration, Dimensions: dims, Unit: metric.UnitMillisecondsAverage, Kind: metric.KindDefault},
-		{Priority: metric.PriorityHigh, MetricName: metricNameCommitDuration, Dimensions: dims, Unit: metric.UnitMillisecondsAverage, Kind: metric.KindDefault},
-		{Priority: metric.PriorityHigh, MetricName: metricNameCommitFailures, Dimensions: dims, Unit: metric.UnitCount, Kind: metric.KindDefault},
+		{Priority: metric.PriorityHigh, MetricName: metricNameProcessDuration, Dimensions: partitionDims, Unit: metric.UnitMillisecondsAverage, Kind: metric.KindDefault},
+		{Priority: metric.PriorityHigh, MetricName: metricNameWaitDuration, Dimensions: partitionDims, Unit: metric.UnitMillisecondsAverage, Kind: metric.KindDefault},
+		{Priority: metric.PriorityHigh, MetricName: metricNameCommitDuration, Dimensions: partitionDims, Unit: metric.UnitMillisecondsAverage, Kind: metric.KindDefault},
+		{Priority: metric.PriorityHigh, MetricName: metricNameCommitFailures, Dimensions: partitionDims, Unit: metric.UnitCount, Kind: metric.KindDefault},
 		{Priority: metric.PriorityHigh, MetricName: metricNameRebalanceCount, Dimensions: dims, Unit: metric.UnitCount, Kind: metric.KindDefault},
 	}
 }


### PR DESCRIPTION
## Problem

The kafka consumer registers default metrics for `ProcessDuration`, `WaitDuration`, `CommitDuration`, `CommitFailures`, and `RecordsConsumedFailed` with 3 label keys: `ClientType`, `Client`, `Topic`.

However, `PartitionConsumer.Consume()` writes these same metrics at runtime via `MetricPair` which includes a 4th label key: `Partition`.

In Prometheus, a metric name must always use the **same set of label keys**. When the default is registered first (3 keys) and then a runtime write arrives (4 keys), the `prometheus.Registry` returns an `AlreadyRegisteredError`. The existing collector (3 labels) is reused, but then `.With()` is called with 4 labels — causing a panic or silent metric loss.

## Fix

Add `DimensionPartition: metric.DimensionDefault` to the default metrics that are written per-partition at runtime. This ensures the Prometheus collector is created with the correct 4-label schema from the start.

Metrics that are only written at the topic level (`RecordsConsumed`, `PollCount`, `PollDuration`, `RebalanceCount`) remain unchanged with 3 labels.

## Tested

- `go build -tags fixtures,integration ./...` ✓
- `go test -tags fixtures,integration ./pkg/kafka/...` ✓