### PR TITLE
stream/mdlsub: add sqs filter policies for sqs subs on sns;

### DIFF
--- a/pkg/cloud/aws/sns/attributes.go
+++ b/pkg/cloud/aws/sns/attributes.go
@@ -57,7 +57,7 @@ func IsValidAttributeName(name string) bool {
 	return validAttributeRegex.MatchString(name)
 }
 
-func buildFilterPolicy(attributes map[string]string) (string, error) {
+func buildFilterPolicy(attributes map[string][]string) (string, error) {
 	bytes, err := json.Marshal(attributes)
 	if err != nil {
 		return "", fmt.Errorf("can not marshal attributes to json: %w", err)

--- a/pkg/cloud/aws/sns/service.go
+++ b/pkg/cloud/aws/sns/service.go
@@ -58,13 +58,13 @@ func (s *Service) CreateTopic(ctx context.Context, topicName string) (string, er
 	return *out.TopicArn, nil
 }
 
-func (s *Service) SubscribeSqs(ctx context.Context, queueArn string, topicArn string, attributes map[string][]string) error {
+func (s *Service) SubscribeSqs(ctx context.Context, queueArn string, topicArn string, filterPolicy map[string][]string) error {
 	ctx = cloudAws.WithResourceTarget(ctx, topicArn)
 
 	var err error
 	var exists bool
 
-	if exists, err = s.subscriptionExists(ctx, queueArn, topicArn, attributes); err != nil {
+	if exists, err = s.subscriptionExists(ctx, queueArn, topicArn, filterPolicy); err != nil {
 		return fmt.Errorf("can not check if the subscription exists already: %w", err)
 	}
 
@@ -84,8 +84,8 @@ func (s *Service) SubscribeSqs(ctx context.Context, queueArn string, topicArn st
 		Protocol:   aws.String("sqs"),
 	}
 
-	if len(attributes) > 0 {
-		policy, err := buildFilterPolicy(attributes)
+	if len(filterPolicy) > 0 {
+		policy, err := buildFilterPolicy(filterPolicy)
 		if err != nil {
 			return fmt.Errorf("can not build filter policy: %w", err)
 		}
@@ -105,7 +105,7 @@ func (s *Service) SubscribeSqs(ctx context.Context, queueArn string, topicArn st
 	return nil
 }
 
-func (s *Service) subscriptionExists(ctx context.Context, queueArn string, topicArn string, attributes map[string][]string) (bool, error) {
+func (s *Service) subscriptionExists(ctx context.Context, queueArn string, topicArn string, filterPolicy map[string][]string) (bool, error) {
 	var ok bool
 	var err error
 	var subscriptions []types.Subscription
@@ -119,7 +119,7 @@ func (s *Service) subscriptionExists(ctx context.Context, queueArn string, topic
 			continue
 		}
 
-		if ok, err = s.subscriptionAttributesMatch(ctx, subscription.SubscriptionArn, attributes); err != nil {
+		if ok, err = s.subscriptionAttributesMatch(ctx, subscription.SubscriptionArn, filterPolicy); err != nil {
 			return false, err
 		}
 
@@ -168,7 +168,7 @@ func (s *Service) listSubscriptions(ctx context.Context, topicArn string) ([]typ
 	return subscriptions, nil
 }
 
-func (s *Service) subscriptionAttributesMatch(ctx context.Context, subscriptionArn *string, attributes map[string][]string) (bool, error) {
+func (s *Service) subscriptionAttributesMatch(ctx context.Context, subscriptionArn *string, filterPolicy map[string][]string) (bool, error) {
 	var ok bool
 	var err error
 	var subAttributes map[string]string
@@ -190,7 +190,7 @@ func (s *Service) subscriptionAttributesMatch(ctx context.Context, subscriptionA
 
 	// we have to marshal and unmarshal this to cover the behavior of getting float64 for all numbers,
 	// if we unmarshal something into a map[string]any
-	if expectedFilterPolicy, err = json.Marshal(attributes); err != nil {
+	if expectedFilterPolicy, err = json.Marshal(filterPolicy); err != nil {
 		return false, fmt.Errorf("can not marshal expected filter policy: %w", err)
 	}
 

--- a/pkg/cloud/aws/sns/service.go
+++ b/pkg/cloud/aws/sns/service.go
@@ -58,7 +58,7 @@ func (s *Service) CreateTopic(ctx context.Context, topicName string) (string, er
 	return *out.TopicArn, nil
 }
 
-func (s *Service) SubscribeSqs(ctx context.Context, queueArn string, topicArn string, attributes map[string]string) error {
+func (s *Service) SubscribeSqs(ctx context.Context, queueArn string, topicArn string, attributes map[string][]string) error {
 	ctx = cloudAws.WithResourceTarget(ctx, topicArn)
 
 	var err error
@@ -105,7 +105,7 @@ func (s *Service) SubscribeSqs(ctx context.Context, queueArn string, topicArn st
 	return nil
 }
 
-func (s *Service) subscriptionExists(ctx context.Context, queueArn string, topicArn string, attributes map[string]string) (bool, error) {
+func (s *Service) subscriptionExists(ctx context.Context, queueArn string, topicArn string, attributes map[string][]string) (bool, error) {
 	var ok bool
 	var err error
 	var subscriptions []types.Subscription
@@ -141,7 +141,7 @@ func (s *Service) subscriptionExists(ctx context.Context, queueArn string, topic
 	return false, nil
 }
 
-func (t *Service) listSubscriptions(ctx context.Context, topicArn string) ([]types.Subscription, error) {
+func (s *Service) listSubscriptions(ctx context.Context, topicArn string) ([]types.Subscription, error) {
 	subscriptions := make([]types.Subscription, 0)
 
 	input := &sns.ListSubscriptionsByTopicInput{
@@ -152,7 +152,7 @@ func (t *Service) listSubscriptions(ctx context.Context, topicArn string) ([]typ
 	var out *sns.ListSubscriptionsByTopicOutput
 
 	for {
-		if out, err = t.client.ListSubscriptionsByTopic(ctx, input); err != nil {
+		if out, err = s.client.ListSubscriptionsByTopic(ctx, input); err != nil {
 			return nil, fmt.Errorf("can not list subscriptions by topic: %w", err)
 		}
 
@@ -168,7 +168,7 @@ func (t *Service) listSubscriptions(ctx context.Context, topicArn string) ([]typ
 	return subscriptions, nil
 }
 
-func (s *Service) subscriptionAttributesMatch(ctx context.Context, subscriptionArn *string, attributes map[string]string) (bool, error) {
+func (s *Service) subscriptionAttributesMatch(ctx context.Context, subscriptionArn *string, attributes map[string][]string) (bool, error) {
 	var ok bool
 	var err error
 	var subAttributes map[string]string

--- a/pkg/cloud/aws/sns/service_test.go
+++ b/pkg/cloud/aws/sns/service_test.go
@@ -42,7 +42,7 @@ func (s *ServiceTestSuite) TestSubscribeSqs() {
 
 	subInput := &awsSns.SubscribeInput{
 		Attributes: map[string]string{
-			"FilterPolicy": `{"model":"goso","version":"1"}`,
+			"FilterPolicy": `{"model":["goso"],"version":["1"]}`,
 		},
 		TopicArn: aws.String("topicArn"),
 		Protocol: aws.String("sqs"),
@@ -50,9 +50,9 @@ func (s *ServiceTestSuite) TestSubscribeSqs() {
 	}
 	s.client.EXPECT().Subscribe(matcher.Context, subInput).Return(nil, nil).Once()
 
-	err := s.service.SubscribeSqs(s.ctx, "queueArn", "topicArn", map[string]string{
-		"model":   "goso",
-		"version": "1",
+	err := s.service.SubscribeSqs(s.ctx, "queueArn", "topicArn", map[string][]string{
+		"model":   {"goso"},
+		"version": {"1"},
 	})
 	s.NoError(err)
 }
@@ -73,14 +73,14 @@ func (s *ServiceTestSuite) TestSubscribeSqsExists() {
 	getAttributesInput := &awsSns.GetSubscriptionAttributesInput{SubscriptionArn: aws.String("subscriptionArn")}
 	getAttributesOutput := &awsSns.GetSubscriptionAttributesOutput{
 		Attributes: map[string]string{
-			"FilterPolicy": `{"model":"goso","version":"1"}`,
+			"FilterPolicy": `{"model":["goso"],"version":["1"]}`,
 		},
 	}
 	s.client.EXPECT().GetSubscriptionAttributes(matcher.Context, getAttributesInput).Return(getAttributesOutput, nil).Once()
 
-	err := s.service.SubscribeSqs(s.T().Context(), "queueArn", "topicArn", map[string]string{
-		"model":   "goso",
-		"version": "1",
+	err := s.service.SubscribeSqs(s.T().Context(), "queueArn", "topicArn", map[string][]string{
+		"model":   {"goso"},
+		"version": {"1"},
 	})
 	s.NoError(err)
 }
@@ -112,7 +112,7 @@ func (s *ServiceTestSuite) TestSubscribeSqsExistsWithDifferentAttributes() {
 
 	subInput := &awsSns.SubscribeInput{
 		Attributes: map[string]string{
-			"FilterPolicy": `{"model":"goso"}`,
+			"FilterPolicy": `{"model":["goso"]}`,
 		},
 		Endpoint: aws.String("queueArn"),
 		Protocol: aws.String("sqs"),
@@ -120,9 +120,8 @@ func (s *ServiceTestSuite) TestSubscribeSqsExistsWithDifferentAttributes() {
 	}
 	s.client.EXPECT().Subscribe(matcher.Context, subInput).Return(nil, nil).Once()
 
-	err := s.service.SubscribeSqs(s.T().Context(), "queueArn", "topicArn", map[string]string{
-		// err := s.topic.SubscribeSqs(s.ctx, "queueArn", map[string]any{
-		"model": "goso",
+	err := s.service.SubscribeSqs(s.T().Context(), "queueArn", "topicArn", map[string][]string{
+		"model": {"goso"},
 	})
 	s.NoError(err)
 }
@@ -142,6 +141,69 @@ func (s *ServiceTestSuite) TestSubscribeSqsError() {
 	}
 	s.client.EXPECT().Subscribe(matcher.Context, subInput).Return(nil, subErr).Once()
 
-	err := s.service.SubscribeSqs(s.ctx, "queueArn", "topicArn", map[string]string{})
+	err := s.service.SubscribeSqs(s.ctx, "queueArn", "topicArn", map[string][]string{})
 	s.EqualError(err, "could not subscribe to topic arn topicArn for sqs queue arn queueArn: subscribe error")
+}
+
+func (s *ServiceTestSuite) TestSubscribeSqsWithArrayFilterPolicy() {
+	listInput := &awsSns.ListSubscriptionsByTopicInput{TopicArn: aws.String("topicArn")}
+	listOutput := &awsSns.ListSubscriptionsByTopicOutput{}
+	s.client.EXPECT().ListSubscriptionsByTopic(matcher.Context, listInput).Return(listOutput, nil).Once()
+
+	subInput := &awsSns.SubscribeInput{
+		Attributes: map[string]string{
+			"FilterPolicy": `{"modelId":["model.a","model.b","model.c"]}`,
+		},
+		TopicArn: aws.String("topicArn"),
+		Protocol: aws.String("sqs"),
+		Endpoint: aws.String("queueArn"),
+	}
+	s.client.EXPECT().Subscribe(matcher.Context, subInput).Return(nil, nil).Once()
+
+	err := s.service.SubscribeSqs(s.ctx, "queueArn", "topicArn", map[string][]string{
+		"modelId": {"model.a", "model.b", "model.c"},
+	})
+	s.NoError(err)
+}
+
+func (s *ServiceTestSuite) TestSubscribeSqsExistsWithArrayFilterPolicy() {
+	listInput := &awsSns.ListSubscriptionsByTopicInput{TopicArn: aws.String("topicArn")}
+	listOutput := &awsSns.ListSubscriptionsByTopicOutput{
+		Subscriptions: []types.Subscription{
+			{
+				TopicArn:        aws.String("topicArn"),
+				SubscriptionArn: aws.String("subscriptionArn"),
+				Endpoint:        aws.String("queueArn"),
+			},
+		},
+	}
+	s.client.EXPECT().ListSubscriptionsByTopic(matcher.Context, listInput).Return(listOutput, nil).Once()
+
+	getAttributesInput := &awsSns.GetSubscriptionAttributesInput{SubscriptionArn: aws.String("subscriptionArn")}
+	getAttributesOutput := &awsSns.GetSubscriptionAttributesOutput{
+		Attributes: map[string]string{
+			"FilterPolicy": `{"modelId":["model.a","model.b"]}`,
+		},
+	}
+	s.client.EXPECT().GetSubscriptionAttributes(matcher.Context, getAttributesInput).Return(getAttributesOutput, nil).Once()
+
+	// Existing policy has ["model.a","model.b"] but we want ["model.a","model.b","model.c"], so it should delete and re-subscribe
+	unsubscribeInput := &awsSns.UnsubscribeInput{SubscriptionArn: aws.String("subscriptionArn")}
+	unsubscribeOutput := &awsSns.UnsubscribeOutput{}
+	s.client.EXPECT().Unsubscribe(matcher.Context, unsubscribeInput).Return(unsubscribeOutput, nil).Once()
+
+	subInput := &awsSns.SubscribeInput{
+		Attributes: map[string]string{
+			"FilterPolicy": `{"modelId":["model.a","model.b","model.c"]}`,
+		},
+		Endpoint: aws.String("queueArn"),
+		Protocol: aws.String("sqs"),
+		TopicArn: aws.String("topicArn"),
+	}
+	s.client.EXPECT().Subscribe(matcher.Context, subInput).Return(nil, nil).Once()
+
+	err := s.service.SubscribeSqs(s.ctx, "queueArn", "topicArn", map[string][]string{
+		"modelId": {"model.a", "model.b", "model.c"},
+	})
+	s.NoError(err)
 }

--- a/pkg/mdlsub/config_postprocessor_subscriber.go
+++ b/pkg/mdlsub/config_postprocessor_subscriber.go
@@ -185,8 +185,8 @@ func snsSubscriberInputConfigPostProcessor(config cfg.GosoConf, name string, sub
 				Application: sourceModel.Application,
 				Tags:        cfg.Tags(sourceModel.Tags),
 			},
-			TopicId:    topicId,
-			Attributes: buildSubscriberFilterAttributes(modelIds),
+			TopicId:      topicId,
+			FilterPolicy: buildSubscriberFilterPolicy(modelIds),
 		},
 	}
 
@@ -266,7 +266,7 @@ func kvstoreSubscriberOutputConfigPostProcessor(config cfg.GosoConf, name string
 	return cfg.WithConfigSetting(kvstoreKey, kvstoreSettings, cfg.SkipExisting), nil
 }
 
-func buildSubscriberFilterAttributes(modelIds []string) map[string][]string {
+func buildSubscriberFilterPolicy(modelIds []string) map[string][]string {
 	if len(modelIds) == 0 {
 		return nil
 	}

--- a/pkg/mdlsub/config_postprocessor_subscriber.go
+++ b/pkg/mdlsub/config_postprocessor_subscriber.go
@@ -2,6 +2,7 @@ package mdlsub
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/justtrackio/gosoline/pkg/cfg"
@@ -14,7 +15,7 @@ func init() {
 }
 
 type (
-	SubscriberInputConfigPostProcessor  func(config cfg.GosoConf, name string, subscriberSettings *SubscriberSettings) (cfg.Option, error)
+	SubscriberInputConfigPostProcessor  func(config cfg.GosoConf, name string, subscriberSettings *SubscriberSettings, modelIds []string) (cfg.Option, error)
 	SubscriberOutputConfigPostProcessor func(config cfg.GosoConf, name string, subscriberSettings *SubscriberSettings) (cfg.Option, error)
 )
 
@@ -38,8 +39,21 @@ func SubscriberConfigPostProcessor(config cfg.GosoConf) (bool, error) {
 		return false, fmt.Errorf("failed to unmarshal mdlsub settings: %w", err)
 	}
 
+	// Collect all modelIds per input key so we can build filter policies
+	modelIdsByInput, err := collectModelIdsByInput(config, settings)
+	if err != nil {
+		return false, err
+	}
+
 	for name, subscriberSettings := range settings.Subscribers {
-		if err := processSubscriberConfig(config, name, subscriberSettings); err != nil {
+		inputKey, err := getInputKeyForSubscriber(config, name, subscriberSettings)
+		if err != nil {
+			return false, err
+		}
+
+		modelIds := modelIdsByInput[inputKey]
+
+		if err := processSubscriberConfig(config, name, subscriberSettings, modelIds); err != nil {
 			return false, err
 		}
 	}
@@ -47,7 +61,45 @@ func SubscriberConfigPostProcessor(config cfg.GosoConf) (bool, error) {
 	return true, nil
 }
 
-func processSubscriberConfig(config cfg.GosoConf, name string, subscriberSettings *SubscriberSettings) error {
+func collectModelIdsByInput(config cfg.Config, settings *Settings) (map[string][]string, error) {
+	result := make(map[string][]string)
+
+	for name, subscriberSettings := range settings.Subscribers {
+		if subscriberSettings.Input != stream.InputTypeSns {
+			continue
+		}
+
+		inputKey, err := getInputKeyForSubscriber(config, name, subscriberSettings)
+		if err != nil {
+			return nil, err
+		}
+
+		sourceModel := subscriberSettings.SourceModel
+		if err := sourceModel.PadFromConfig(config); err != nil {
+			return nil, fmt.Errorf("can not pad source model for subscriber %s: %w", name, err)
+		}
+
+		modelId := sourceModel.String()
+		result[inputKey] = append(result[inputKey], modelId)
+	}
+
+	for key := range result {
+		slices.Sort(result[key])
+	}
+
+	return result, nil
+}
+
+func getInputKeyForSubscriber(config cfg.Config, name string, subscriberSettings *SubscriberSettings) (string, error) {
+	inputKey, err := getInputConfigKey(config, name, subscriberSettings.SourceModel)
+	if err != nil {
+		return "", fmt.Errorf("can not get input key for subscriber %s: %w", name, err)
+	}
+
+	return inputKey, nil
+}
+
+func processSubscriberConfig(config cfg.GosoConf, name string, subscriberSettings *SubscriberSettings, modelIds []string) error {
 	var ok bool
 	var err error
 	var consumerName string
@@ -78,7 +130,7 @@ func processSubscriberConfig(config cfg.GosoConf, name string, subscriberSetting
 	}
 
 	if inputPostProcessor, ok = subscriberInputConfigPostProcessors[subscriberSettings.Input]; ok {
-		if inputOption, err = inputPostProcessor(config, name, subscriberSettings); err != nil {
+		if inputOption, err = inputPostProcessor(config, name, subscriberSettings, modelIds); err != nil {
 			return fmt.Errorf("can not process input config for subscriber %s: %w", name, err)
 		}
 
@@ -100,7 +152,7 @@ func processSubscriberConfig(config cfg.GosoConf, name string, subscriberSetting
 	return nil
 }
 
-func snsSubscriberInputConfigPostProcessor(config cfg.GosoConf, name string, subscriberSettings *SubscriberSettings) (cfg.Option, error) {
+func snsSubscriberInputConfigPostProcessor(config cfg.GosoConf, name string, subscriberSettings *SubscriberSettings, modelIds []string) (cfg.Option, error) {
 	var err error
 	var inputKey string
 
@@ -133,14 +185,15 @@ func snsSubscriberInputConfigPostProcessor(config cfg.GosoConf, name string, sub
 				Application: sourceModel.Application,
 				Tags:        cfg.Tags(sourceModel.Tags),
 			},
-			TopicId: topicId,
+			TopicId:    topicId,
+			Attributes: buildSubscriberFilterAttributes(modelIds),
 		},
 	}
 
 	return cfg.WithConfigSetting(inputKey, inputSettings, cfg.SkipExisting), nil
 }
 
-func kafkaSubscriberInputConfigPostProcessor(config cfg.GosoConf, name string, subscriberSettings *SubscriberSettings) (cfg.Option, error) {
+func kafkaSubscriberInputConfigPostProcessor(config cfg.GosoConf, name string, subscriberSettings *SubscriberSettings, _ []string) (cfg.Option, error) {
 	var err error
 	var inputKey string
 
@@ -167,7 +220,7 @@ func kafkaSubscriberInputConfigPostProcessor(config cfg.GosoConf, name string, s
 	return cfg.WithConfigSetting(inputKey, inputSettings, cfg.SkipExisting), nil
 }
 
-func kinesisSubscriberInputConfigPostProcessor(config cfg.GosoConf, name string, subscriberSettings *SubscriberSettings) (cfg.Option, error) {
+func kinesisSubscriberInputConfigPostProcessor(config cfg.GosoConf, name string, subscriberSettings *SubscriberSettings, _ []string) (cfg.Option, error) {
 	var err error
 	var inputKey string
 
@@ -211,6 +264,16 @@ func kvstoreSubscriberOutputConfigPostProcessor(config cfg.GosoConf, name string
 	kvstoreSettings.Elements = []string{kvstore.TypeRedis, kvstore.TypeDdb}
 
 	return cfg.WithConfigSetting(kvstoreKey, kvstoreSettings, cfg.SkipExisting), nil
+}
+
+func buildSubscriberFilterAttributes(modelIds []string) map[string][]string {
+	if len(modelIds) == 0 {
+		return nil
+	}
+
+	return map[string][]string{
+		AttributeModelId: modelIds,
+	}
 }
 
 func GetSubscriberFQN(config cfg.Config, name string, sourceModel SubscriberModel) (string, error) {

--- a/pkg/mdlsub/config_postprocessor_subscriber_test.go
+++ b/pkg/mdlsub/config_postprocessor_subscriber_test.go
@@ -10,23 +10,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBuildSubscriberFilterAttributes_Empty(t *testing.T) {
-	attrs := buildSubscriberFilterAttributes(nil)
+func TestBuildSubscriberFilterPolicy_Empty(t *testing.T) {
+	attrs := buildSubscriberFilterPolicy(nil)
 	assert.Nil(t, attrs)
 
-	attrs = buildSubscriberFilterAttributes([]string{})
+	attrs = buildSubscriberFilterPolicy([]string{})
 	assert.Nil(t, attrs)
 }
 
-func TestBuildSubscriberFilterAttributes_Single(t *testing.T) {
-	attrs := buildSubscriberFilterAttributes([]string{"mcoins.marketing.management.app"})
+func TestBuildSubscriberFilterPolicy_Single(t *testing.T) {
+	attrs := buildSubscriberFilterPolicy([]string{"mcoins.marketing.management.app"})
 	assert.Equal(t, map[string][]string{
 		"modelId": {"mcoins.marketing.management.app"},
 	}, attrs)
 }
 
-func TestBuildSubscriberFilterAttributes_Multiple(t *testing.T) {
-	attrs := buildSubscriberFilterAttributes([]string{
+func TestBuildSubscriberFilterPolicy_Multiple(t *testing.T) {
+	attrs := buildSubscriberFilterPolicy([]string{
 		"mcoins.marketing.management.app",
 		"mcoins.marketing.management.network",
 		"mcoins.marketing.management.platform",
@@ -216,5 +216,5 @@ func TestSnsSubscriberInputConfigPostProcessor_SetsFilterAttributes(t *testing.T
 	require.Len(t, inputSettings.Targets, 1)
 	assert.Equal(t, map[string][]string{
 		"modelId": {"mcoins.marketing.management.app", "mcoins.marketing.management.network"},
-	}, inputSettings.Targets[0].Attributes)
+	}, inputSettings.Targets[0].FilterPolicy)
 }

--- a/pkg/mdlsub/config_postprocessor_subscriber_test.go
+++ b/pkg/mdlsub/config_postprocessor_subscriber_test.go
@@ -1,0 +1,220 @@
+package mdlsub
+
+import (
+	"testing"
+
+	"github.com/justtrackio/gosoline/pkg/cfg"
+	"github.com/justtrackio/gosoline/pkg/mdl"
+	"github.com/justtrackio/gosoline/pkg/stream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildSubscriberFilterAttributes_Empty(t *testing.T) {
+	attrs := buildSubscriberFilterAttributes(nil)
+	assert.Nil(t, attrs)
+
+	attrs = buildSubscriberFilterAttributes([]string{})
+	assert.Nil(t, attrs)
+}
+
+func TestBuildSubscriberFilterAttributes_Single(t *testing.T) {
+	attrs := buildSubscriberFilterAttributes([]string{"mcoins.marketing.management.app"})
+	assert.Equal(t, map[string][]string{
+		"modelId": {"mcoins.marketing.management.app"},
+	}, attrs)
+}
+
+func TestBuildSubscriberFilterAttributes_Multiple(t *testing.T) {
+	attrs := buildSubscriberFilterAttributes([]string{
+		"mcoins.marketing.management.app",
+		"mcoins.marketing.management.network",
+		"mcoins.marketing.management.platform",
+	})
+	assert.Equal(t, map[string][]string{
+		"modelId": {
+			"mcoins.marketing.management.app",
+			"mcoins.marketing.management.network",
+			"mcoins.marketing.management.platform",
+		},
+	}, attrs)
+}
+
+func TestCollectModelIdsByInput(t *testing.T) {
+	config := cfg.New(map[string]any{
+		"app": map[string]any{
+			"name": "subscriber",
+			"env":  "dev",
+			"tags": map[string]any{
+				"project": "mcoins",
+				"family":  "marketing",
+				"group":   "attribution",
+			},
+		},
+	})
+
+	settings := &Settings{
+		Subscribers: map[string]*SubscriberSettings{
+			"app": {
+				Input: "sns",
+				SourceModel: SubscriberModel{
+					ModelId: mdl.ModelId{
+						Name: "app",
+						Tags: map[string]string{
+							"project": "mcoins",
+							"family":  "marketing",
+							"group":   "management",
+						},
+						DomainPattern: "{app.tags.project}.{app.tags.family}.{app.tags.group}",
+					},
+					Shared: true,
+				},
+			},
+			"network": {
+				Input: "sns",
+				SourceModel: SubscriberModel{
+					ModelId: mdl.ModelId{
+						Name: "network",
+						Tags: map[string]string{
+							"project": "mcoins",
+							"family":  "marketing",
+							"group":   "management",
+						},
+						DomainPattern: "{app.tags.project}.{app.tags.family}.{app.tags.group}",
+					},
+					Shared: true,
+				},
+			},
+			"kafkaModel": {
+				Input: "kafka",
+				SourceModel: SubscriberModel{
+					ModelId: mdl.ModelId{
+						Name: "kafkaModel",
+					},
+				},
+			},
+		},
+	}
+
+	result, err := collectModelIdsByInput(config, settings)
+	require.NoError(t, err)
+
+	// kafkaModel should not appear since it's not SNS input
+	// Both app and network share the same input key because they are shared
+	assert.Len(t, result, 1)
+
+	for _, modelIds := range result {
+		assert.Contains(t, modelIds, "mcoins.marketing.management.app")
+		assert.Contains(t, modelIds, "mcoins.marketing.management.network")
+		assert.Len(t, modelIds, 2)
+	}
+}
+
+func TestCollectModelIdsByInput_NonShared(t *testing.T) {
+	config := cfg.New(map[string]any{
+		"app": map[string]any{
+			"name": "subscriber",
+			"env":  "dev",
+			"tags": map[string]any{
+				"project": "mcoins",
+				"family":  "marketing",
+				"group":   "attribution",
+			},
+		},
+	})
+
+	settings := &Settings{
+		Subscribers: map[string]*SubscriberSettings{
+			"app": {
+				Input: "sns",
+				SourceModel: SubscriberModel{
+					ModelId: mdl.ModelId{
+						Name: "app",
+						Tags: map[string]string{
+							"project": "mcoins",
+							"family":  "marketing",
+							"group":   "management",
+						},
+						DomainPattern: "{app.tags.project}.{app.tags.family}.{app.tags.group}",
+					},
+				},
+			},
+			"network": {
+				Input: "sns",
+				SourceModel: SubscriberModel{
+					ModelId: mdl.ModelId{
+						Name: "network",
+						Tags: map[string]string{
+							"project": "mcoins",
+							"family":  "marketing",
+							"group":   "management",
+						},
+						DomainPattern: "{app.tags.project}.{app.tags.family}.{app.tags.group}",
+					},
+				},
+			},
+		},
+	}
+
+	result, err := collectModelIdsByInput(config, settings)
+	require.NoError(t, err)
+
+	// Non-shared subscribers get separate input keys
+	assert.Len(t, result, 2)
+
+	for _, modelIds := range result {
+		assert.Len(t, modelIds, 1)
+	}
+}
+
+func TestSnsSubscriberInputConfigPostProcessor_SetsFilterAttributes(t *testing.T) {
+	config := cfg.New(map[string]any{
+		"app": map[string]any{
+			"name": "subscriber",
+			"tags": map[string]any{
+				"project": "mcoins",
+				"family":  "marketing",
+				"group":   "attribution",
+			},
+		},
+	})
+
+	subscriberSettings := &SubscriberSettings{
+		Input: "sns",
+		SourceModel: SubscriberModel{
+			ModelId: mdl.ModelId{
+				Name: "app",
+				Tags: map[string]string{
+					"project": "mcoins",
+					"family":  "marketing",
+					"group":   "management",
+				},
+				DomainPattern: "{app.tags.project}.{app.tags.family}.{app.tags.group}",
+			},
+		},
+	}
+
+	modelIds := []string{
+		"mcoins.marketing.management.app",
+		"mcoins.marketing.management.network",
+	}
+
+	option, err := snsSubscriberInputConfigPostProcessor(config, "app", subscriberSettings, modelIds)
+	require.NoError(t, err)
+	require.NotNil(t, option)
+
+	err = config.Option(option)
+	require.NoError(t, err)
+
+	// Read back the input config to verify attributes were set
+	inputKey := stream.ConfigurableInputKey("subscriber-app")
+
+	inputSettings := &stream.SnsInputConfiguration{}
+	err = config.UnmarshalKey(inputKey, inputSettings)
+	require.NoError(t, err)
+
+	require.Len(t, inputSettings.Targets, 1)
+	assert.Equal(t, map[string][]string{
+		"modelId": {"mcoins.marketing.management.app", "mcoins.marketing.management.network"},
+	}, inputSettings.Targets[0].Attributes)
+}

--- a/pkg/stream/input_configurable.go
+++ b/pkg/stream/input_configurable.go
@@ -148,9 +148,9 @@ func newRedisInputFromConfig(ctx context.Context, config cfg.Config, logger log.
 
 type SnsInputTargetConfiguration struct {
 	cfg.ResourceIdentifier
-	TopicId    string            `cfg:"topic_id" validate:"required"`
-	Attributes map[string]string `cfg:"attributes"`
-	ClientName string            `cfg:"client_name" default:"default"`
+	TopicId    string              `cfg:"topic_id" validate:"required"`
+	Attributes map[string][]string `cfg:"attributes"`
+	ClientName string              `cfg:"client_name" default:"default"`
 }
 
 type SnsInputConfiguration struct {

--- a/pkg/stream/input_configurable.go
+++ b/pkg/stream/input_configurable.go
@@ -148,9 +148,9 @@ func newRedisInputFromConfig(ctx context.Context, config cfg.Config, logger log.
 
 type SnsInputTargetConfiguration struct {
 	cfg.ResourceIdentifier
-	TopicId    string              `cfg:"topic_id" validate:"required"`
-	Attributes map[string][]string `cfg:"attributes"`
-	ClientName string              `cfg:"client_name" default:"default"`
+	TopicId      string              `cfg:"topic_id" validate:"required"`
+	FilterPolicy map[string][]string `cfg:"filter_policy"`
+	ClientName   string              `cfg:"client_name" default:"default"`
 }
 
 type SnsInputConfiguration struct {
@@ -203,10 +203,10 @@ func readSnsInputSettings(config cfg.Config, name string) (*SnsInputSettings, []
 		}
 
 		targets[i] = SnsInputTarget{
-			Identity:   t.ToIdentity(),
-			TopicId:    t.TopicId,
-			Attributes: t.Attributes,
-			ClientName: clientName,
+			Identity:     t.ToIdentity(),
+			TopicId:      t.TopicId,
+			FilterPolicy: t.FilterPolicy,
+			ClientName:   clientName,
 		}
 	}
 

--- a/pkg/stream/input_sns.go
+++ b/pkg/stream/input_sns.go
@@ -44,7 +44,7 @@ func (s SnsInputSettings) IsFifoEnabled() bool {
 type SnsInputTarget struct {
 	Identity   cfg.Identity
 	TopicId    string
-	Attributes map[string]string
+	Attributes map[string][]string
 	ClientName string
 }
 

--- a/pkg/stream/input_sns.go
+++ b/pkg/stream/input_sns.go
@@ -42,10 +42,10 @@ func (s SnsInputSettings) IsFifoEnabled() bool {
 }
 
 type SnsInputTarget struct {
-	Identity   cfg.Identity
-	TopicId    string
-	Attributes map[string][]string
-	ClientName string
+	Identity     cfg.Identity
+	TopicId      string
+	FilterPolicy map[string][]string
+	ClientName   string
 }
 
 func (t SnsInputTarget) GetIdentity() cfg.Identity {

--- a/pkg/stream/input_sns_lifecycle.go
+++ b/pkg/stream/input_sns_lifecycle.go
@@ -80,7 +80,7 @@ func (l *lifecycleManager) Create(ctx context.Context) error {
 			return fmt.Errorf("can not create topic %s: %w", topicName, err)
 		}
 
-		if err = l.snsService.SubscribeSqs(ctx, props.Arn, topicArn, target.Attributes); err != nil {
+		if err = l.snsService.SubscribeSqs(ctx, props.Arn, topicArn, target.FilterPolicy); err != nil {
 			return fmt.Errorf("can not subscribe to queue: %w", err)
 		}
 	}


### PR DESCRIPTION
This pull request introduces significant improvements to how SNS subscription filter policies are handled, particularly by supporting multiple values per attribute (array filter policies) and ensuring consistent usage throughout the codebase. It also enhances the configuration post-processing logic for subscribers, adds comprehensive unit tests, and refactors function signatures for clarity and extensibility.

**SNS Subscription Filter Policy Improvements:**

- Changed the SNS filter policy handling to support attributes with multiple values (arrays), updating function signatures and logic from `map[string]string` to `map[string][]string` throughout the SNS service implementation. This allows for more flexible and accurate filtering when subscribing SQS queues to SNS topics. [[1]](diffhunk://#diff-1fd45225e0db32091385d38573a9b61aeefcf2860bac582e4e378130348a8931L60-R60) [[2]](diffhunk://#diff-cd0e674ca69e2ca9306f87bf064bf66fa5e76eb673f3f5fc521933cc2b58fd44L61-R61) [[3]](diffhunk://#diff-cd0e674ca69e2ca9306f87bf064bf66fa5e76eb673f3f5fc521933cc2b58fd44L108-R108) [[4]](diffhunk://#diff-cd0e674ca69e2ca9306f87bf064bf66fa5e76eb673f3f5fc521933cc2b58fd44L171-R171)
- Updated all relevant test cases in `service_test.go` to use the new array-based filter policy format and added new tests to cover scenarios with array filter policies, including cases where the set of model IDs changes and requires resubscription. [[1]](diffhunk://#diff-67c38fa349e4c0d40abb250de9b47be03017f59a9d79ef1516fc393a188cdea1L45-R55) [[2]](diffhunk://#diff-67c38fa349e4c0d40abb250de9b47be03017f59a9d79ef1516fc393a188cdea1L76-R83) [[3]](diffhunk://#diff-67c38fa349e4c0d40abb250de9b47be03017f59a9d79ef1516fc393a188cdea1L115-R124) [[4]](diffhunk://#diff-67c38fa349e4c0d40abb250de9b47be03017f59a9d79ef1516fc393a188cdea1L145-R209)

**Subscriber Configuration Post-Processing Enhancements:**

- Refactored the subscriber input config post-processor functions to accept a list of model IDs and to build filter attributes accordingly, enabling correct SNS filter policy configuration for shared and non-shared subscribers. [[1]](diffhunk://#diff-3baa7f798c25648bce7d37f700ef723112a58e3577bf5a36cf1e0dd6e813d46cL17-R18) [[2]](diffhunk://#diff-3baa7f798c25648bce7d37f700ef723112a58e3577bf5a36cf1e0dd6e813d46cR42-R102) [[3]](diffhunk://#diff-3baa7f798c25648bce7d37f700ef723112a58e3577bf5a36cf1e0dd6e813d46cL81-R133) [[4]](diffhunk://#diff-3baa7f798c25648bce7d37f700ef723112a58e3577bf5a36cf1e0dd6e813d46cL103-R155) [[5]](diffhunk://#diff-3baa7f798c25648bce7d37f700ef723112a58e3577bf5a36cf1e0dd6e813d46cR189-R196) [[6]](diffhunk://#diff-3baa7f798c25648bce7d37f700ef723112a58e3577bf5a36cf1e0dd6e813d46cL170-R223)
- Added helper functions to collect model IDs by input and to build subscriber filter attributes, ensuring that all relevant model IDs are included in the SNS filter policy for each input. [[1]](diffhunk://#diff-3baa7f798c25648bce7d37f700ef723112a58e3577bf5a36cf1e0dd6e813d46cR42-R102) [[2]](diffhunk://#diff-3baa7f798c25648bce7d37f700ef723112a58e3577bf5a36cf1e0dd6e813d46cR269-R278)

**Testing and Validation:**

- Added a new test file, `config_postprocessor_subscriber_test.go`, with comprehensive unit tests for the new filter attribute logic, model ID collection, and SNS subscriber input config post-processor. These tests verify correct behavior for both shared and non-shared subscribers and for various combinations of model IDs.

**Minor Refactors:**

- Fixed a receiver naming inconsistency in the SNS service implementation for clarity. [[1]](diffhunk://#diff-cd0e674ca69e2ca9306f87bf064bf66fa5e76eb673f3f5fc521933cc2b58fd44L144-R144) [[2]](diffhunk://#diff-cd0e674ca69e2ca9306f87bf064bf66fa5e76eb673f3f5fc521933cc2b58fd44L155-R155)
- Added the `slices` import for sorting model ID arrays to ensure deterministic filter policies.

These changes collectively make SNS subscription management more robust, flexible, and easier to test and maintain.