### PR TITLE
kafka: handle unknown topic errors;

### DIFF
--- a/pkg/kafka/consumer/consumer.go
+++ b/pkg/kafka/consumer/consumer.go
@@ -15,6 +15,7 @@ import (
 	"github.com/justtrackio/gosoline/pkg/log"
 	"github.com/justtrackio/gosoline/pkg/metric"
 	"github.com/justtrackio/gosoline/pkg/reslife"
+	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo"
 )
 
@@ -132,12 +133,28 @@ func newExecutor(logger log.Logger, reader Reader, settings *Settings) exec.Exec
 		res,
 		&settings.Backoff,
 		[]exec.ErrorChecker{
+			CheckKafkaUnknownTopicError,
 			CheckKafkaRetryableError(reader),
 		},
 		exec.WithElapsedTimeTrackerFactory(func() exec.ElapsedTimeTracker {
 			return exec.NewErrorTriggeredElapsedTimeTracker()
 		}),
 	)
+}
+
+// CheckKafkaUnknownTopicError is an exec.ErrorChecker that fails fast when the consumer is configured
+// for a topic that does not exist. franz-go surfaces these as UNKNOWN_TOPIC_OR_PARTITION (or
+// UNKNOWN_TOPIC_ID) once KeepRetryableFetchErrors is enabled.
+func CheckKafkaUnknownTopicError(_ any, err error) exec.ErrorType {
+	if isUnknownTopicError(err) {
+		return exec.ErrorTypePermanent
+	}
+
+	return exec.ErrorTypeUnknown
+}
+
+func isUnknownTopicError(err error) bool {
+	return errors.Is(err, kerr.UnknownTopicOrPartition) || errors.Is(err, kerr.UnknownTopicID)
 }
 
 // CheckKafkaRetryableError is an exec.ErrorChecker that classifies Kafka errors.
@@ -258,6 +275,16 @@ func (c *consumer) pollRecords(ctx context.Context) (any, error) {
 
 		if errors.As(fetchError.Err, &errDataLoss) {
 			c.logger.Warn(ctx, "%s", fetchError.Err.Error())
+
+			continue
+		}
+
+		// KeepRetryableFetchErrors surfaces missing-topic errors so we can fail fast, but also exposes other
+		// retryable per-partition errors that franz-go recovers from internally. Ignore those and keep the
+		// records returned alongside them, rather than discarding the fetch (which could drop records).
+		if kerr.IsRetriable(fetchError.Err) && !isUnknownTopicError(fetchError.Err) {
+			c.logger.Warn(ctx, "ignoring retryable kafka fetch error (topic: %s, partition: %d): %s",
+				fetchError.Topic, fetchError.Partition, fetchError.Err.Error())
 
 			continue
 		}

--- a/pkg/kafka/consumer/consumer_test.go
+++ b/pkg/kafka/consumer/consumer_test.go
@@ -3,6 +3,7 @@ package consumer_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"testing"
@@ -10,12 +11,17 @@ import (
 
 	"github.com/justtrackio/gosoline/pkg/clock"
 	"github.com/justtrackio/gosoline/pkg/exec"
+	"github.com/justtrackio/gosoline/pkg/kafka"
 	"github.com/justtrackio/gosoline/pkg/kafka/consumer"
 	kafkaConsumerMocks "github.com/justtrackio/gosoline/pkg/kafka/consumer/mocks"
 	"github.com/justtrackio/gosoline/pkg/log"
+	"github.com/justtrackio/gosoline/pkg/metric"
 	metricMocks "github.com/justtrackio/gosoline/pkg/metric/mocks"
+	"github.com/justtrackio/gosoline/pkg/test/matcher"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/twmb/franz-go/pkg/kerr"
+	"github.com/twmb/franz-go/pkg/kgo"
 	"golang.org/x/sys/unix"
 )
 
@@ -196,5 +202,235 @@ func TestCheckKafkaRetryableError(t *testing.T) {
 			result := consumer.CheckKafkaRetryableError(kafkaReader)(nil, tt.err)
 			assert.Equal(t, tt.expected, result, "CheckKafkaRetryableError(nil, %v) = %v, want %v", tt.err, result, tt.expected)
 		})
+	}
+}
+
+func TestCheckKafkaUnknownTopicError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected exec.ErrorType
+	}{
+		{
+			name:     "nil error falls through",
+			err:      nil,
+			expected: exec.ErrorTypeUnknown,
+		},
+		{
+			name:     "UnknownTopicOrPartition is permanent",
+			err:      kerr.UnknownTopicOrPartition,
+			expected: exec.ErrorTypePermanent,
+		},
+		{
+			name:     "UnknownTopicID is permanent",
+			err:      kerr.UnknownTopicID,
+			expected: exec.ErrorTypePermanent,
+		},
+		{
+			name:     "wrapped UnknownTopicOrPartition is permanent",
+			err:      fmt.Errorf("failed to fetch records (topic: %s, partition: %d): %w", "some-topic", 0, kerr.UnknownTopicOrPartition),
+			expected: exec.ErrorTypePermanent,
+		},
+		{
+			name: "joined wrapped UnknownTopicOrPartition is permanent",
+			err: errors.Join(
+				fmt.Errorf("failed to fetch records (topic: %s, partition: %d): %w", "other-topic", 1, kerr.LeaderNotAvailable),
+				fmt.Errorf("failed to fetch records (topic: %s, partition: %d): %w", "some-topic", 0, kerr.UnknownTopicOrPartition),
+			),
+			expected: exec.ErrorTypePermanent,
+		},
+		{
+			name:     "retryable kafka error falls through",
+			err:      kerr.NotLeaderForPartition,
+			expected: exec.ErrorTypeUnknown,
+		},
+		{
+			name:     "generic error falls through",
+			err:      errors.New("some random error"),
+			expected: exec.ErrorTypeUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := consumer.CheckKafkaUnknownTopicError(nil, tt.err)
+			assert.Equal(t, tt.expected, result, "CheckKafkaUnknownTopicError(nil, %v) = %v, want %v", tt.err, result, tt.expected)
+		})
+	}
+}
+
+// A missing topic must NOT be ignored; it has to be surfaced so the executor fails the consumer fast.
+// franz-go surfaces this as UNKNOWN_TOPIC_OR_PARTITION or UNKNOWN_TOPIC_ID once KeepRetryableFetchErrors
+// is enabled.
+func TestConsumerRunFailsFastOnUnknownTopic(t *testing.T) {
+	for name, partitionErr := range map[string]error{
+		"UnknownTopicOrPartition": kerr.UnknownTopicOrPartition,
+		"UnknownTopicID":          kerr.UnknownTopicID,
+	} {
+		t.Run(name, func(t *testing.T) {
+			reader := kafkaConsumerMocks.NewReader(t)
+			handler := kafkaConsumerMocks.NewKafkaMessageHandler(t)
+			metricWriter := metricMocks.NewWriter(t)
+
+			reader.EXPECT().PollRecords(nil, 100).Return(fetchWithPartitionError(nil, partitionErr)).Once()
+			reader.EXPECT().CloseAllowingRebalance().Once()
+			handler.EXPECT().Stop().Once()
+
+			readerFactory := func(_ context.Context, _ *consumer.PartitionManager) (consumer.Reader, error) {
+				return reader, nil
+			}
+
+			fakeClock := clock.NewFakeClock()
+			healthCheckTimer := clock.NewHealthCheckTimerWithInterfaces(fakeClock, time.Minute)
+
+			c := consumer.NewConsumerWithInterfaces(
+				log.NewLogger(),
+				fakeClock,
+				healthCheckTimer,
+				handler,
+				readerFactory,
+				consumer.Settings{
+					MaxPollRecords: 100,
+					IdleWaitTime:   500 * time.Millisecond,
+				},
+				metricWriter,
+				"missing-topic",
+				false,
+				"test-consumer",
+			)
+
+			err := c.Run(t.Context())
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, partitionErr), "expected error to wrap %v, got: %v", partitionErr, err)
+		})
+	}
+}
+
+// A retryable, non-unknown-topic fetch error (e.g. NOT_LEADER_FOR_PARTITION) must be ignored so that the
+// records delivered alongside it are still processed and the consumer keeps running.
+func TestConsumerRunIgnoresRetryableFetchError(t *testing.T) {
+	reader := kafkaConsumerMocks.NewReader(t)
+	handler := kafkaConsumerMocks.NewKafkaMessageHandler(t)
+	metricWriter := metricMocks.NewWriter(t)
+
+	records := []*kgo.Record{{Value: []byte("payload")}}
+	// The first poll returns a record alongside a retryable per-partition error; the second poll reports the
+	// client as closed so Run leaves its loop.
+	reader.EXPECT().PollRecords(nil, 100).Return(fetchWithPartitionError(records, kerr.NotLeaderForPartition)).Once()
+	reader.EXPECT().PollRecords(nil, 100).Return(clientClosedFetches()).Once()
+	reader.EXPECT().AllowRebalance().Once()
+	reader.EXPECT().CloseAllowingRebalance().Once()
+
+	handler.EXPECT().Handle(records).Once()
+	handler.EXPECT().Stop().Once()
+
+	dims := metric.Dimensions{
+		kafka.DimensionClientType: kafka.DimensionConsumer,
+		kafka.DimensionClient:     "test-consumer",
+		kafka.DimensionTopic:      "test-topic",
+	}
+	expectedMetrics := metric.Data{
+		metric.NewMetricDatum("PollCount", dims, 1.0, metric.UnitCount, metric.PriorityHigh),
+		metric.NewMetricDatum("PollDuration", dims, 0.0, metric.UnitMillisecondsAverage, metric.PriorityHigh),
+		metric.NewMetricDatum("RecordsConsumed", dims, 1.0, metric.UnitCount, metric.PriorityHigh),
+	}
+	metricWriter.EXPECT().Write(matcher.Context, expectedMetrics).Once()
+
+	readerFactory := func(_ context.Context, _ *consumer.PartitionManager) (consumer.Reader, error) {
+		return reader, nil
+	}
+
+	fakeClock := clock.NewFakeClock()
+	healthCheckTimer := clock.NewHealthCheckTimerWithInterfaces(fakeClock, time.Minute)
+
+	c := consumer.NewConsumerWithInterfaces(
+		log.NewLogger(),
+		fakeClock,
+		healthCheckTimer,
+		handler,
+		readerFactory,
+		consumer.Settings{
+			MaxPollRecords: 100,
+			IdleWaitTime:   500 * time.Millisecond,
+		},
+		metricWriter,
+		"test-topic",
+		true,
+		"test-consumer",
+	)
+
+	err := c.Run(t.Context())
+	assert.NoError(t, err, "a retryable non-unknown-topic fetch error should be ignored")
+}
+
+// A non-retryable fetch error must be surfaced so the executor treats it as permanent and fails the consumer.
+func TestConsumerRunSurfacesNonRetryableFetchError(t *testing.T) {
+	reader := kafkaConsumerMocks.NewReader(t)
+	handler := kafkaConsumerMocks.NewKafkaMessageHandler(t)
+	metricWriter := metricMocks.NewWriter(t)
+
+	// InvalidTopicException (code 17) is not retryable.
+	reader.EXPECT().PollRecords(nil, 100).Return(fetchWithPartitionError(nil, kerr.InvalidTopicException)).Once()
+	reader.EXPECT().CloseAllowingRebalance().Once()
+	handler.EXPECT().Stop().Once()
+
+	readerFactory := func(_ context.Context, _ *consumer.PartitionManager) (consumer.Reader, error) {
+		return reader, nil
+	}
+
+	fakeClock := clock.NewFakeClock()
+	healthCheckTimer := clock.NewHealthCheckTimerWithInterfaces(fakeClock, time.Minute)
+
+	c := consumer.NewConsumerWithInterfaces(
+		log.NewLogger(),
+		fakeClock,
+		healthCheckTimer,
+		handler,
+		readerFactory,
+		consumer.Settings{
+			MaxPollRecords: 100,
+			IdleWaitTime:   500 * time.Millisecond,
+		},
+		metricWriter,
+		"test-topic",
+		false,
+		"test-consumer",
+	)
+
+	err := c.Run(t.Context())
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, kerr.InvalidTopicException), "expected error to wrap INVALID_TOPIC_EXCEPTION, got: %v", err)
+}
+
+// fetchWithPartitionError builds a single-partition Fetches carrying the given records alongside a
+// per-partition fetch error. franz-go may surface per-partition errors this way once
+// KeepRetryableFetchErrors is enabled.
+func fetchWithPartitionError(records []*kgo.Record, partitionErr error) kgo.Fetches {
+	return kgo.Fetches{
+		{
+			Topics: []kgo.FetchTopic{
+				{
+					Topic: "test-topic",
+					Partitions: []kgo.FetchPartition{
+						{Partition: 0, Records: records, Err: partitionErr},
+					},
+				},
+			},
+		},
+	}
+}
+
+func clientClosedFetches() kgo.Fetches {
+	return kgo.Fetches{
+		{
+			Topics: []kgo.FetchTopic{
+				{
+					Topic: "test-topic",
+					Partitions: []kgo.FetchPartition{
+						{Partition: 0, Err: kgo.ErrClientClosed},
+					},
+				},
+			},
+		},
 	}
 }

--- a/pkg/kafka/consumer/reader.go
+++ b/pkg/kafka/consumer/reader.go
@@ -32,6 +32,10 @@ func NewReader(ctx context.Context, config cfg.Config, logger log.Logger, settin
 		kgo.ConsumeResetOffset(settings.GetStartOffset()),
 		kgo.ConsumeStartOffset(settings.GetStartOffset()),
 		kgo.ConsumeTopics(topicName),
+		// Keep retryable fetch errors so that errors like UNKNOWN_TOPIC_OR_PARTITION are surfaced to
+		// PollRecords instead of being silently stripped by franz-go. This lets us detect a consumer
+		// that is configured for a topic which does not exist and fail fast instead of idling forever.
+		kgo.KeepRetryableFetchErrors(),
 		kgo.FetchIsolationLevel(settings.GetFetchIsolationLevel()),
 		kgo.HeartbeatInterval(settings.HeartbeatInterval),
 		kgo.RebalanceTimeout(settings.RebalanceTimeout),

--- a/pkg/kafka/consumer/reader_test.go
+++ b/pkg/kafka/consumer/reader_test.go
@@ -1,0 +1,48 @@
+package consumer_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/justtrackio/gosoline/pkg/cfg"
+	"github.com/justtrackio/gosoline/pkg/kafka/consumer"
+	"github.com/justtrackio/gosoline/pkg/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+func TestNewReader_KeepsRetryableFetchErrors(t *testing.T) {
+	config := cfg.New(map[string]any{
+		"app": map[string]any{
+			"env":  "test",
+			"name": "testapp",
+		},
+		"kafka": map[string]any{
+			"naming": map[string]any{
+				"topic_pattern": "{app.name}-{topicId}",
+			},
+			"connection": map[string]any{
+				"default": map[string]any{
+					"brokers": []any{"localhost:9092"},
+				},
+			},
+		},
+	})
+
+	settings := consumer.Settings{
+		Connection:       "default",
+		TopicId:          "test-topic",
+		SessionTimeout:   45 * time.Second,
+		RebalanceTimeout: 60 * time.Second,
+	}
+
+	// isReadOnly is true so the reader does not require a consumer group / partition manager.
+	reader, err := consumer.NewReader(t.Context(), config, log.NewLogger(), settings, nil, true, "test-consumer")
+	require.NoError(t, err)
+
+	client, ok := reader.(*kgo.Client)
+	require.True(t, ok, "expected reader to be a *kgo.Client")
+
+	assert.Equal(t, true, client.OptValue(kgo.KeepRetryableFetchErrors))
+}


### PR DESCRIPTION
By default the franz-go consumer considers unknown topic errors retryable and keeps silently retrying them forever. A misconfigured topic could thus go unnoticed.

This change enables the `KeepRetryableFetchErrors` option for the franz-go reader which makes franz-go return unknown topic errors (among other errors it considers retryable), so we can fail and log the error in that case.