### PR TITLE
Fix SNS filter policies on repeated resource creation

### DIFF
--- a/pkg/cloud/aws/sns/client.go
+++ b/pkg/cloud/aws/sns/client.go
@@ -23,6 +23,7 @@ type Client interface {
 	ListTopics(ctx context.Context, params *sns.ListTopicsInput, optFns ...func(options *sns.Options)) (*sns.ListTopicsOutput, error)
 	Publish(ctx context.Context, params *sns.PublishInput, optFns ...func(options *sns.Options)) (*sns.PublishOutput, error)
 	PublishBatch(ctx context.Context, input *sns.PublishBatchInput, optFns ...func(options *sns.Options)) (*sns.PublishBatchOutput, error)
+	SetSubscriptionAttributes(ctx context.Context, params *sns.SetSubscriptionAttributesInput, optFns ...func(*sns.Options)) (*sns.SetSubscriptionAttributesOutput, error)
 	Subscribe(ctx context.Context, params *sns.SubscribeInput, optFns ...func(options *sns.Options)) (*sns.SubscribeOutput, error)
 	Unsubscribe(ctx context.Context, params *sns.UnsubscribeInput, optFns ...func(*sns.Options)) (*sns.UnsubscribeOutput, error)
 }

--- a/pkg/cloud/aws/sns/mocks/Client.go
+++ b/pkg/cloud/aws/sns/mocks/Client.go
@@ -540,6 +540,80 @@ func (_c *Client_PublishBatch_Call) RunAndReturn(run func(context.Context, *sns.
 	return _c
 }
 
+// SetSubscriptionAttributes provides a mock function with given fields: ctx, params, optFns
+func (_m *Client) SetSubscriptionAttributes(ctx context.Context, params *sns.SetSubscriptionAttributesInput, optFns ...func(*sns.Options)) (*sns.SetSubscriptionAttributesOutput, error) {
+	_va := make([]interface{}, len(optFns))
+	for _i := range optFns {
+		_va[_i] = optFns[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, params)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetSubscriptionAttributes")
+	}
+
+	var r0 *sns.SetSubscriptionAttributesOutput
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *sns.SetSubscriptionAttributesInput, ...func(*sns.Options)) (*sns.SetSubscriptionAttributesOutput, error)); ok {
+		return rf(ctx, params, optFns...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *sns.SetSubscriptionAttributesInput, ...func(*sns.Options)) *sns.SetSubscriptionAttributesOutput); ok {
+		r0 = rf(ctx, params, optFns...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*sns.SetSubscriptionAttributesOutput)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *sns.SetSubscriptionAttributesInput, ...func(*sns.Options)) error); ok {
+		r1 = rf(ctx, params, optFns...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Client_SetSubscriptionAttributes_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetSubscriptionAttributes'
+type Client_SetSubscriptionAttributes_Call struct {
+	*mock.Call
+}
+
+// SetSubscriptionAttributes is a helper method to define mock.On call
+//   - ctx context.Context
+//   - params *sns.SetSubscriptionAttributesInput
+//   - optFns ...func(*sns.Options)
+func (_e *Client_Expecter) SetSubscriptionAttributes(ctx interface{}, params interface{}, optFns ...interface{}) *Client_SetSubscriptionAttributes_Call {
+	return &Client_SetSubscriptionAttributes_Call{Call: _e.mock.On("SetSubscriptionAttributes",
+		append([]interface{}{ctx, params}, optFns...)...)}
+}
+
+func (_c *Client_SetSubscriptionAttributes_Call) Run(run func(ctx context.Context, params *sns.SetSubscriptionAttributesInput, optFns ...func(*sns.Options))) *Client_SetSubscriptionAttributes_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]func(*sns.Options), len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(func(*sns.Options))
+			}
+		}
+		run(args[0].(context.Context), args[1].(*sns.SetSubscriptionAttributesInput), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *Client_SetSubscriptionAttributes_Call) Return(_a0 *sns.SetSubscriptionAttributesOutput, _a1 error) *Client_SetSubscriptionAttributes_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Client_SetSubscriptionAttributes_Call) RunAndReturn(run func(context.Context, *sns.SetSubscriptionAttributesInput, ...func(*sns.Options)) (*sns.SetSubscriptionAttributesOutput, error)) *Client_SetSubscriptionAttributes_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Subscribe provides a mock function with given fields: ctx, params, optFns
 func (_m *Client) Subscribe(ctx context.Context, params *sns.SubscribeInput, optFns ...func(*sns.Options)) (*sns.SubscribeOutput, error) {
 	_va := make([]interface{}, len(optFns))

--- a/pkg/cloud/aws/sns/service.go
+++ b/pkg/cloud/aws/sns/service.go
@@ -131,11 +131,13 @@ func (s *Service) subscriptionExists(ctx context.Context, queueArn string, topic
 			"topicArn":        *subscription.TopicArn,
 			"subscriptionArt": *subscription.SubscriptionArn,
 			"queueArn":        queueArn,
-		}).Info(ctx, "found not matching subscription for queue %s, deleting %s", queueArn, *subscription.SubscriptionArn)
+		}).Info(ctx, "found not matching subscription for queue %s, updating %s", queueArn, *subscription.SubscriptionArn)
 
-		if err = s.deleteSubscription(ctx, subscription.SubscriptionArn); err != nil {
-			return false, fmt.Errorf("can not delete subscription: %w", err)
+		if err = s.setSubscriptionFilterPolicy(ctx, subscription.SubscriptionArn, filterPolicy); err != nil {
+			return false, fmt.Errorf("can not update subscription: %w", err)
 		}
+
+		return true, nil
 	}
 
 	return false, nil
@@ -218,13 +220,23 @@ func (s *Service) getSubscriptionAttributes(ctx context.Context, subscriptionArn
 	return out.Attributes, nil
 }
 
-func (s *Service) deleteSubscription(ctx context.Context, subscriptionArn *string) error {
-	input := &sns.UnsubscribeInput{
+func (s *Service) setSubscriptionFilterPolicy(ctx context.Context, subscriptionArn *string, filterPolicy map[string][]string) error {
+	policy := "{}"
+	if len(filterPolicy) > 0 {
+		var err error
+		if policy, err = buildFilterPolicy(filterPolicy); err != nil {
+			return fmt.Errorf("can not build filter policy: %w", err)
+		}
+	}
+
+	input := &sns.SetSubscriptionAttributesInput{
+		AttributeName:   aws.String("FilterPolicy"),
+		AttributeValue:  aws.String(policy),
 		SubscriptionArn: subscriptionArn,
 	}
 
-	if _, err := s.client.Unsubscribe(ctx, input); err != nil {
-		return fmt.Errorf("can not unsubscribe from sns topic: %w", err)
+	if _, err := s.client.SetSubscriptionAttributes(ctx, input); err != nil {
+		return fmt.Errorf("can not set subscription attributes: %w", err)
 	}
 
 	return nil

--- a/pkg/cloud/aws/sns/service_test.go
+++ b/pkg/cloud/aws/sns/service_test.go
@@ -106,19 +106,12 @@ func (s *ServiceTestSuite) TestSubscribeSqsExistsWithDifferentAttributes() {
 	}
 	s.client.EXPECT().GetSubscriptionAttributes(matcher.Context, getAttributesInput).Return(getAttributesOutput, nil).Once()
 
-	unsubscribeInput := &awsSns.UnsubscribeInput{SubscriptionArn: aws.String("subscriptionArn")}
-	unsubscribeOutput := &awsSns.UnsubscribeOutput{}
-	s.client.EXPECT().Unsubscribe(matcher.Context, unsubscribeInput).Return(unsubscribeOutput, nil).Once()
-
-	subInput := &awsSns.SubscribeInput{
-		Attributes: map[string]string{
-			"FilterPolicy": `{"model":["goso"]}`,
-		},
-		Endpoint: aws.String("queueArn"),
-		Protocol: aws.String("sqs"),
-		TopicArn: aws.String("topicArn"),
+	setAttributesInput := &awsSns.SetSubscriptionAttributesInput{
+		AttributeName:   aws.String("FilterPolicy"),
+		AttributeValue:  aws.String(`{"model":["goso"]}`),
+		SubscriptionArn: aws.String("subscriptionArn"),
 	}
-	s.client.EXPECT().Subscribe(matcher.Context, subInput).Return(nil, nil).Once()
+	s.client.EXPECT().SetSubscriptionAttributes(matcher.Context, setAttributesInput).Return(&awsSns.SetSubscriptionAttributesOutput{}, nil).Once()
 
 	err := s.service.SubscribeSqs(s.T().Context(), "queueArn", "topicArn", map[string][]string{
 		"model": {"goso"},
@@ -187,20 +180,12 @@ func (s *ServiceTestSuite) TestSubscribeSqsExistsWithArrayFilterPolicy() {
 	}
 	s.client.EXPECT().GetSubscriptionAttributes(matcher.Context, getAttributesInput).Return(getAttributesOutput, nil).Once()
 
-	// Existing policy has ["model.a","model.b"] but we want ["model.a","model.b","model.c"], so it should delete and re-subscribe
-	unsubscribeInput := &awsSns.UnsubscribeInput{SubscriptionArn: aws.String("subscriptionArn")}
-	unsubscribeOutput := &awsSns.UnsubscribeOutput{}
-	s.client.EXPECT().Unsubscribe(matcher.Context, unsubscribeInput).Return(unsubscribeOutput, nil).Once()
-
-	subInput := &awsSns.SubscribeInput{
-		Attributes: map[string]string{
-			"FilterPolicy": `{"modelId":["model.a","model.b","model.c"]}`,
-		},
-		Endpoint: aws.String("queueArn"),
-		Protocol: aws.String("sqs"),
-		TopicArn: aws.String("topicArn"),
+	setAttributesInput := &awsSns.SetSubscriptionAttributesInput{
+		AttributeName:   aws.String("FilterPolicy"),
+		AttributeValue:  aws.String(`{"modelId":["model.a","model.b","model.c"]}`),
+		SubscriptionArn: aws.String("subscriptionArn"),
 	}
-	s.client.EXPECT().Subscribe(matcher.Context, subInput).Return(nil, nil).Once()
+	s.client.EXPECT().SetSubscriptionAttributes(matcher.Context, setAttributesInput).Return(&awsSns.SetSubscriptionAttributesOutput{}, nil).Once()
 
 	err := s.service.SubscribeSqs(s.ctx, "queueArn", "topicArn", map[string][]string{
 		"modelId": {"model.a", "model.b", "model.c"},


### PR DESCRIPTION
## Issue

SNS inputs that autocreate SQS subscriptions applied their filter policy during the first application run, but the filter could disappear on subsequent runs. When an existing subscription did not match the configured policy, Gosoline deleted it and immediately recreated it. Due to SNS eventual consistency, the subsequent Subscribe call could resolve to the existing subscription, leaving the subscription without the intended filter policy.

## Fix

Update the existing subscription in place with SNS SetSubscriptionAttributes instead of deleting and recreating it. This preserves the subscription ARN and reliably applies changed policies. An empty policy is represented as {} so configured policy removal is also handled correctly.

## Tests

- go test ./pkg/cloud/aws/sns
- go test ./pkg/stream ./pkg/mdlsub
- git diff --check