### PR TITLE
feature: add legacy HTTP error mappers

### DIFF
--- a/pkg/httpserver/error.go
+++ b/pkg/httpserver/error.go
@@ -1,11 +1,51 @@
 package httpserver
 
 import (
+	"sync"
+
 	"github.com/gin-gonic/gin"
 	"github.com/justtrackio/gosoline/pkg/mdl"
 )
 
 type ErrorHandler func(statusCode int, err error) *Response
+
+// ErrorMapper maps an application error to an HTTP status code. The handled
+// result indicates whether the mapper applies to the error.
+type ErrorMapper func(err error) (statusCode int, handled bool)
+
+var (
+	errorMappersMu sync.RWMutex
+	errorMappers   []ErrorMapper
+)
+
+// RegisterErrorMapper adds a status mapper used by the HTTP handler helpers.
+// Mappers are evaluated for errors that would otherwise use the generic 500
+// fallback; the built-in forbidden, cancellation, and validation mappings take
+// precedence.
+func RegisterErrorMapper(mapper ErrorMapper) {
+	if mapper == nil {
+		panic("error mapper is required")
+	}
+
+	errorMappersMu.Lock()
+	defer errorMappersMu.Unlock()
+
+	errorMappers = append(errorMappers, mapper)
+}
+
+func errorStatusCodeFromMappers(err error) (int, bool) {
+	errorMappersMu.RLock()
+	mappers := append([]ErrorMapper(nil), errorMappers...)
+	errorMappersMu.RUnlock()
+
+	for _, mapper := range mappers {
+		if statusCode, handled := mapper(err); handled {
+			return statusCode, true
+		}
+	}
+
+	return 0, false
+}
 
 func errorHandlerJson(statusCode int, err error) *Response {
 	body := gin.H{"err": err.Error()}

--- a/pkg/httpserver/error_mapper_test.go
+++ b/pkg/httpserver/error_mapper_test.go
@@ -1,0 +1,60 @@
+package httpserver_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/justtrackio/gosoline/pkg/httpserver"
+	"github.com/stretchr/testify/assert"
+)
+
+type errorReturningHandler struct {
+	err error
+}
+
+func (h errorReturningHandler) Handle(context.Context, *httpserver.Request) (*httpserver.Response, error) {
+	return nil, h.err
+}
+
+func TestCreateHandler_UsesRegisteredErrorMapper(t *testing.T) {
+	expectedError := errors.New("authorization denied")
+	httpserver.RegisterErrorMapper(func(err error) (int, bool) {
+		if errors.Is(err, expectedError) {
+			return http.StatusForbidden, true
+		}
+
+		return 0, false
+	})
+
+	handler := httpserver.CreateHandler(errorReturningHandler{
+		err: fmt.Errorf("request rejected: %w", expectedError),
+	})
+	response := httpserver.HttpTest("GET", "/action", "/action", "", handler)
+
+	assert.Equal(t, http.StatusForbidden, response.Code)
+	assert.JSONEq(t, `{"err":"request rejected: authorization denied"}`, response.Body.String())
+}
+
+func TestCreateHandler_PreservesBuiltInForbiddenMapping(t *testing.T) {
+	httpserver.RegisterErrorMapper(func(err error) (int, bool) {
+		if errors.Is(err, httpserver.ErrAccessForbidden) {
+			return http.StatusTeapot, true
+		}
+
+		return 0, false
+	})
+
+	handler := httpserver.CreateHandler(errorReturningHandler{err: httpserver.ErrAccessForbidden})
+	response := httpserver.HttpTest("GET", "/action", "/action", "", handler)
+
+	assert.Equal(t, http.StatusForbidden, response.Code)
+}
+
+func TestRegisterErrorMapperRejectsNil(t *testing.T) {
+	assert.Panics(t, func() {
+		httpserver.RegisterErrorMapper(nil)
+	})
+}

--- a/pkg/httpserver/handler.go
+++ b/pkg/httpserver/handler.go
@@ -469,6 +469,12 @@ func parseUrl(ctx *gin.Context) (*url.URL, error) {
 }
 
 func handleError(ginCtx *gin.Context, errHandler ErrorHandler, statusCode int, ginError gin.Error) {
+	if statusCode == http.StatusInternalServerError {
+		if mappedStatusCode, handled := errorStatusCodeFromMappers(ginError.Err); handled {
+			statusCode = mappedStatusCode
+		}
+	}
+
 	//nolint:errcheck // we just want to add the error to the context and are not interested in the result
 	_ = ginCtx.Error(&ginError)
 	resp := errHandler(statusCode, ginError.Err)


### PR DESCRIPTION
## Summary

- Add a generic `ErrorMapper` registry to the legacy `pkg/httpserver` package.
- Allow registered mappers to replace the generic 500 fallback status.
- Preserve the existing forbidden, request-cancellation, and validation mappings.
- Add focused tests for wrapped custom errors, precedence, and nil registration.

This enables the authz HTTP adapter to be registered by services still using the legacy Gosoline HTTP server without coupling Gosoline to authz.

## Validation

- `go test -count=1 ./...`
- `go vet ./...`
- `go build ./...`
- `go mod verify`
- `gofmt -d ...`
- `git diff --check`